### PR TITLE
feat: improve editor ui

### DIFF
--- a/src/editor/editor-panel.tsx
+++ b/src/editor/editor-panel.tsx
@@ -3,7 +3,7 @@ import MonacoEditor from 'react-monaco-editor';
 import * as Monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import ReactResizeDetector from 'react-resize-detector';
 
-function EditorPanel(props: { code: string; readOnly?: boolean; onChange?: (code: string) => void }) {
+function EditorPanel(props: { code: string; readOnly?: boolean; onChange?: (code: string) => void; hide?: boolean }) {
     const { code: templateCode, readOnly } = props;
     const editor = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
     const [code, setCode] = useState(templateCode);

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -17,11 +17,11 @@
 
 .editor {
     width: 100%;
-    height: calc(100% - 34px);
+    height: calc(100% - 30px);
 }
 
 .split-pane-root {
-    height: calc(100% - 34px) !important;
+    height: calc(100% - 30px) !important;
 }
 
 .editor-header {
@@ -37,7 +37,7 @@
 .preview-container {
     width: 100%;
     height: 100%;
-    padding: 10px;
+    padding: 6px;
     background: #f6f6f6;
     overflow-y: auto;
 }

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -29,7 +29,6 @@
     padding: 4px;
     padding-left: 10px;
     background: #f6f6f6;
-    border-top: 1px solid lightgray;
     border-bottom: 1px solid lightgray;
     height: 30px;
 }

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -74,9 +74,14 @@ function Editor(props: any) {
     const [size, setSize] = useState<{ width: number; height: number }>();
     const [gm, setGm] = useState(stringify(urlSpec ?? (examples[INIT_DEMO_INDEX].spec as GeminidSpec)));
     const [log, setLog] = useState<Validity>({ message: '', state: 'success' });
-    const [showVC, setShowVC] = useState<boolean>(false);
-    const [isMaximizeVis, setIsMaximizeVis] = useState<boolean>(false);
 
+    // whether to show HiGlass' viewConfig on the left-bottom
+    const [showVC, setShowVC] = useState<boolean>(false);
+
+    // whether to hide source code on the left
+    const [isMaximizeVis, setIsMaximizeVis] = useState<boolean>((urlParams?.full as string) === 'true' || false);
+
+    // for using HiGlass JS API
     const hgRef = useRef<any>();
 
     /**
@@ -84,9 +89,9 @@ function Editor(props: any) {
      */
     useEffect(() => {
         if (editorMode === 'Normal Mode') {
-            setGm(urlSpec ?? stringify(replaceTemplate(JSON.parse(stringify(demo.spec)) as GeminidSpec)));
+            setGm(stringify(replaceTemplate(JSON.parse(stringify(demo.spec)) as GeminidSpec)));
         } else {
-            setGm(urlSpec ?? stringify(demo.spec as GeminidSpec));
+            setGm(stringify(demo.spec as GeminidSpec));
         }
         setHg(undefined);
     }, [demo, editorMode]);
@@ -140,7 +145,7 @@ function Editor(props: any) {
                             position: 'relative',
                             display: 'block',
                             background: 'white',
-                            margin: 10,
+                            margin: 0,
                             padding: 0, // non-zero padding acts unexpectedly w/ HiGlassComponent
                             width: size.width,
                             height: size.height
@@ -243,7 +248,9 @@ function Editor(props: any) {
                     onClick={() => {
                         if (gm.length <= LIMIT_CLIPBOARD_LEN) {
                             // copy the unique url to clipboard using `<input/>`
-                            const url = `https://sehilyi.github.io/geminid/?spec=${JSONCrush(gm)}`;
+                            const url = `https://sehilyi.github.io/geminid/?full=${isMaximizeVis}&spec=${JSONCrush(
+                                gm
+                            )}`;
                             const element = document.getElementById('spec-url-exporter');
                             (element as any).type = 'text';
                             (element as any).value = url;

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -55,6 +55,10 @@ const INIT_DEMO_INDEX = examples.findIndex(d => d.forceShow) !== -1 ? examples.f
 // Limit of the character length to allow copy to clipboard
 const LIMIT_CLIPBOARD_LEN = 4096;
 
+// ! these should be updated upon change in css files
+const EDITOR_HEADER_HEIGHT = 30;
+const VIEWCONFIG_HEADER_HEIGHT = 30;
+
 // TODO: what is the type of prop?
 /**
  * React component for editing Gemini specs
@@ -70,6 +74,8 @@ function Editor(props: any) {
     const [size, setSize] = useState<{ width: number; height: number }>();
     const [gm, setGm] = useState(stringify(urlSpec ?? (examples[INIT_DEMO_INDEX].spec as GeminidSpec)));
     const [log, setLog] = useState<Validity>({ message: '', state: 'success' });
+    const [showVC, setShowVC] = useState<boolean>(false);
+    const [isMaximizeVis, setIsMaximizeVis] = useState<boolean>(false);
 
     const hgRef = useRef<any>();
 
@@ -264,9 +270,29 @@ function Editor(props: any) {
                     </svg>
                 </span>
             </div>
+            {/* ------------ main view ------------ */}
             <div className="editor">
-                <SplitPane className="split-pane-root" split="vertical" defaultSize="40%" onChange={undefined}>
-                    <SplitPane split="horizontal" defaultSize="calc(100% - 48px)" onChange={undefined}>
+                <SplitPane
+                    className="split-pane-root"
+                    split="vertical"
+                    defaultSize={'40%'}
+                    size={isMaximizeVis ? '0px' : '40%'}
+                    minSize="0px"
+                >
+                    <SplitPane
+                        split="horizontal"
+                        defaultSize="calc(100% - 30px)"
+                        maxSize={window.innerHeight - EDITOR_HEADER_HEIGHT - VIEWCONFIG_HEADER_HEIGHT}
+                        onChange={(size: number) => {
+                            const secondSize = window.innerHeight - EDITOR_HEADER_HEIGHT - size;
+                            if (secondSize > VIEWCONFIG_HEADER_HEIGHT && !showVC) {
+                                setShowVC(true);
+                            } else if (secondSize <= VIEWCONFIG_HEADER_HEIGHT && showVC) {
+                                // hide the viewConfig view when no enough space assigned
+                                setShowVC(false);
+                            }
+                        }}
+                    >
                         {/* Gemini Editor */}
                         <>
                             <EditorPanel
@@ -279,12 +305,14 @@ function Editor(props: any) {
                             <div className={`compile-message compile-message-${log.state}`}>{log.message}</div>
                         </>
                         {/* HiGlass View Config */}
-                        <SplitPane split="vertical" defaultSize="100%" onChange={undefined}>
+                        <SplitPane split="vertical" defaultSize="100%">
                             <>
                                 <div className="editor-header">
-                                    <b>Compiled HiGlass ViewConfigs</b> (Read Only)
+                                    <b>Compiled HiGlass ViewConfig</b> (Read Only)
                                 </div>
-                                <EditorPanel code={stringify(hg)} readOnly={true} onChange={undefined} />
+                                <div style={{ height: '100%', visibility: showVC ? 'visible' : 'hidden' }}>
+                                    <EditorPanel code={stringify(hg)} readOnly={true} />
+                                </div>
                             </>
                             {/**
                              * TODO: This is only for showing a scroll view for the higlass view config editor
@@ -297,6 +325,50 @@ function Editor(props: any) {
                     <div className="preview-container">{hglass}</div>
                 </SplitPane>
             </div>
+            {/* ------------ floating buttons ------------ */}
+            <span
+                title={isMaximizeVis ? 'Show Geminid code' : 'Maximize a visualization panel'}
+                style={{
+                    position: 'fixed',
+                    right: '10px',
+                    top: '40px',
+                    color: 'black',
+                    cursor: 'pointer'
+                }}
+                onClick={() => {
+                    setIsMaximizeVis(!isMaximizeVis);
+                }}
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    strokeWidth="2"
+                    stroke="currentColor"
+                    fill="none"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                >
+                    {isMaximizeVis ? (
+                        <>
+                            <path d="M5 9h2a2 2 0 0 0 2 -2v-2" />
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                            <path d="M15 19v-2a2 2 0 0 1 2 -2h2" />
+                            <path d="M15 5v2a2 2 0 0 0 2 2h2" />
+                            <path d="M5 15h2a2 2 0 0 1 2 2v2" />
+                        </>
+                    ) : (
+                        <>
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                            <path d="M4 8v-2a2 2 0 0 1 2 -2h2" />
+                            <path d="M4 16v2a2 2 0 0 0 2 2h2" />
+                            <path d="M16 4h2a2 2 0 0 1 2 2v2" />
+                            <path d="M16 20h2a2 2 0 0 0 2 -2v-2" />
+                        </>
+                    )}
+                </svg>
+            </span>
         </>
     );
 }


### PR DESCRIPTION
<img width="1040" alt="Screen Shot 2020-12-25 at 3 19 01 PM" src="https://user-images.githubusercontent.com/9922882/103141593-8a22c180-46c4-11eb-8f5c-e36981c2fef2.png">

- allow maximizing visualization panel
- allow specifying the size mode in the url as a parameter (i.e., `?full=true`)
- by default, the compiled HiGlass viewConfig view is hidden on the left-bottom