### PR TITLE
feat: adaptive axis format considering width/height of track

### DIFF
--- a/src/core/geminid-to-higlass.ts
+++ b/src/core/geminid-to-higlass.ts
@@ -88,7 +88,16 @@ export function geminidToHiGlass(
         ['x', 'y'].forEach(c => {
             const channel = (firstResolvedSpec as any)[c];
             if (IsChannelDeep(channel) && channel.axis && channel.axis !== 'none') {
-                hgModel.setAxisTrack(channel.axis);
+                const narrowSize = 400;
+                const narrowerSize = 200;
+                const narrowType =
+                    // show two labels at the end in a `si` format when the track is too narrow
+                    (c === 'x' && bb.width <= narrowerSize) || (c === 'y' && bb.height <= narrowerSize)
+                        ? 'narrower'
+                        : (c === 'x' && bb.width <= narrowSize) || (c === 'y' && bb.height <= narrowSize)
+                        ? 'narrow'
+                        : 'regular';
+                hgModel.setAxisTrack(channel.axis, narrowType);
             }
         });
 

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -192,7 +192,10 @@ export class HiGlassModel {
         return this;
     }
 
-    public setAxisTrack(position: 'left' | 'right' | 'top' | 'bottom') {
+    public setAxisTrack(
+        position: 'left' | 'right' | 'top' | 'bottom',
+        type: 'regular' | 'narrow' | 'narrower' = 'regular'
+    ) {
         if (!this.hg.views) return this;
         const baseTrackType = '-chromosome-labels';
         const direction = position === 'left' || position === 'right' ? 'vertical' : 'horizontal';
@@ -206,6 +209,8 @@ export class HiGlassModel {
                 options: {
                     color: 'black',
                     tickColor: 'black',
+                    tickFormat: type === 'narrower' ? 'si' : 'plain',
+                    tickPositions: type === 'regular' ? 'even' : 'ends',
                     reverseOrientation: position === 'bottom' ? true : false
                 }
             }


### PR DESCRIPTION
When a track is too narrow, show only two axis labels at the end in a `si` format.

This can be helpful for reimplementing Enriched Heatmap or Xena (i.e., showing multiple narrow regions):

http://genocat.tools/tools/enrichedheatmap.html

<img width="221" alt="Screen Shot 2020-12-28 at 9 55 10 AM" src="https://user-images.githubusercontent.com/9922882/103222779-cf2c3b00-48f2-11eb-931d-9a19fd4c1394.png">
<img width="419" alt="Screen Shot 2020-12-28 at 9 54 59 AM" src="https://user-images.githubusercontent.com/9922882/103222780-cf2c3b00-48f2-11eb-837d-baee4e097e38.png">
<img width="624" alt="Screen Shot 2020-12-28 at 9 54 52 AM" src="https://user-images.githubusercontent.com/9922882/103222781-cf2c3b00-48f2-11eb-8531-f028e8160ade.png">
