### PR TITLE
refactor: use compactLayout to entirely remove empty tracks for between-track gaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "d3-scale": "^3.2.1",
         "file-loader": "^6.0.0",
         "gh-pages": "^2.2.0",
-        "higlass": "^1.11.3",
+        "higlass": "1.11.5",
         "higlass-register": "^0.3.0",
         "higlass-text": "^0.1.1",
         "json-stringify-pretty-compact": "^2.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,6 @@
         <script crossorigin type="text/javascript" src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
         <script crossorigin type="text/javascript" src="https://unpkg.com/pixi.js@5/dist/pixi.js"></script>
         <script crossorigin type="text/javascript" src="https://unpkg.com/react-bootstrap@0.32.1/dist/react-bootstrap.js"></script>
-        <script crossorigin type="text/javascript" src="https://unpkg.com/higlass@1.11.3/dist/hglib.min.js"></script>
+        <script crossorigin type="text/javascript" src="https://unpkg.com/higlass@1.11.5/dist/hglib.min.js"></script>
     </body>
 </html>

--- a/schema/geminid.schema.json
+++ b/schema/geminid.schema.json
@@ -1261,7 +1261,6 @@
         "link-between",
         "link-within",
         "dummy",
-        "empty",
         "header"
       ],
       "type": "string"

