### PR TITLE
feat: allow encoding data to strokeWidth and opacity

### DIFF
--- a/schema/geminid.schema.json
+++ b/schema/geminid.schema.json
@@ -124,9 +124,6 @@
     "BasicSingleTrack": {
       "additionalProperties": false,
       "properties": {
-        "background": {
-          "$ref": "#/definitions/ChannelValue"
-        },
         "circularLayout": {
           "type": "boolean"
         },
@@ -161,7 +158,7 @@
           "$ref": "#/definitions/DataMetadata"
         },
         "opacity": {
-          "$ref": "#/definitions/ChannelValue"
+          "$ref": "#/definitions/Channel"
         },
         "outerRadius": {
           "type": "number"
@@ -1419,16 +1416,6 @@
       "additionalProperties": false,
       "description": "Superposing multiple tracks.",
       "properties": {
-        "background": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ChannelValue"
-            },
-            {
-              "$ref": "#/definitions/Channel"
-            }
-          ]
-        },
         "circularLayout": {
           "anyOf": [
             {
@@ -1526,14 +1513,7 @@
           ]
         },
         "opacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ChannelValue"
-            },
-            {
-              "$ref": "#/definitions/Channel"
-            }
-          ]
+          "$ref": "#/definitions/Channel"
         },
         "outerRadius": {
           "anyOf": [
@@ -1611,16 +1591,6 @@
           "items": {
             "additionalProperties": false,
             "properties": {
-              "background": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/ChannelValue"
-                  },
-                  {
-                    "$ref": "#/definitions/Channel"
-                  }
-                ]
-              },
               "circularLayout": {
                 "anyOf": [
                   {
@@ -1718,14 +1688,7 @@
                 ]
               },
               "opacity": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/ChannelValue"
-                  },
-                  {
-                    "$ref": "#/definitions/Channel"
-                  }
-                ]
+                "$ref": "#/definitions/Channel"
               },
               "outerRadius": {
                 "anyOf": [
@@ -2025,16 +1988,6 @@
     "SuperposedTrackTwoLevels": {
       "additionalProperties": false,
       "properties": {
-        "background": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ChannelValue"
-            },
-            {
-              "$ref": "#/definitions/Channel"
-            }
-          ]
-        },
         "circularLayout": {
           "anyOf": [
             {
@@ -2132,14 +2085,7 @@
           ]
         },
         "opacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ChannelValue"
-            },
-            {
-              "$ref": "#/definitions/Channel"
-            }
-          ]
+          "$ref": "#/definitions/Channel"
         },
         "outerRadius": {
           "anyOf": [
@@ -2217,16 +2163,6 @@
           "items": {
             "additionalProperties": false,
             "properties": {
-              "background": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/ChannelValue"
-                  },
-                  {
-                    "$ref": "#/definitions/Channel"
-                  }
-                ]
-              },
               "circularLayout": {
                 "anyOf": [
                   {
@@ -2324,14 +2260,7 @@
                 ]
               },
               "opacity": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/ChannelValue"
-                  },
-                  {
-                    "$ref": "#/definitions/Channel"
-                  }
-                ]
+                "$ref": "#/definitions/Channel"
               },
               "outerRadius": {
                 "anyOf": [
@@ -2409,16 +2338,6 @@
                 "items": {
                   "additionalProperties": false,
                   "properties": {
-                    "background": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/definitions/ChannelValue"
-                        },
-                        {
-                          "$ref": "#/definitions/Channel"
-                        }
-                      ]
-                    },
                     "circularLayout": {
                       "anyOf": [
                         {
@@ -2516,14 +2435,7 @@
                       ]
                     },
                     "opacity": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/definitions/ChannelValue"
-                        },
-                        {
-                          "$ref": "#/definitions/Channel"
-                        }
-                      ]
+                      "$ref": "#/definitions/Channel"
                     },
                     "outerRadius": {
                       "anyOf": [

--- a/src/core/geminid-track-model.ts
+++ b/src/core/geminid-track-model.ts
@@ -282,8 +282,13 @@ export class GeminidTrackModel {
                 }
                 /* genomic is not supported */
                 break;
-            case 'background':
-                // TODO:
+            case 'strokeWidth':
+            case 'opacity':
+                if (channelFieldType === 'quantitative') {
+                    return (this.channelScales[channelKey] as d3.ScaleLinear<any, any>)(value as number);
+                }
+                /* nominal is not supported */
+                /* genomic is not supported */
                 break;
             default:
                 console.warn(`${channelKey} is not supported for encoding values, so returning a undefined value`);
@@ -532,9 +537,6 @@ export class GeminidTrackModel {
                         case 'text':
                             value = '';
                             break;
-                        case 'background':
-                            value = undefined;
-                            break;
                         default:
                         // console.warn(WARN_MSG(channelKey, 'value'));
                     }
@@ -569,6 +571,12 @@ export class GeminidTrackModel {
                                 break;
                             case 'size':
                                 range = CHANNEL_DEFAULTS.SIZE_RANGE;
+                                break;
+                            case 'strokeWidth':
+                                range = [1, 3];
+                                break;
+                            case 'opacity':
+                                range = [0, 1];
                                 break;
                             default:
                                 // console.warn(WARN_MSG(channelKey, channel.type));
@@ -674,6 +682,8 @@ export class GeminidTrackModel {
                         case 'xe':
                         case 'y':
                         case 'size':
+                        case 'opacity':
+                        case 'strokeWidth':
                             this.channelScales[channelKey] = d3
                                 .scaleLinear()
                                 .domain(domain as [number, number])

--- a/src/core/geminid-track-model.ts
+++ b/src/core/geminid-track-model.ts
@@ -369,7 +369,7 @@ export class GeminidTrackModel {
      *
      */
     public visualPropertyByChannel(channelKey: keyof typeof ChannelTypes, datum?: { [k: string]: string | number }) {
-        const value = datum !== undefined ? getValueUsingChannel(datum, this.spec()[channelKey] as Channel) : undefined;
+        const value = datum !== undefined ? getValueUsingChannel(datum, this.spec()[channelKey] as Channel) : undefined; // Is this safe enough?
         return this.encodedValue(channelKey, value);
     }
 

--- a/src/core/geminid.schema.ts
+++ b/src/core/geminid.schema.ts
@@ -190,8 +190,7 @@ export interface BasicSingleTrack {
 
     stroke?: Channel;
     strokeWidth?: Channel;
-    opacity?: ChannelValue;
-    background?: ChannelValue;
+    opacity?: Channel;
 
     // Experimental
     stackY?: boolean; // Eventually, will be added to y's `Channel` w/ gap
@@ -219,6 +218,7 @@ export type SuperposedTrackTwoLevels = Partial<SingleTrack> & {
 };
 
 export interface TrackStyle {
+    background?: string;
     dashed?: [number, number];
     linePattern?: { type: 'triangle-l' | 'triangle-r'; size: number };
     curve?: 'top' | 'bottom' | 'left' | 'right';
@@ -233,7 +233,6 @@ export interface TrackStyle {
     textStrokeWidth?: number;
     textFontWeight?: 'bold' | 'normal';
     //
-    background?: string; // deprecated
     stroke?: string; // deprecated
     strokeWidth?: number; // deprecated
 }
@@ -280,8 +279,7 @@ export const enum CHANNEL_KEYS {
     stroke = 'stroke',
     strokeWidth = 'strokeWidth',
     size = 'size',
-    text = 'text',
-    background = 'background'
+    text = 'text'
 }
 
 /**
@@ -305,8 +303,7 @@ export const ChannelTypes = {
     stroke: 'stroke',
     strokeWidth: 'strokeWidth',
     size: 'size',
-    text: 'text',
-    background: 'background'
+    text: 'text'
 } as const;
 
 export type ChannelType = keyof typeof ChannelTypes | string;

--- a/src/core/mark/area.ts
+++ b/src/core/mark/area.ts
@@ -46,6 +46,7 @@ export function drawArea(HGC: any, trackInfo: any, tile: any, tm: GeminidTrackMo
     const colorCategories = (tm.getChannelDomainArray('color') as string[]) ?? ['___SINGLE_COLOR___'];
 
     /* constant values */
+    // we do not support encoding opacity, strokeWidth, and stroke for area marks
     const constantOpacity = tm.encodedPIXIProperty('opacity');
     const constantStrokeWidth = tm.encodedPIXIProperty('strokeWidth');
     const constantStroke = tm.encodedPIXIProperty('stroke');

--- a/src/core/mark/bar.ts
+++ b/src/core/mark/bar.ts
@@ -43,12 +43,6 @@ export function drawBar(HGC: any, trackInfo: any, tile: any, tm: GeminidTrackMod
     const rowCategories = (tm.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
     const rowHeight = trackHeight / rowCategories.length;
 
-    /* background */
-    if (tm.encodedValue('background')) {
-        tile.graphics.beginFill(colorToHex(tm.encodedValue('background')), 1);
-        tile.graphics.drawRect(xScale(tileX), 0, xScale(tileX + tileWidth) - xScale(tileX), trackHeight);
-    }
-
     /* baseline */
     const baselineValue = IsChannelDeep(spec.y) ? spec.y?.baseline : undefined;
     const baselineY = tm.encodedValue('y', baselineValue) ?? 0;

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -36,8 +36,7 @@ export const SUPPORTED_CHANNELS: (keyof typeof ChannelTypes)[] = [
     'stroke',
     'strokeWidth',
     'opacity',
-    'text',
-    'background'
+    'text'
     // ...
 ];
 

--- a/src/core/mark/line.ts
+++ b/src/core/mark/line.ts
@@ -15,12 +15,6 @@ export function drawLine(HGC: any, trackInfo: any, tile: any, tm: GeminidTrackMo
 
     /* track size */
     const [trackWidth, trackHeight] = trackInfo.dimensions;
-    const tileSize = trackInfo.tilesetInfo.tile_size;
-    const { tileX, tileWidth } = trackInfo.getTilePosAndDimensions(
-        tile.tileData.zoomLevel,
-        tile.tileData.tilePos,
-        tileSize
-    );
 
     /* circular parameters */
     const circular = spec.circularLayout;
@@ -32,21 +26,12 @@ export function drawLine(HGC: any, trackInfo: any, tile: any, tm: GeminidTrackMo
     const cx = trackWidth / 2.0;
     const cy = trackHeight / 2.0;
 
-    /* genomic scale */
-    const xScale = tm.getChannelScale('x');
-
     /* row separation */
     const rowCategories = (tm.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
     const rowHeight = trackHeight / rowCategories.length;
 
     /* color separation */
     const colorCategories = (tm.getChannelDomainArray('color') as string[]) ?? ['___SINGLE_COLOR___'];
-
-    /* background */
-    if (tm.encodedValue('background')) {
-        tile.graphics.beginFill(colorToHex(tm.encodedValue('background')), 1);
-        tile.graphics.drawRect(xScale(tileX), 0, xScale(tileX + tileWidth) - xScale(tileX), trackHeight);
-    }
 
     /* render */
     const graphics = tile.graphics;

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -50,16 +50,15 @@ export function drawLink(HGC: any, trackInfo: any, tile: any, tm: GeminidTrackMo
             const xeValue = getValueUsingChannel(d, spec.xe as Channel) as number;
             const x1Value = getValueUsingChannel(d, spec.x1 as Channel) as number;
             const x1eValue = getValueUsingChannel(d, spec.x1e as Channel) as number;
-            const colorValue = getValueUsingChannel(d, spec.color as Channel) as string;
+
             const stroke = tm.encodedPIXIProperty('stroke', d);
+            const color = tm.encodedPIXIProperty('color', d);
+            const opacity = tm.encodedPIXIProperty('opacity', d);
 
             let x = xScale(xValue);
             let xe = xScale(xeValue);
             let x1 = xScale(x1Value);
             let x1e = xScale(x1eValue);
-
-            const color = tm.encodedValue('color', colorValue);
-            const opacity = tm.encodedValue('opacity');
 
             // stroke
             g.lineStyle(

--- a/src/core/mark/point.ts
+++ b/src/core/mark/point.ts
@@ -31,20 +31,8 @@ export function drawPoint(HGC: any, trackInfo: any, tile: any, model: GeminidTra
     const rowCategories = (model.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
     const rowHeight = trackHeight / rowCategories.length;
 
-    /* constant values */
-    const constantStrokeWidth = model.encodedPIXIProperty('strokeWidth');
-    const constantStroke = model.encodedPIXIProperty('stroke');
-
     /* render */
     const g = tile.graphics;
-
-    // stroke
-    g.lineStyle(
-        constantStrokeWidth,
-        colorToHex(constantStroke),
-        1, // alpha
-        1 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
-    );
 
     rowCategories.forEach(rowCategory => {
         const rowPosition = model.encodedValue('row', rowCategory);
@@ -58,12 +46,22 @@ export function drawPoint(HGC: any, trackInfo: any, tile: any, model: GeminidTra
             const cy = model.encodedPIXIProperty('y-center', d);
             const color = model.encodedPIXIProperty('color', d);
             const size = model.encodedPIXIProperty('p-size', d);
+            const strokeWidth = model.encodedPIXIProperty('strokeWidth', d);
+            const stroke = model.encodedPIXIProperty('stroke', d);
             const opacity = model.encodedPIXIProperty('opacity', d);
 
             if (size <= 0.1 || opacity === 0 || cx + size < 0 || cx - size > trackWidth) {
                 // Don't draw invisible marks
                 return;
             }
+
+            // stroke
+            g.lineStyle(
+                strokeWidth,
+                colorToHex(stroke),
+                opacity, // alpha
+                1 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+            );
 
             if (circular) {
                 const r = trackOuterRadius - ((rowPosition + rowHeight - cy) / trackHeight) * trackRingSize;

--- a/src/core/mark/rect.ts
+++ b/src/core/mark/rect.ts
@@ -50,10 +50,6 @@ export function drawRect(HGC: any, trackInfo: any, tile: any, model: GeminidTrac
     const yCategories = (model.getChannelDomainArray('y') as string[]) ?? ['___SINGLE_Y_POSITION___'];
     const cellHeight = rowHeight / yCategories.length;
 
-    /* constant values */
-    const strokeWidth = model.encodedPIXIProperty('strokeWidth');
-    // const stroke = model.encodedValue('stroke');
-
     /* render */
     const g = tile.graphics;
     rowCategories.forEach(rowCategory => {
@@ -70,6 +66,7 @@ export function drawRect(HGC: any, trackInfo: any, tile: any, model: GeminidTrac
             ye: number;
             color: string;
             stroke: string;
+            strokeWidth: number;
             opacity: number;
             datum: Datum;
         }[] = [];
@@ -84,6 +81,7 @@ export function drawRect(HGC: any, trackInfo: any, tile: any, model: GeminidTrac
                 const x = model.encodedPIXIProperty('x', d);
                 const color = model.encodedPIXIProperty('color', d);
                 const stroke = model.encodedPIXIProperty('stroke', d);
+                const strokeWidth = model.encodedPIXIProperty('strokeWidth', d);
                 const opacity = model.encodedPIXIProperty('opacity', d);
                 const rectWidth = model.encodedPIXIProperty('width', d, { markWidth: tileUnitWidth });
                 const rectHeight = model.encodedPIXIProperty('height', d, { markHeight: cellHeight });
@@ -132,6 +130,7 @@ export function drawRect(HGC: any, trackInfo: any, tile: any, model: GeminidTrac
                     ye: y + rectHeight,
                     color,
                     stroke,
+                    strokeWidth,
                     opacity: actualOpacity,
                     datum: d
                 });
@@ -141,7 +140,7 @@ export function drawRect(HGC: any, trackInfo: any, tile: any, model: GeminidTrac
         const yScaleFactor = 1; // Math.max(...pixiProps.map(d => d.ye)) / rowHeight;
 
         pixiProps.forEach(prop => {
-            const { xs, xe, ys, ye, color, stroke, opacity, datum } = prop;
+            const { xs, xe, ys, ye, color, stroke, strokeWidth, opacity, datum } = prop;
 
             // stroke
             g.lineStyle(

--- a/src/core/mark/rule.ts
+++ b/src/core/mark/rule.ts
@@ -24,9 +24,6 @@ export function drawRule(HGC: any, trackInfo: any, tile: any, tm: GeminidTrackMo
     const linePattern = spec.style?.linePattern;
     const curved = spec.style?.curve;
 
-    /* constant values */
-    const strokeWidth = tm.encodedPIXIProperty('strokeWidth');
-
     /* render */
     rowCategories.forEach(rowCategory => {
         // we are separately drawing each row so that y scale can be more effectively shared across tiles without rerendering from the bottom
@@ -42,6 +39,7 @@ export function drawRule(HGC: any, trackInfo: any, tile: any, tm: GeminidTrackMo
             const xe = tm.encodedPIXIProperty('xe', d);
             const y = tm.encodedPIXIProperty('y', d);
             const color = tm.encodedPIXIProperty('color', d);
+            const strokeWidth = tm.encodedPIXIProperty('strokeWidth', d);
             const opacity = tm.encodedPIXIProperty('opacity', d);
 
             rowGraphics.lineStyle(

--- a/src/core/mark/text.ts
+++ b/src/core/mark/text.ts
@@ -74,6 +74,7 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GeminidTrackMo
                 const xe = tm.encodedPIXIProperty('xe', d);
                 const cx = tm.encodedPIXIProperty('x-center', d);
                 const y = tm.encodedPIXIProperty('y', d) + dy;
+                const opacity = tm.encodedPIXIProperty('opacity', d);
 
                 if (cx < 0 || cx > trackWidth) {
                     // we do not draw texts that are out of the view
@@ -104,13 +105,15 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GeminidTrackMo
                 trackInfo.textsBeingUsed++;
 
                 const alphaTransition = tm.markVisibility(d, metric);
-                if (!text || alphaTransition === 0) {
+                const actualOpacity = Math.min(alphaTransition, opacity);
+
+                if (!text || actualOpacity === 0) {
                     trackInfo.textsBeingUsed--;
                     textGraphic.visible = false;
                     return;
                 }
 
-                textGraphic.alpha = alphaTransition;
+                textGraphic.alpha = actualOpacity;
 
                 textGraphic.resolution = 8;
                 textGraphic.updateText();
@@ -143,6 +146,7 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GeminidTrackMo
                 const color = tm.encodedPIXIProperty('color', d);
                 const cx = tm.encodedPIXIProperty('x-center', d);
                 const y = tm.encodedPIXIProperty('y', d) + dy;
+                const opacity = tm.encodedPIXIProperty('opacity', d);
 
                 if (cx < 0 || cx > trackWidth) {
                     // we do not draw texts that are out of the view
@@ -173,13 +177,15 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GeminidTrackMo
                 trackInfo.textsBeingUsed++;
 
                 const alphaTransition = tm.markVisibility(d, metric);
-                if (!text || alphaTransition === 0) {
+                const actualOpacity = Math.min(alphaTransition, opacity);
+
+                if (!text || actualOpacity === 0) {
                     trackInfo.textsBeingUsed--;
                     textGraphic.visible = false;
                     return;
                 }
 
-                textGraphic.alpha = alphaTransition;
+                textGraphic.alpha = actualOpacity;
                 textGraphic.anchor.x = 0.5;
                 textGraphic.anchor.y = 0.5;
 

--- a/src/core/mark/triangle.ts
+++ b/src/core/mark/triangle.ts
@@ -57,14 +57,15 @@ export function drawTriangle(HGC: any, trackInfo: any, tile: any, tm: GeminidTra
             const xValue = getValueUsingChannel(d, spec.x as Channel) as number;
             const xeValue = getValueUsingChannel(d, spec.xe as Channel) as number;
             const yValue = getValueUsingChannel(d, spec.y as Channel) as string | number;
-            const colorValue = getValueUsingChannel(d, spec.color as Channel) as string;
             // const sizeValue = getValueUsingChannel(d, spec.size as Channel) as number;
 
             const x = xScale(xValue);
             const xe = xScale(xeValue);
             const y = tm.encodedValue('y', yValue);
-            const color = tm.encodedValue('color', colorValue);
-            const opacity = tm.encodedValue('opacity');
+            const strokeWidth = tm.encodedPIXIProperty('strokeWidth', d);
+            const stroke = tm.encodedPIXIProperty('stroke', d);
+            const color = tm.encodedPIXIProperty('color', d);
+            const opacity = tm.encodedPIXIProperty('opacity', d);
             // const size = tm.encodedValue('size', sizeValue);
 
             // TODO: Consider the `size` channel below
@@ -92,8 +93,8 @@ export function drawTriangle(HGC: any, trackInfo: any, tile: any, tm: GeminidTra
 
             // stroke
             g.lineStyle(
-                tm.encodedValue('strokeWidth'),
-                colorToHex(tm.encodedValue('stroke')),
+                strokeWidth,
+                colorToHex(stroke),
                 0, // actualOpacity, // alpha // TODO: becoming too sharp when drawing narrow triangle
                 0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
             );


### PR DESCRIPTION
Fixes #39 

This PR moves a `background` property to `TrackStyle` and allow encoding quantitative values to `strokeWidth` and `opacity`