### PR TITLE
feat: reduce the pkg size by specifying external libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     ],
     "scripts": {
         "start": "webpack-dev-server --mode development --config webpack.config.editor.js",
-        "build": "rm -rf build/*; rm -rf dist/*; webpack --mode production",
+        "build": "rm -rf build/*; rm -rf dist/*; webpack --mode production --config webpack.config.js",
         "build-log": "rm -rf build/*; rm -rf dist/*; yarn build --display-error-details",
         "build-editor": "webpack --mode production --config webpack.config.editor.js",
         "test": "jest src/",
@@ -105,6 +105,7 @@
         "ts-json-schema-generator": "^0.75.0",
         "ts-loader": "^8.0.2",
         "typescript": "~4.1.2",
+        "unminified-webpack-plugin": "^2.0.0",
         "webpack": "^4.44.1",
         "webpack-bundle-analyzer": "^3.8.0",
         "webpack-cli": "^3.3.12",

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -450,7 +450,10 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 // Send data preview to the editor so that it can be shown to users.
                 try {
                     // !!! This shouldn't be called while using npm gosling.js package.
-                    import('pubsub-js').then(pubsub => {
+                    /*eslint-disable */
+                    const pubsub = require('pubsub-js');
+                    /*eslint-enable */
+                    if (pubsub) {
                         const NUM_OF_ROWS_IN_PREVIEW = 100;
                         const numOrRows = tile.tileData.tabularData.length;
                         pubsub.publish('data-preview', {
@@ -462,7 +465,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                                     : sampleSize(tile.tileData.tabularData, NUM_OF_ROWS_IN_PREVIEW)
                             // ...
                         });
-                    });
+                    }
                 } catch (e) {
                     // ..
                 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const webpack = require("webpack");
 
-module.exports = () => {
+module.exports = (env, argv) => {
   const config = {
     entry: { 
       main: './src/index.ts'
@@ -10,14 +10,15 @@ module.exports = () => {
       filename: "gosling.js",
       path: path.resolve(__dirname, "dist"),
       libraryTarget: 'umd',
-      umdNamedDefine: true
+      umdNamedDefine: true,
+      library: 'gosling'
     },
     performance: {
       hints: false,
       maxEntrypointSize: 512000,
       maxAssetSize: 512000,
     },
-    mode: 'production',
+    mode: argv.mode === 'production' ? 'production' : 'development',
     devtool: 'source-map',
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.json'],
@@ -33,10 +34,41 @@ module.exports = () => {
         }
       ],
     },
+    externals: {
+      "higlass": {
+        commonjs: "higlass",
+        commonjs2: "higlass",
+        amd: "higlass",
+        root: "hglib",
+      },
+      "pixi.js": {
+        commonjs: "pixi.js",
+        commonjs2: "pixi.js",
+        amd: "pixi.js",
+        root: "PIXI",
+      },
+      react: {
+        commonjs: "react",
+        commonjs2: "react",
+        amd: "react",
+        root: "React",
+      },
+      "react-dom": {
+        commonjs: "react-dom",
+        commonjs2: "react-dom",
+        amd: "react-dom",
+        root: "ReactDOM",
+      },
+    },
     plugins: [
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify('production')
+        }
+      }),
       new webpack.SourceMapDevToolPlugin({
         exclude: ['higlass']
-      }),
+      })
     ]
   };
   return config;


### PR DESCRIPTION
Towards #162 

This PR removes higlass, pixi.js, react, and react-dom from the gosling.js package, hence dramatically reducing the bundle size (21MB => 3MB).