--- a/src/core/geminid-to-higlass.ts
+++ b/src/core/geminid-to-higlass.ts
@@ -23,7 +23,7 @@ export function geminidToHiGlass(
     // we only look into the first resolved spec to get information, such as size of the track
     const firstResolvedSpec = resolveSuperposedTracks(gmTrack)[0];
 
-    if (IsDataDeep(firstResolvedSpec.data) && firstResolvedSpec.mark !== 'empty') {
+    if (IsDataDeep(firstResolvedSpec.data)) {
         let server, tilesetUid;
 
         if (IsDataDeepTileset(firstResolvedSpec.data)) {
@@ -93,9 +93,6 @@ export function geminidToHiGlass(
         });
 
         hgModel.validateSpec();
-    } else if (firstResolvedSpec.mark === 'empty') {
-        // The `empty` tracks are used to add gaps between tracks vertically.
-        hgModel.addDefaultView().setLayout(layout).setEmptyTrack(bb.width, bb.height);
     } else if (firstResolvedSpec.mark === 'header') {
         // `text` tracks are used to show title and subtitle of the views
         hgModel.addDefaultView().setLayout(layout);

--- a/src/core/geminid.schema.ts
+++ b/src/core/geminid.schema.ts
@@ -122,10 +122,6 @@ export interface OneOfFilter {
     not: boolean;
 }
 
-// TODO: Ensure to use `EmptyTrack` for the convenient
-// export type Track = EmptyTrack | NonEmptyTrack;
-// export type NonEmptyTrack = SingleTrack | SuperposedTrack | SuperposedTrackTwoLevels;
-
 export type Track = SingleTrack | SuperposedTrack | SuperposedTrackTwoLevels;
 
 export type SingleTrack = BasicSingleTrack | CustomChannel;
@@ -136,12 +132,6 @@ export type CustomChannel = {
 } & {
     [k in CHANNEL_KEYS]?: never;
 };
-
-export interface EmptyTrack {
-    type: 'empty';
-    width: number;
-    height: number;
-}
 
 export interface BasicSingleTrack {
     title?: string;
@@ -385,8 +375,6 @@ export type MarkType =
     | 'link-between'
     | 'link-within' // uses either x and x1 or y and y1
     | 'dummy'
-    // being used to add gaps between tracks
-    | 'empty'
     // being used to show title/subtitle internally
     | 'header';
 

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -36,6 +36,7 @@ export class HiGlassModel {
     private hg: HiGlassSpec;
     constructor() {
         this.hg = {
+            compactLayout: false,
             trackSourceServers: [],
             views: [],
             zoomLocks: {
@@ -90,21 +91,6 @@ export class HiGlassModel {
         return this;
     }
 
-    // Trick to add a vertical gap between tracks. We are using this trick because HiGlass `layout` do not support vertical gaps.
-    public setEmptyTrack(width: number, height: number) {
-        if (this.getLastView()) {
-            this.getLastView().tracks.center = [
-                {
-                    server: 'http://higlass.io/api/v1',
-                    type: 'empty',
-                    width,
-                    height
-                }
-            ];
-        }
-        return this;
-    }
-
     public addBrush(
         viewId: string,
         fromViewUid?: string,
@@ -136,7 +122,7 @@ export class HiGlassModel {
      * Get the last view that renders any visualization, so skiping empty tracks.
      */
     public getLastVisView() {
-        const vs = this.hg.views.filter(v => (v.tracks as any).center[0].type === 'combined');
+        const vs = this.hg.views.filter(v => (v.tracks as any).center?.[0]?.type === 'combined');
         return vs[vs.length - 1];
     }
 

--- a/src/core/higlass.schema.json
+++ b/src/core/higlass.schema.json
@@ -21,6 +21,9 @@
         "zoomFixed": {
             "type": "boolean"
         },
+        "compactLayout": {
+            "type": "boolean"
+        },
         "exportViewUrl": {
             "type": "string"
         },

--- a/src/core/higlass.schema.ts
+++ b/src/core/higlass.schema.ts
@@ -9,6 +9,7 @@ export interface HiGlassSpec {
     zoomFixed?: boolean;
     viewEditable?: boolean;
     tracksEditable?: boolean;
+    compactLayout?: boolean;
     trackSourceServers?: string[];
     exportViewUrl?: string;
     chromInfoPath?: string;
@@ -209,8 +210,6 @@ export type EnumTrackType =
     | 'viewport-projection-center'
     | 'viewport-projection-horizontal'
     | 'viewport-projection-vertical'
-    // Not included in the HiGlass schema, but used in its exmaples
-    | 'empty'
     // custom tracks
     | 'gemini-track'
     | 'text';

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -127,17 +127,6 @@ const getTextTrack = (size: Size, title?: string, subtitle?: string) => {
     ) as Track;
 };
 
-const getGapTrack = (size: Size) => {
-    return JSON.parse(
-        JSON.stringify({
-            mark: 'empty',
-            data: { type: 'csv', url: 'tileset_info/?d=' },
-            width: size.width,
-            height: size.height
-        })
-    ) as Track;
-};
-
 // TODO: handle overflow by the ill-defined spec
 /**
  *
@@ -216,34 +205,9 @@ export function getArrangement(spec: GeminidSpec): TrackInfo[] {
         }
 
         if (spec.layout?.direction === 'horizontal') {
-            ci += span;
+            ci += typeof track.span === 'number' ? track.span : 1;
 
             if (ci >= numColumns && ri < numRows - 1) {
-                // Add between-row gaps.
-                const yOffset = y + height;
-                const gapHeight = rowGaps[ri];
-
-                if (gapHeight !== 0) {
-                    Array(numColumns)
-                        .fill(0)
-                        .forEach((_, _ci) => {
-                            const xOffset =
-                                columnSizes.slice(0, _ci).reduce((a, b) => a + b, 0) +
-                                columnGaps.slice(0, _ci).reduce((a, b) => a + b, 0);
-                            const colWidth = columnSizes[_ci];
-                            info.push({
-                                track: getGapTrack({ width: colWidth, height: gapHeight }),
-                                boundingBox: { x: xOffset, y: yOffset, width: colWidth, height: gapHeight },
-                                layout: {
-                                    x: (xOffset / totalWidth) * 12.0,
-                                    y: (yOffset / totalHeight) * 12.0,
-                                    w: (colWidth / totalWidth) * 12.0,
-                                    h: (gapHeight / totalHeight) * 12.0
-                                }
-                            });
-                        });
-                }
-
                 ci = 0;
                 ri++;
             }
@@ -254,27 +218,6 @@ export function getArrangement(spec: GeminidSpec): TrackInfo[] {
             if (ri >= numRows) {
                 ri = 0;
                 ci++;
-            } else {
-                // Add between-row gaps.
-                if (ri < numRows) {
-                    const yOffset = y + height;
-                    const xOffset = x;
-                    const gapHeight = rowGaps[ri - 1];
-                    const colWidth = width;
-
-                    if (gapHeight !== 0) {
-                        info.push({
-                            track: getGapTrack({ width: colWidth, height: gapHeight }),
-                            boundingBox: { x: xOffset, y: yOffset, width: colWidth, height: gapHeight },
-                            layout: {
-                                x: (xOffset / totalWidth) * 12.0,
-                                y: (yOffset / totalHeight) * 12.0,
-                                w: (colWidth / totalWidth) * 12.0,
-                                h: (gapHeight / totalHeight) * 12.0
-                            }
-                        });
-                    }
-                }
             }
         }
     });

--- a/src/core/utils/validate.ts
+++ b/src/core/utils/validate.ts
@@ -44,7 +44,8 @@ export function validateTrack(track: Track) {
         // ...
 
         // Additionally, validate the schema with the aspects that cannot be validated by the json schema
-        if (!getGenomicChannelFromTrack(spec)) {
+        if (!getGenomicChannelFromTrack(spec) && spec.mark !== 'rect-brush') {
+            // as an exception, rect-brush can encode no genomic data
             errorMessages.push('genomic type is not encoded to either a x- or y- axis');
             // EXPERIMENTAL: we are removing this rule in our spec.
             valid = false;

--- a/src/editor/example/basic/upset.ts
+++ b/src/editor/example/basic/upset.ts
@@ -37,12 +37,6 @@ export const EXAMPLE_UPSET: GeminidSpec = {
             ]
         },
         {
-            mark: 'empty',
-            data: { type: 'csv', url: '' },
-            width: 50,
-            height: 50
-        },
-        {
             data: {
                 url: EXAMPLE_DATASETS.multivec,
                 type: 'tileset'

--- a/test/core/higlass-model.test.ts
+++ b/test/core/higlass-model.test.ts
@@ -16,13 +16,6 @@ describe('Should produce higlass model correctly', () => {
         expect(higlass.spec().views?.[0].initialYDomain?.[1]).toEqual(CHROMOSOME_INTERVAL_HG38['chr2'][0] + 200);
     });
 
-    it('Should set empty track correctly', () => {
-        const higlass = new HiGlassModel();
-        higlass.addDefaultView();
-        higlass.setEmptyTrack(10, 10);
-        expect(higlass.spec().views?.[0].tracks.center?.[0].type).toEqual('empty');
-    });
-
     it('Should add brush correctly', () => {
         const higlass = new HiGlassModel();
         higlass.addDefaultView();

--- a/yarn.lock
+++ b/yarn.lock
@@ -9267,10 +9267,10 @@ higlass@1.11.2:
     vkbeautify "^0.99.3"
     whatwg-fetch "^3.0.0"
 
-higlass@^1.11.3:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/higlass/-/higlass-1.11.3.tgz#179e8bf4bd7292aaf9a97528299c750c09b6f598"
-  integrity sha512-NqtijUuJxb8Cet/0hOhPLgoB8slPnjxFCYTE6LXXv+AJyAs1iRWDndlrQEb0UlU0n5Meuh9Bg3j6R2UGxDXNRA==
+higlass@1.11.5:
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/higlass/-/higlass-1.11.5.tgz#356385febc307a3c1f9d70d09c7b3a067175de64"
+  integrity sha512-1wqJtAqKu4fPivDHHNyFzqrSt1eb9WHdvXvqwtaGoqWldghVCk9jig8+SQ0DIHuvuyY5KRbif0tEkFmFqE521A==
   dependencies:
     ajv "^6.10.0"
     box-intersect "^1.0.1"


### PR DESCRIPTION
Fixes #46 

This allows us to entirely remove `empty` type tracks that were used to introduce between-track gaps, thus much simplifying the source code.