### PR TITLE
refactor: change terms

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -382,7 +382,7 @@
         "assembly": {
           "$ref": "#/definitions/Assembly"
         },
-        "centerHole": {
+        "centerRadius": {
           "type": "number"
         },
         "data": {
@@ -922,7 +922,7 @@
             "assembly": {
               "$ref": "#/definitions/Assembly"
             },
-            "centerHole": {
+            "centerRadius": {
               "type": "number"
             },
             "description": {
@@ -977,7 +977,7 @@
             "assembly": {
               "$ref": "#/definitions/Assembly"
             },
-            "centerHole": {
+            "centerRadius": {
               "type": "number"
             },
             "description": {
@@ -1039,7 +1039,7 @@
             "assembly": {
               "$ref": "#/definitions/Assembly"
             },
-            "centerHole": {
+            "centerRadius": {
               "type": "number"
             },
             "description": {
@@ -1101,7 +1101,7 @@
             "assembly": {
               "$ref": "#/definitions/Assembly"
             },
-            "centerHole": {
+            "centerRadius": {
               "type": "number"
             },
             "description": {
@@ -1163,7 +1163,7 @@
             "assembly": {
               "$ref": "#/definitions/Assembly"
             },
-            "centerHole": {
+            "centerRadius": {
               "type": "number"
             },
             "description": {
@@ -1227,7 +1227,7 @@
         "assembly": {
           "$ref": "#/definitions/Assembly"
         },
-        "centerHole": {
+        "centerRadius": {
           "type": "number"
         },
         "hconcatViews": {
@@ -1625,7 +1625,7 @@
         "assembly": {
           "$ref": "#/definitions/Assembly"
         },
-        "centerHole": {
+        "centerRadius": {
           "type": "number"
         },
         "color": {
@@ -1668,7 +1668,7 @@
               "assembly": {
                 "$ref": "#/definitions/Assembly"
               },
-              "centerHole": {
+              "centerRadius": {
                 "type": "number"
               },
               "color": {
@@ -1967,7 +1967,7 @@
         "assembly": {
           "$ref": "#/definitions/Assembly"
         },
-        "centerHole": {
+        "centerRadius": {
           "type": "number"
         },
         "layout": {
@@ -2061,7 +2061,7 @@
         "assembly": {
           "$ref": "#/definitions/Assembly"
         },
-        "centerHole": {
+        "centerRadius": {
           "type": "number"
         },
         "layout": {
@@ -2114,7 +2114,7 @@
         "assembly": {
           "$ref": "#/definitions/Assembly"
         },
-        "centerHole": {
+        "centerRadius": {
           "type": "number"
         },
         "color": {
@@ -2435,7 +2435,7 @@
         "assembly": {
           "$ref": "#/definitions/Assembly"
         },
-        "centerHole": {
+        "centerRadius": {
           "type": "number"
         },
         "layout": {
@@ -2522,7 +2522,7 @@
         "assembly": {
           "$ref": "#/definitions/Assembly"
         },
-        "centerHole": {
+        "centerRadius": {
           "type": "number"
         },
         "layout": {

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -12,22 +12,6 @@
       ],
       "type": "string"
     },
-    "ArrangedViews": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ParallelViews"
-        },
-        {
-          "$ref": "#/definitions/SerialViews"
-        },
-        {
-          "$ref": "#/definitions/VConcatViews"
-        },
-        {
-          "$ref": "#/definitions/HConcatViews"
-        }
-      ]
-    },
     "Assembly": {
       "enum": [
         "hg38",
@@ -383,6 +367,7 @@
           "$ref": "#/definitions/Assembly"
         },
         "centerRadius": {
+          "description": "Proportion of the radius of the center white space.",
           "type": "number"
         },
         "data": {
@@ -423,6 +408,9 @@
         },
         "width": {
           "type": "number"
+        },
+        "xAxis": {
+          "$ref": "#/definitions/AxisPosition"
         },
         "xDomain": {
           "anyOf": [
@@ -923,6 +911,7 @@
               "$ref": "#/definitions/Assembly"
             },
             "centerRadius": {
+              "description": "Proportion of the radius of the center white space.",
               "type": "number"
             },
             "description": {
@@ -949,6 +938,9 @@
               },
               "type": "array"
             },
+            "xAxis": {
+              "$ref": "#/definitions/AxisPosition"
+            },
             "xDomain": {
               "anyOf": [
                 {
@@ -972,307 +964,20 @@
           "type": "object"
         },
         {
-          "additionalProperties": false,
           "properties": {
-            "assembly": {
-              "$ref": "#/definitions/Assembly"
-            },
-            "centerRadius": {
-              "type": "number"
-            },
             "description": {
               "type": "string"
-            },
-            "layout": {
-              "$ref": "#/definitions/Layout"
-            },
-            "parallelViews": {
-              "items": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/View"
-                  },
-                  {
-                    "$ref": "#/definitions/ArrangedViews"
-                  }
-                ]
-              },
-              "type": "array"
-            },
-            "spacing": {
-              "type": "number"
-            },
-            "static": {
-              "type": "boolean"
             },
             "subtitle": {
               "type": "string"
             },
             "title": {
               "type": "string"
-            },
-            "xDomain": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/DomainInterval"
-                },
-                {
-                  "$ref": "#/definitions/DomainChrInterval"
-                },
-                {
-                  "$ref": "#/definitions/DomainChr"
-                }
-              ]
-            },
-            "xLinkID": {
-              "type": "string"
             }
           },
-          "required": [
-            "parallelViews"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "assembly": {
-              "$ref": "#/definitions/Assembly"
-            },
-            "centerRadius": {
-              "type": "number"
-            },
-            "description": {
-              "type": "string"
-            },
-            "layout": {
-              "$ref": "#/definitions/Layout"
-            },
-            "serialViews": {
-              "items": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/View"
-                  },
-                  {
-                    "$ref": "#/definitions/ArrangedViews"
-                  }
-                ]
-              },
-              "type": "array"
-            },
-            "spacing": {
-              "type": "number"
-            },
-            "static": {
-              "type": "boolean"
-            },
-            "subtitle": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "xDomain": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/DomainInterval"
-                },
-                {
-                  "$ref": "#/definitions/DomainChrInterval"
-                },
-                {
-                  "$ref": "#/definitions/DomainChr"
-                }
-              ]
-            },
-            "xLinkID": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "serialViews"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "assembly": {
-              "$ref": "#/definitions/Assembly"
-            },
-            "centerRadius": {
-              "type": "number"
-            },
-            "description": {
-              "type": "string"
-            },
-            "layout": {
-              "$ref": "#/definitions/Layout"
-            },
-            "spacing": {
-              "type": "number"
-            },
-            "static": {
-              "type": "boolean"
-            },
-            "subtitle": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "vconcatViews": {
-              "items": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/View"
-                  },
-                  {
-                    "$ref": "#/definitions/ArrangedViews"
-                  }
-                ]
-              },
-              "type": "array"
-            },
-            "xDomain": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/DomainInterval"
-                },
-                {
-                  "$ref": "#/definitions/DomainChrInterval"
-                },
-                {
-                  "$ref": "#/definitions/DomainChr"
-                }
-              ]
-            },
-            "xLinkID": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "vconcatViews"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "assembly": {
-              "$ref": "#/definitions/Assembly"
-            },
-            "centerRadius": {
-              "type": "number"
-            },
-            "description": {
-              "type": "string"
-            },
-            "hconcatViews": {
-              "items": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/View"
-                  },
-                  {
-                    "$ref": "#/definitions/ArrangedViews"
-                  }
-                ]
-              },
-              "type": "array"
-            },
-            "layout": {
-              "$ref": "#/definitions/Layout"
-            },
-            "spacing": {
-              "type": "number"
-            },
-            "static": {
-              "type": "boolean"
-            },
-            "subtitle": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "xDomain": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/DomainInterval"
-                },
-                {
-                  "$ref": "#/definitions/DomainChrInterval"
-                },
-                {
-                  "$ref": "#/definitions/DomainChr"
-                }
-              ]
-            },
-            "xLinkID": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "hconcatViews"
-          ],
           "type": "object"
         }
       ]
-    },
-    "HConcatViews": {
-      "additionalProperties": false,
-      "properties": {
-        "assembly": {
-          "$ref": "#/definitions/Assembly"
-        },
-        "centerRadius": {
-          "type": "number"
-        },
-        "hconcatViews": {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/View"
-              },
-              {
-                "$ref": "#/definitions/ArrangedViews"
-              }
-            ]
-          },
-          "type": "array"
-        },
-        "layout": {
-          "$ref": "#/definitions/Layout"
-        },
-        "spacing": {
-          "type": "number"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "xDomain": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DomainInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChrInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChr"
-            }
-          ]
-        },
-        "xLinkID": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "hconcatViews"
-      ],
-      "type": "object"
     },
     "IncludeFilter": {
       "additionalProperties": false,
@@ -1626,6 +1331,7 @@
           "$ref": "#/definitions/Assembly"
         },
         "centerRadius": {
+          "description": "Proportion of the radius of the center white space.",
           "type": "number"
         },
         "color": {
@@ -1669,6 +1375,7 @@
                 "$ref": "#/definitions/Assembly"
               },
               "centerRadius": {
+                "description": "Proportion of the radius of the center white space.",
                 "type": "number"
               },
               "color": {
@@ -1788,6 +1495,9 @@
               },
               "x1e": {
                 "$ref": "#/definitions/Channel"
+              },
+              "xAxis": {
+                "$ref": "#/definitions/AxisPosition"
               },
               "xDomain": {
                 "anyOf": [
@@ -1910,6 +1620,9 @@
         "x1e": {
           "$ref": "#/definitions/Channel"
         },
+        "xAxis": {
+          "$ref": "#/definitions/AxisPosition"
+        },
         "xDomain": {
           "anyOf": [
             {
@@ -1961,59 +1674,6 @@
       ],
       "type": "string"
     },
-    "ParallelViews": {
-      "additionalProperties": false,
-      "properties": {
-        "assembly": {
-          "$ref": "#/definitions/Assembly"
-        },
-        "centerRadius": {
-          "type": "number"
-        },
-        "layout": {
-          "$ref": "#/definitions/Layout"
-        },
-        "parallelViews": {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/View"
-              },
-              {
-                "$ref": "#/definitions/ArrangedViews"
-              }
-            ]
-          },
-          "type": "array"
-        },
-        "spacing": {
-          "type": "number"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "xDomain": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DomainInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChrInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChr"
-            }
-          ]
-        },
-        "xLinkID": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "parallelViews"
-      ],
-      "type": "object"
-    },
     "Range": {
       "anyOf": [
         {
@@ -2055,59 +1715,6 @@
       ],
       "type": "object"
     },
-    "SerialViews": {
-      "additionalProperties": false,
-      "properties": {
-        "assembly": {
-          "$ref": "#/definitions/Assembly"
-        },
-        "centerRadius": {
-          "type": "number"
-        },
-        "layout": {
-          "$ref": "#/definitions/Layout"
-        },
-        "serialViews": {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/View"
-              },
-              {
-                "$ref": "#/definitions/ArrangedViews"
-              }
-            ]
-          },
-          "type": "array"
-        },
-        "spacing": {
-          "type": "number"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "xDomain": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DomainInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChrInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChr"
-            }
-          ]
-        },
-        "xLinkID": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "serialViews"
-      ],
-      "type": "object"
-    },
     "SingleTrack": {
       "additionalProperties": false,
       "properties": {
@@ -2115,6 +1722,7 @@
           "$ref": "#/definitions/Assembly"
         },
         "centerRadius": {
+          "description": "Proportion of the radius of the center white space.",
           "type": "number"
         },
         "color": {
@@ -2234,6 +1842,9 @@
         },
         "x1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "xAxis": {
+          "$ref": "#/definitions/AxisPosition"
         },
         "xDomain": {
           "anyOf": [
@@ -2429,59 +2040,6 @@
       },
       "type": "object"
     },
-    "VConcatViews": {
-      "additionalProperties": false,
-      "properties": {
-        "assembly": {
-          "$ref": "#/definitions/Assembly"
-        },
-        "centerRadius": {
-          "type": "number"
-        },
-        "layout": {
-          "$ref": "#/definitions/Layout"
-        },
-        "spacing": {
-          "type": "number"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "vconcatViews": {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/View"
-              },
-              {
-                "$ref": "#/definitions/ArrangedViews"
-              }
-            ]
-          },
-          "type": "array"
-        },
-        "xDomain": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DomainInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChrInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChr"
-            }
-          ]
-        },
-        "xLinkID": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "vconcatViews"
-      ],
-      "type": "object"
-    },
     "VectorData": {
       "additionalProperties": false,
       "properties": {
@@ -2513,52 +2071,6 @@
         "url",
         "column",
         "value"
-      ],
-      "type": "object"
-    },
-    "View": {
-      "additionalProperties": false,
-      "properties": {
-        "assembly": {
-          "$ref": "#/definitions/Assembly"
-        },
-        "centerRadius": {
-          "type": "number"
-        },
-        "layout": {
-          "$ref": "#/definitions/Layout"
-        },
-        "spacing": {
-          "type": "number"
-        },
-        "static": {
-          "type": "boolean"
-        },
-        "tracks": {
-          "items": {
-            "$ref": "#/definitions/Track"
-          },
-          "type": "array"
-        },
-        "xDomain": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DomainInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChrInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChr"
-            }
-          ]
-        },
-        "xLinkID": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "tracks"
       ],
       "type": "object"
     },

--- a/src/core/gosling-track-model.test.ts
+++ b/src/core/gosling-track-model.test.ts
@@ -83,6 +83,30 @@ describe('default options should be added into the original spec', () => {
 });
 
 describe('Gosling track model should be properly generated with data', () => {
+    it('Ill-defined scales (e.g., row = quantitative) should not crash the compiler', () => {
+        const track: Track = {
+            ...MINIMAL_TRACK_SPEC,
+            row: { field: 'row', type: 'quantitative' },
+            size: { value: 1 },
+            stroke: { value: 'white' },
+            strokeWidth: { value: 0.5 },
+            opacity: { value: 1 },
+            height: 300
+        };
+        const model = new GoslingTrackModel(track, [{ row: 'a' }, { row: 'b' }, { row: 'a' }]);
+        const spec = model.spec();
+        const rowDomain = IsChannelDeep(spec.row) ? (spec.row.domain as string[]) : [];
+
+        // scale
+        expect(model.getChannelScale('row')).toBeUndefined();
+
+        // domain
+        expect(rowDomain).toBeUndefined();
+
+        // encoded value
+        expect(model.encodedValue('row', 'a')).toBeUndefined();
+    });
+
     it('Default values, such as domain, should be correctly generated based on the data', () => {
         const track: Track = {
             ...MINIMAL_TRACK_SPEC,

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -741,6 +741,7 @@ export class GoslingTrackModel {
                             );
                             break;
                         default:
+                            break;
                         // console.warn('Not supported channel for calculating scales');
                     }
                 } else if (channel.type === 'nominal') {
@@ -763,6 +764,7 @@ export class GoslingTrackModel {
                             this.channelScales[channelKey] = scaleOrdinal(range as string[]).domain(domain as string[]);
                             break;
                         default:
+                            break;
                         // console.warn('Not supported channel for calculating scales');
                     }
                 }

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -245,6 +245,11 @@ export class GoslingTrackModel {
             return undefined;
         }
 
+        if (typeof this.channelScales[channelKey] !== 'function') {
+            // Scale is undefined, so returning undefined.
+            return undefined;
+        }
+
         // The type of a channel scale is determined by a { channel type, field type } pair
         switch (channelKey) {
             case 'x':
@@ -705,6 +710,11 @@ export class GoslingTrackModel {
             } else if (IsChannelDeep(channel)) {
                 const domain = channel.domain;
                 const range = channel.range;
+
+                if (domain === undefined || range === undefined) {
+                    // we do not have sufficient info to generate scales
+                    return;
+                }
 
                 if (channel.type === 'quantitative' || channel.type === 'genomic') {
                     switch (channelKey) {

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -27,10 +27,7 @@ import {
     MultivecData,
     VectorData,
     DataTrack,
-    BIGWIGData,
-    GoslingSpec,
-    ArrangedViews,
-    View
+    BIGWIGData
 } from './gosling.schema';
 import { SUPPORTED_CHANNELS } from './mark';
 import { isArray } from 'lodash';
@@ -187,14 +184,6 @@ export function IsStackedChannel(track: SingleTrack, channelKey: keyof typeof Ch
         IsChannelDeep(channel) &&
         channel.type === 'quantitative'
     );
-}
-
-export function getArrangedViews(spec: GoslingSpec | ArrangedViews): (View | ArrangedViews)[] {
-    if ('parallelViews' in spec) return spec.parallelViews;
-    if ('serialViews' in spec) return spec.serialViews;
-    if ('vconcatViews' in spec) return spec.vconcatViews;
-    if ('hconcatViews' in spec) return spec.hconcatViews;
-    return [];
 }
 
 /**

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -15,7 +15,7 @@ export interface CommonViewDef {
     static?: boolean;
     assembly?: Assembly;
     layout?: Layout;
-    centerHole?: number; // [0, 1], default: 0.3 (`DEFAULT_INNER_HOLE_PROP`) // TODO: Not supported yet
+    centerRadius?: number; // [0, 1], default: 0.3 (`DEFAULT_INNER_HOLE_PROP`) // TODO: Not supported yet
     xDomain?: DomainInterval | DomainChrInterval | DomainChr; // TODO: Support `DomainGene`
     xLinkID?: string;
     // xAxis?: AxisPosition; // TODO:

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -1,7 +1,7 @@
 import { GLYPH_LOCAL_PRESET_TYPE, GLYPH_HIGLASS_PRESET_TYPE } from '../editor/example/glyph';
 
 /* ----------------------------- ROOT SPEC ----------------------------- */
-export type GoslingSpec = (View | (ParallelViews | SerialViews | VConcatViews | HConcatViews)) & CommonRootDef;
+export type GoslingSpec = (View | ArrangedViews) & CommonRootDef;
 
 export interface CommonRootDef {
     title?: string;
@@ -10,37 +10,47 @@ export interface CommonRootDef {
 }
 
 /* ----------------------------- VIEW ----------------------------- */
+export type Layout = 'linear' | 'circular';
+export type Assembly = 'hg38' | 'hg19' | 'hg18' | 'hg17' | 'hg16' | 'mm10' | 'mm9';
+
 export interface CommonViewDef {
+    layout?: Layout;
+
     spacing?: number;
     static?: boolean;
+
     assembly?: Assembly;
-    layout?: Layout;
-    centerRadius?: number; // [0, 1], default: 0.3 (`DEFAULT_INNER_HOLE_PROP`) // TODO: Not supported yet
-    xDomain?: DomainInterval | DomainChrInterval | DomainChr; // TODO: Support `DomainGene`
+
+    xDomain?: DomainInterval | DomainChrInterval | DomainChr; // We can support `DomainGene` as well later.
     xLinkID?: string;
-    // xAxis?: AxisPosition; // TODO:
+    xAxis?: AxisPosition; // not supported currently
+
+    /**
+     * Proportion of the radius of the center white space.
+     */
+    centerRadius?: number; // [0, 1] (default: 0.3)
 }
+export type ArrangedViews = ParallalViews | SerialViews | HorizontalViews | VerticalViews;
 
-export type ArrangedViews = ParallelViews | SerialViews | VConcatViews | HConcatViews;
-
-export interface ParallelViews extends CommonViewDef {
-    parallelViews: (View | ArrangedViews)[];
+export interface ParallalViews extends CommonViewDef {
+    arrangement: 'parallel';
+    views: (View | ArrangedViews)[];
 }
 
 export interface SerialViews extends CommonViewDef {
-    serialViews: (View | ArrangedViews)[];
+    arrangement: 'serial';
+    views: (View | ArrangedViews)[];
 }
 
-export interface VConcatViews extends CommonViewDef {
-    vconcatViews: (View | ArrangedViews)[];
+export interface HorizontalViews extends CommonViewDef {
+    arrangement: 'horizontal';
+    views: (View | ArrangedViews)[];
 }
 
-export interface HConcatViews extends CommonViewDef {
-    hconcatViews: (View | ArrangedViews)[];
+export interface VerticalViews extends CommonViewDef {
+    arrangement: 'vertical';
+    views: (View | ArrangedViews)[];
 }
-
-export type Layout = 'linear' | 'circular';
-export type Assembly = 'hg38' | 'hg19' | 'hg18' | 'hg17' | 'hg16' | 'mm10' | 'mm9';
 
 /*
  * View is a group of tracks that share the same genomic axes and are linked each other by default.

--- a/src/core/mark/outline-circular.ts
+++ b/src/core/mark/outline-circular.ts
@@ -28,10 +28,10 @@ export function drawCircularOutlines(HGC: any, trackInfo: any, tile: any, tm: Go
     if (spec.style?.outlineWidth !== 0 && !(spec.layout === 'circular' && spec.mark === 'link')) {
         // circular link marks usually use entire inner space
         g.lineStyle(
-            0.5,
+            spec.style?.outlineWidth ? spec.style?.outlineWidth / 2.5 : 0,
             colorToHex(spec.style?.outline ?? '#DBDBDB'),
-            0.1, // 0.4, // alpha
-            0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+            1, // 0.4, // alpha
+            1 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
         );
         g.beginFill(colorToHex('lightgray'), 0.05);
         g.moveTo(posStartInner.x, posStartInner.y);

--- a/src/core/utils/bounding-box.test.ts
+++ b/src/core/utils/bounding-box.test.ts
@@ -185,7 +185,7 @@ describe('Arrangement', () => {
             ]
         };
         const spec2: GoslingSpec = {
-            arrangement: 'vertical',
+            arrangement: 'horizontal',
             views: [
                 {
                     tracks: [

--- a/src/core/utils/bounding-box.test.ts
+++ b/src/core/utils/bounding-box.test.ts
@@ -1,3 +1,4 @@
+import { GoslingSpec } from '../gosling.schema';
 import { DEFAULT_VIEW_SPACING } from '../layout/defaults';
 import { getBoundingBox, getRelativeTrackInfo } from './bounding-box';
 
@@ -68,8 +69,9 @@ describe('Arrangement', () => {
     });
 
     it('Palallel Views', () => {
-        const spec = {
-            parallelViews: [
+        const spec: GoslingSpec = {
+            arrangement: 'parallel',
+            views: [
                 {
                     tracks: [
                         { overlay: [], width: 10, height: 10 },
@@ -97,8 +99,9 @@ describe('Arrangement', () => {
     });
 
     it('Serial Views', () => {
-        const spec = {
-            serialViews: [
+        const spec: GoslingSpec = {
+            arrangement: 'serial',
+            views: [
                 {
                     tracks: [
                         { overlay: [], width: 10, height: 10 },
@@ -126,8 +129,9 @@ describe('Arrangement', () => {
     });
 
     it('Parallel Views === VConcat Views in Linear Layout', () => {
-        const spec1 = {
-            parallelViews: [
+        const spec1: GoslingSpec = {
+            arrangement: 'parallel',
+            views: [
                 {
                     tracks: [
                         { overlay: [], width: 10, height: 10 },
@@ -142,8 +146,9 @@ describe('Arrangement', () => {
                 }
             ]
         };
-        const spec2 = {
-            vconcatViews: [
+        const spec2: GoslingSpec = {
+            arrangement: 'vertical',
+            views: [
                 {
                     tracks: [
                         { overlay: [], width: 10, height: 10 },
@@ -162,8 +167,9 @@ describe('Arrangement', () => {
     });
 
     it('Serial Views === HConcat Views in Linear Layout', () => {
-        const spec1 = {
-            serialViews: [
+        const spec1: GoslingSpec = {
+            arrangement: 'serial',
+            views: [
                 {
                     tracks: [
                         { overlay: [], width: 10, height: 10 },
@@ -178,8 +184,9 @@ describe('Arrangement', () => {
                 }
             ]
         };
-        const spec2 = {
-            hconcatViews: [
+        const spec2: GoslingSpec = {
+            arrangement: 'vertical',
+            views: [
                 {
                     tracks: [
                         { overlay: [], width: 10, height: 10 },
@@ -200,13 +207,16 @@ describe('Arrangement', () => {
     it('Complex Parallel Views in Linear Layout', () => {
         {
             const t = { overlay: [], width: 10, height: 10 };
-            const spec = {
-                parallelViews: [
+            const spec: GoslingSpec = {
+                arrangement: 'parallel',
+                views: [
                     {
-                        parallelViews: [{ tracks: [t] }]
+                        arrangement: 'parallel',
+                        views: [{ tracks: [t] }]
                     },
                     {
-                        parallelViews: [{ tracks: [t] }]
+                        arrangement: 'parallel',
+                        views: [{ tracks: [t] }]
                     }
                 ]
             };
@@ -224,13 +234,16 @@ describe('Arrangement', () => {
     it('Complex Serial Views in Linear Layout', () => {
         {
             const t = { overlay: [], width: 10, height: 10 };
-            const spec = {
-                serialViews: [
+            const spec: GoslingSpec = {
+                arrangement: 'serial',
+                views: [
                     {
-                        serialViews: [{ tracks: [t] }]
+                        arrangement: 'serial',
+                        views: [{ tracks: [t] }]
                     },
                     {
-                        serialViews: [{ tracks: [t] }]
+                        arrangement: 'serial',
+                        views: [{ tracks: [t] }]
                     }
                 ]
             };
@@ -248,43 +261,52 @@ describe('Arrangement', () => {
     it('Complex Views in Linear Layout', () => {
         {
             const t = { overlay: [], width: 10, height: 10 };
-            const spec1 = {
-                parallelViews: [
+            const spec1: GoslingSpec = {
+                arrangement: 'parallel',
+                views: [
                     { tracks: [t] },
                     {
-                        serialViews: [{ tracks: [t] }]
+                        arrangement: 'serial',
+                        views: [{ tracks: [t] }]
                     }
                 ]
             };
-            const spec2 = {
-                parallelViews: [{ tracks: [t] }, { tracks: [t] }]
+            const spec2: GoslingSpec = {
+                arrangement: 'parallel',
+                views: [{ tracks: [t] }, { tracks: [t] }]
             };
             expect(getRelativeTrackInfo(spec1)).toEqual(getRelativeTrackInfo(spec2));
         }
         {
             const t = { overlay: [], width: 10, height: 10 };
-            const spec1 = {
-                serialViews: [
+            const spec1: GoslingSpec = {
+                arrangement: 'serial',
+                views: [
                     { tracks: [t] },
                     {
-                        serialViews: [{ tracks: [t] }]
+                        arrangement: 'serial',
+                        views: [{ tracks: [t] }]
                     }
                 ]
             };
-            const spec2 = {
-                serialViews: [{ tracks: [t] }, { tracks: [t] }]
+            const spec2: GoslingSpec = {
+                arrangement: 'serial',
+                views: [{ tracks: [t] }, { tracks: [t] }]
             };
             expect(getRelativeTrackInfo(spec1)).toEqual(getRelativeTrackInfo(spec2));
         }
         {
             const t = { overlay: [], width: 10, height: 10 };
-            const spec = {
-                serialViews: [
+            const spec: GoslingSpec = {
+                arrangement: 'serial',
+                views: [
                     {
-                        parallelViews: [{ tracks: [t] }, { tracks: [t] }]
+                        arrangement: 'parallel',
+                        views: [{ tracks: [t] }, { tracks: [t] }]
                     },
                     {
-                        serialViews: [{ tracks: [t] }]
+                        arrangement: 'serial',
+                        views: [{ tracks: [t] }]
                     }
                 ]
             };
@@ -304,13 +326,16 @@ describe('Arrangement', () => {
         {
             const t = { overlay: [], width: 10, height: 10 };
             const t_2w = { overlay: [], width: 20, height: 10 };
-            const spec = {
-                serialViews: [
+            const spec: GoslingSpec = {
+                arrangement: 'serial',
+                views: [
                     {
-                        parallelViews: [{ tracks: [t] }, { tracks: [t_2w] }]
+                        arrangement: 'parallel',
+                        views: [{ tracks: [t] }, { tracks: [t_2w] }]
                     },
                     {
-                        serialViews: [{ tracks: [t] }]
+                        arrangement: 'serial',
+                        views: [{ tracks: [t] }]
                     }
                 ]
             };

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -159,7 +159,7 @@ function traverseAndCollectTrackInfo(
         allChildCircularLayout &&
         traversedAtLeastOnce &&
         noChildConcatArrangement &&
-        (spec.arrangement === 'parallel' || spec.arrangement === 'serial' || 'tracks' in spec);
+        (('views' in spec && (spec.arrangement === 'parallel' || spec.arrangement === 'serial')) || 'tracks' in spec);
 
     const numTracksBeforeInsert = output.length;
 

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -245,7 +245,7 @@ function traverseAndCollectTrackInfo(
     if (isThisCircularRoot) {
         const cTracks = output.slice(numTracksBeforeInsert);
 
-        const INNER_HOLE = spec.centerHole !== undefined ? spec.centerHole : DEFAULT_INNER_HOLE_PROP;
+        const INNER_HOLE = spec.centerRadius !== undefined ? spec.centerRadius : DEFAULT_INNER_HOLE_PROP;
         const TOTAL_RADIUS = cumWidth / 2.0; // (cumWidth + cumHeight) / 2.0 / 2.0;
         const TOTAL_RING_SIZE = TOTAL_RADIUS * (1 - INNER_HOLE);
 

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -1,5 +1,5 @@
 import { ArrangedViews, CommonViewDef, GoslingSpec, Track, View } from '../gosling.schema';
-import { getArrangedViews, IsXAxis } from '../gosling.schema.guards';
+import { IsXAxis } from '../gosling.schema.guards';
 import { HIGLASS_AXIS_SIZE } from '../higlass-model';
 import {
     DEFAULT_INNER_HOLE_PROP,
@@ -149,7 +149,7 @@ function traverseAndCollectTrackInfo(
 
     let noChildConcatArrangement = true; // if v/hconcat is being used by children, circular visualizations should be adjacently placed.
     traverseViewArrangements(spec, (a: ArrangedViews) => {
-        if ('vconcatViews' in a || 'hconcatViews' in a) {
+        if (a.arrangement === 'vertical' || a.arrangement === 'horizontal') {
             noChildConcatArrangement = false;
         }
     });
@@ -159,7 +159,7 @@ function traverseAndCollectTrackInfo(
         allChildCircularLayout &&
         traversedAtLeastOnce &&
         noChildConcatArrangement &&
-        ('parallelViews' in spec || 'serialViews' in spec || 'tracks' in spec);
+        (spec.arrangement === 'parallel' || spec.arrangement === 'serial' || 'tracks' in spec);
 
     const numTracksBeforeInsert = output.length;
 
@@ -200,9 +200,9 @@ function traverseAndCollectTrackInfo(
         const spacing = spec.spacing ? spec.spacing : DEFAULT_VIEW_SPACING;
 
         // We first calculate position and size of each view and track by considering it as if it uses a linear layout
-        if ('parallelViews' in spec || 'vconcatViews' in spec) {
+        if (spec.arrangement === 'parallel' || spec.arrangement === 'vertical') {
             // const sizes = getSizeDefOfArrangedViews(spec);
-            getArrangedViews(spec).forEach((v, i, array) => {
+            spec.views.forEach((v, i, array) => {
                 const viewBB = traverseAndCollectTrackInfo(
                     v,
                     output,
@@ -219,8 +219,8 @@ function traverseAndCollectTrackInfo(
                 }
                 cumHeight += viewBB.height;
             });
-        } else if ('serialViews' in spec || 'hconcatViews' in spec) {
-            getArrangedViews(spec).forEach((v, i, array) => {
+        } else if (spec.arrangement === 'serial' || spec.arrangement === 'horizontal') {
+            spec.views.forEach((v, i, array) => {
                 const viewBB = traverseAndCollectTrackInfo(
                     v,
                     output,

--- a/src/core/utils/polar.ts
+++ b/src/core/utils/polar.ts
@@ -1,4 +1,4 @@
-export const RADIAN_GAP = 0.04;
+export const RADIAN_GAP = 0; //0.04;
 
 /**
  * Convert a value in a single-linear axis to a radian value. Anticlockwise, starts from 12 o'clock.

--- a/src/core/utils/spec-preprocess.test.ts
+++ b/src/core/utils/spec-preprocess.test.ts
@@ -16,6 +16,7 @@ describe('Fix Spec Downstream', () => {
         expect(!isNaN(+size.width) && isFinite(size.width)).toEqual(true);
         expect(!isNaN(+size.height) && isFinite(size.height)).toEqual(true);
     });
+
     it('static', () => {
         {
             const spec: GoslingSpec = {
@@ -38,6 +39,25 @@ describe('Fix Spec Downstream', () => {
             expect((spec.views[0] as any).tracks[0].static).toEqual(true); // TODO:
         }
     });
+
+    it('spacing should be overriden to views but not tracks', () => {
+        {
+            const spec: GoslingSpec = {
+                arrangement: 'parallel',
+                spacing: 24,
+                views: [
+                    {
+                        arrangement: 'serial',
+                        views: [{ tracks: [{ overlay: [], width: 0, height: 0 }] }]
+                    }
+                ]
+            };
+            traverseToFixSpecDownstream(spec);
+            expect(spec.views[0].spacing).toEqual(24);
+            expect((spec.views[0] as any).views[0].spacing).toBeUndefined();
+        }
+    });
+
     it('Layout in Tracks Should Be Removed', () => {
         const spec: GoslingSpec = {
             arrangement: 'parallel',

--- a/src/core/utils/spec-preprocess.test.ts
+++ b/src/core/utils/spec-preprocess.test.ts
@@ -5,7 +5,8 @@ import { traverseToFixSpecDownstream, overrideTemplates } from './spec-preproces
 describe('Fix Spec Downstream', () => {
     it('Empty Views', () => {
         const info = getRelativeTrackInfo({
-            parallelViews: [
+            arrangement: 'parallel',
+            views: [
                 {
                     tracks: []
                 }
@@ -19,32 +20,35 @@ describe('Fix Spec Downstream', () => {
         {
             const spec: GoslingSpec = {
                 static: true,
-                parallelViews: [{ tracks: [{ overlay: [], width: 0, height: 0 }] }]
+                arrangement: 'parallel',
+                views: [{ tracks: [{ overlay: [], width: 0, height: 0 }] }]
             };
             traverseToFixSpecDownstream(spec);
-            expect(spec.parallelViews[0].static).toEqual(true);
-            expect((spec.parallelViews[0] as any).tracks[0].static).toEqual(true);
+            expect(spec.views[0].static).toEqual(true);
+            expect((spec.views[0] as any).tracks[0].static).toEqual(true);
         }
         {
             const spec: GoslingSpec = {
                 layout: 'circular',
-                parallelViews: [{ layout: 'linear', tracks: [{ overlay: [], width: 0, height: 0 }] }]
+                arrangement: 'parallel',
+                views: [{ layout: 'linear', tracks: [{ overlay: [], width: 0, height: 0 }] }]
             };
             traverseToFixSpecDownstream(spec);
-            expect(spec.parallelViews[0].static).toEqual(true);
-            expect((spec.parallelViews[0] as any).tracks[0].static).toEqual(true); // TODO:
+            expect(spec.views[0].static).toEqual(true);
+            expect((spec.views[0] as any).tracks[0].static).toEqual(true); // TODO:
         }
     });
     it('Layout in Tracks Should Be Removed', () => {
         const spec: GoslingSpec = {
-            parallelViews: [
+            arrangement: 'parallel',
+            views: [
                 {
                     tracks: [{ layout: 'circular', overlay: [], width: 0, height: 0 }]
                 }
             ]
         };
         traverseToFixSpecDownstream(spec);
-        expect((spec.parallelViews[0] as any).tracks[0].layout).toEqual('linear');
+        expect((spec.views[0] as any).tracks[0].layout).toEqual('linear');
     });
 });
 

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -72,13 +72,13 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | View, parentDef?
             spec.static = spec.layout === 'circular' ? true : parentDef.static !== undefined ? parentDef.static : false;
         if (spec.xDomain === undefined) spec.xDomain = parentDef.xDomain;
         if (spec.xLinkID === undefined) spec.xLinkID = parentDef.xLinkID;
-        if (spec.centerHole === undefined) spec.centerHole = parentDef.centerHole;
+        if (spec.centerRadius === undefined) spec.centerRadius = parentDef.centerRadius;
     } else {
         // This means we are at the rool level, so assign default values if missing
         if (spec.assembly === undefined) spec.assembly = 'hg38';
         if (spec.layout === undefined) spec.layout = 'linear';
         if (spec.static === undefined) spec.static = spec.layout === 'circular' ? true : false;
-        if (spec.centerHole === undefined) spec.centerHole = DEFAULT_INNER_HOLE_PROP;
+        if (spec.centerRadius === undefined) spec.centerRadius = DEFAULT_INNER_HOLE_PROP;
         // Nothing to do when `xDomain` not suggested
         // Nothing to do when `xLinkID` not suggested
     }

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -2,7 +2,12 @@ import assign from 'lodash/assign';
 import uuid from 'uuid';
 import { SingleTrack, GoslingSpec, View, Track, CommonViewDef, ArrangedViews } from '../gosling.schema';
 import { IsTemplate, IsDataDeepTileset, IsSingleTrack, IsChannelDeep, IsOverlaidTrack } from '../gosling.schema.guards';
-import { DEFAULT_INNER_HOLE_PROP, DEFAULT_TRACK_HEIGHT_LINEAR, DEFAULT_TRACK_WIDTH_LINEAR } from '../layout/defaults';
+import {
+    DEFAULT_INNER_HOLE_PROP,
+    DEFAULT_TRACK_HEIGHT_LINEAR,
+    DEFAULT_TRACK_WIDTH_LINEAR,
+    DEFAULT_VIEW_SPACING
+} from '../layout/defaults';
 import { spreadTracksByData } from './overlay';
 
 /**
@@ -66,12 +71,14 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | View, parentDef?
         if (spec.xDomain === undefined) spec.xDomain = parentDef.xDomain;
         if (spec.xLinkID === undefined) spec.xLinkID = parentDef.xLinkID;
         if (spec.centerRadius === undefined) spec.centerRadius = parentDef.centerRadius;
+        if (spec.spacing === undefined && !('tracks' in spec)) spec.spacing = parentDef.spacing;
     } else {
         // This means we are at the rool level, so assign default values if missing
         if (spec.assembly === undefined) spec.assembly = 'hg38';
         if (spec.layout === undefined) spec.layout = 'linear';
         if (spec.static === undefined) spec.static = spec.layout === 'circular' ? true : false;
         if (spec.centerRadius === undefined) spec.centerRadius = DEFAULT_INNER_HOLE_PROP;
+        if (spec.spacing === undefined) spec.spacing = DEFAULT_VIEW_SPACING;
         // Nothing to do when `xDomain` not suggested
         // Nothing to do when `xLinkID` not suggested
     }

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -1,14 +1,7 @@
 import assign from 'lodash/assign';
 import uuid from 'uuid';
 import { SingleTrack, GoslingSpec, View, Track, CommonViewDef, ArrangedViews } from '../gosling.schema';
-import {
-    IsTemplate,
-    IsDataDeepTileset,
-    IsSingleTrack,
-    IsChannelDeep,
-    IsOverlaidTrack,
-    getArrangedViews
-} from '../gosling.schema.guards';
+import { IsTemplate, IsDataDeepTileset, IsSingleTrack, IsChannelDeep, IsOverlaidTrack } from '../gosling.schema.guards';
 import { DEFAULT_INNER_HOLE_PROP, DEFAULT_TRACK_HEIGHT_LINEAR, DEFAULT_TRACK_WIDTH_LINEAR } from '../layout/defaults';
 import { spreadTracksByData } from './overlay';
 
@@ -21,7 +14,7 @@ export function traverseTracks(spec: GoslingSpec, callback: (t: Track, i: number
     if ('tracks' in spec) {
         spec.tracks.forEach((...args) => callback(...args));
     } else {
-        getArrangedViews(spec).forEach(view => traverseTracks(view, callback));
+        spec.views.forEach(view => traverseTracks(view, callback));
     }
 }
 
@@ -34,7 +27,7 @@ export function traverseTracksAndViews(spec: GoslingSpec, callback: (tv: CommonV
     if ('tracks' in spec) {
         spec.tracks.forEach(t => callback(t));
     } else {
-        getArrangedViews(spec).forEach(v => {
+        spec.views.forEach(v => {
             callback(v);
             traverseTracksAndViews(v, callback);
         });
@@ -51,7 +44,7 @@ export function traverseViewArrangements(spec: GoslingSpec, callback: (tv: Arran
         // No need to do anything
     } else {
         callback(spec);
-        getArrangedViews(spec).forEach(v => {
+        spec.views.forEach(v => {
             traverseViewArrangements(v, callback);
         });
     }
@@ -174,7 +167,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | View, parentDef?
         });
     } else {
         // we did not reach track definition, so continue traversing
-        getArrangedViews(spec).forEach(v => {
+        spec.views.forEach(v => {
             traverseToFixSpecDownstream(v, spec as CommonViewDef);
         });
     }

--- a/src/editor/example/circular-overview-linear-detail-views.ts
+++ b/src/editor/example/circular-overview-linear-detail-views.ts
@@ -2,7 +2,8 @@ import { GoslingSpec } from '../../core/gosling.schema';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 export const EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL: GoslingSpec = {
-    vconcatViews: [
+    arrangement: 'vertical',
+    views: [
         {
             layout: 'circular',
             tracks: [
@@ -101,7 +102,8 @@ export const EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL: GoslingSpec = {
         },
         {
             spacing: 10,
-            hconcatViews: [
+            arrangement: 'horizontal',
+            views: [
                 {
                     tracks: [
                         {

--- a/src/editor/example/corces.ts
+++ b/src/editor/example/corces.ts
@@ -7,7 +7,8 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
     // description:
     //     'Corces et al. 2020. Single-cell epigenomic analyses implicate candidate causal variants at inherited risk loci for Alzheimer’s and Parkinson’s diseases. Nature Genetics, pp.1-11.',
     layout: 'circular',
-    vconcatViews: [
+    arrangement: 'vertical',
+    views: [
         {
             layout: 'linear',
             xDomain: { chromosome: '3' },

--- a/src/editor/example/corces.ts
+++ b/src/editor/example/corces.ts
@@ -11,7 +11,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
         {
             layout: 'linear',
             xDomain: { chromosome: '3' },
-            centerHole: 0.9,
+            centerRadius: 0.9,
             tracks: [
                 {
                     title: 'chr3',

--- a/src/editor/example/fuji.ts
+++ b/src/editor/example/fuji.ts
@@ -29,7 +29,7 @@ export const EX_SPEC_FUJI_PLOT: GoslingSpec = {
     subtitle: 'Kanai, M. et al., Nat. Genet. (2018)',
     static: true,
     layout: 'circular',
-    centerHole: 0.05,
+    centerRadius: 0.05,
     tracks: [
         {
             data: {

--- a/src/editor/example/gene-annotation.ts
+++ b/src/editor/example/gene-annotation.ts
@@ -769,16 +769,19 @@ export const EX_TRACK_GENE_ANNOTATION = {
 export const EX_SPEC_GENE_ANNOTATION: GoslingSpec = {
     layout: 'linear',
     xDomain: { chromosome: '3', interval: [52168000, 52890000] },
-    hconcatViews: [
+    arrangement: 'horizontal',
+    views: [
         {
-            vconcatViews: [
+            arrangement: 'vertical',
+            views: [
                 { tracks: [EX_TRACK_GENE_ANNOTATION.higlass] },
                 { tracks: [EX_TRACK_GENE_ANNOTATION.corces] },
                 { tracks: [EX_TRACK_GENE_ANNOTATION.igv] }
             ]
         },
         {
-            vconcatViews: [
+            arrangement: 'vertical',
+            views: [
                 { tracks: [EX_TRACK_GENE_ANNOTATION.cyverse] },
                 { tracks: [EX_TRACK_GENE_ANNOTATION.gmgdb] },
                 { tracks: [EX_TRACK_GENE_ANNOTATION.g7] }

--- a/src/editor/example/give.ts
+++ b/src/editor/example/give.ts
@@ -4,7 +4,8 @@ export const EX_SPEC_GIVE: GoslingSpec = {
     title: 'GIVE',
     subtitle: 'Reimplementation of GenoCAT examples',
     spacing: 60,
-    vconcatViews: [
+    arrangement: 'vertical',
+    views: [
         {
             layout: 'linear',
             tracks: [

--- a/src/editor/example/ideograms.ts
+++ b/src/editor/example/ideograms.ts
@@ -96,7 +96,8 @@ export const EX_SPEC_CYTOBANDS: GoslingSpec = {
     static: true,
     layout: 'linear',
     centerRadius: 0.2,
-    parallelViews: [
+    arrangement: 'parallel',
+    views: [
         {
             xDomain: { chromosome: '1' },
             tracks: [

--- a/src/editor/example/ideograms.ts
+++ b/src/editor/example/ideograms.ts
@@ -95,7 +95,7 @@ const StackedPeaks: Track = {
 export const EX_SPEC_CYTOBANDS: GoslingSpec = {
     static: true,
     layout: 'linear',
-    centerHole: 0.2,
+    centerRadius: 0.2,
     parallelViews: [
         {
             xDomain: { chromosome: '1' },

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -39,7 +39,8 @@ export const examples: ReadonlyArray<{
     },
     {
         name: 'Pathogenic Lollipop Plot',
-        spec: EX_SPEC_PATHOGENIC
+        spec: EX_SPEC_PATHOGENIC,
+        forceShow: true
     },
     {
         name: 'GIVE (Cao et al. 2018)',

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -1,4 +1,5 @@
 import { GoslingSpec } from '../../core/gosling.schema';
+import { EX_SPEC_LAYOUT_AND_ARRANGEMENT_1, EX_SPEC_LAYOUT_AND_ARRANGEMENT_2 } from './layout-and-arrangement';
 import { EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL } from './circular-overview-linear-detail-views';
 import { EX_SPEC_GENE_ANNOTATION } from './gene-annotation';
 import { EX_SPEC_SEMANTIC_ZOOM } from './semantic-zoom';
@@ -22,6 +23,14 @@ export const examples: ReadonlyArray<{
         hidden: true
     },
     {
+        name: 'Layouts and Arrangements 1',
+        spec: EX_SPEC_LAYOUT_AND_ARRANGEMENT_1
+    },
+    {
+        name: 'Layouts and Arrangements 2',
+        spec: EX_SPEC_LAYOUT_AND_ARRANGEMENT_2
+    },
+    {
         name: 'Circular Overview + Linear Detail Views',
         spec: EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL
     },
@@ -39,8 +48,7 @@ export const examples: ReadonlyArray<{
     },
     {
         name: 'Pathogenic Lollipop Plot',
-        spec: EX_SPEC_PATHOGENIC,
-        forceShow: true
+        spec: EX_SPEC_PATHOGENIC
     },
     {
         name: 'GIVE (Cao et al. 2018)',

--- a/src/editor/example/layout-and-arrangement.ts
+++ b/src/editor/example/layout-and-arrangement.ts
@@ -1,0 +1,102 @@
+import { GoslingSpec } from '../..';
+import { View } from '../../core/gosling.schema';
+import { DEFAULT_VIEW_SPACING } from '../../core/layout/defaults';
+import { GOSLING_PUBLIC_DATA } from './gosling-data';
+
+const COLORS = ['#D45E00', '#029F73', '#0072B2', '#CB7AA7', '#E79F00'];
+
+const spacing = DEFAULT_VIEW_SPACING;
+// const width = 150;
+// const height = 30;
+
+export const getSingleView: (
+    color: string,
+    width: number,
+    height: number,
+    numHSpacing: number,
+    numVSpacing: number
+) => View = (color, width, height, numHSpacing, numVSpacing) => {
+    return {
+        tracks: Array(1).fill({
+            data: {
+                type: 'multivec',
+                url: GOSLING_PUBLIC_DATA.multivec,
+                value: 'y',
+                row: '_',
+                column: 'x',
+                categories: ['_'],
+                bin: 32
+            },
+            mark: 'rect',
+            x: { field: 'start', type: 'genomic', axis: 'none' },
+            xe: { field: 'end', type: 'genomic' },
+            row: { field: '_', type: 'nominal' },
+            color: { value: 'lightgray' },
+            style: { outline: color, outlineWidth: 7 },
+            width: width + numHSpacing * spacing,
+            height: height + numVSpacing * spacing
+        })
+    };
+};
+
+export const EX_SPEC_LAYOUT_AND_ARRANGEMENT_1: GoslingSpec = {
+    static: true,
+    layout: 'linear',
+    arrangement: 'parallel',
+    centerRadius: 0.5,
+    views: [
+        {
+            ...getSingleView(COLORS[0], 400, 30, 1, 0)
+        },
+        {
+            arrangement: 'serial',
+            views: [
+                {
+                    ...getSingleView(COLORS[1], 200, 30, 0, 0)
+                },
+                {
+                    ...getSingleView(COLORS[2], 200, 30, 0, 0)
+                }
+            ]
+        }
+    ]
+};
+
+export const EX_SPEC_LAYOUT_AND_ARRANGEMENT_2: GoslingSpec = {
+    static: true,
+    layout: 'linear',
+    arrangement: 'serial',
+    centerRadius: 0.5,
+    views: [
+        {
+            arrangement: 'serial',
+            views: [
+                {
+                    arrangement: 'parallel',
+                    views: [
+                        {
+                            ...getSingleView(COLORS[0], 300, 60, 1, 0)
+                        },
+                        {
+                            ...getSingleView(COLORS[1], 300, 30, 1, 0)
+                        }
+                    ]
+                },
+                {
+                    arrangement: 'parallel',
+                    views: [
+                        {
+                            ...getSingleView(COLORS[2], 50, 60, 1, 0)
+                        },
+                        {
+                            ...getSingleView(COLORS[3], 50, 30, 1, 0)
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            ...getSingleView(COLORS[4], 50, 90, 0, 1)
+        }
+    ]
+};

--- a/src/editor/example/pathogenic.ts
+++ b/src/editor/example/pathogenic.ts
@@ -13,7 +13,7 @@ export const allDomains = [
 
 export const EX_SPEC_PATHOGENIC: GoslingSpec = {
     xDomain: { chromosome: '3', interval: [10140000, 10160000] },
-    centerHole: 0.1,
+    centerRadius: 0.1,
     layout: 'linear',
     spacing: 0,
     tracks: [

--- a/src/editor/example/pathogenic.ts
+++ b/src/editor/example/pathogenic.ts
@@ -1,4 +1,5 @@
 import { GoslingSpec } from '../../core/gosling.schema';
+import { EX_TRACK_GENE_ANNOTATION } from './gene-annotation';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 export const allDomains = [
@@ -17,6 +18,7 @@ export const EX_SPEC_PATHOGENIC: GoslingSpec = {
     layout: 'linear',
     spacing: 0,
     tracks: [
+        EX_TRACK_GENE_ANNOTATION.higlass,
         {
             data: {
                 url: GOSLING_PUBLIC_DATA.clinvar,
@@ -125,26 +127,27 @@ export const EX_SPEC_PATHOGENIC: GoslingSpec = {
                     // 'risk_factor',
                     // 'Conflicting_interpretations_of_pathogenicity'
                 ],
-                bin: 16
+                bin: 4
+                // bin: 16
             },
-            mark: 'rect',
+            mark: 'bar',
             x: { field: 'start', type: 'genomic' },
             xe: { field: 'end', type: 'genomic' },
-            row: {
-                field: 'significance',
-                type: 'nominal',
-                domain: [
-                    'Pathogenic',
-                    'Pathogenic/Likely_pathogenic',
-                    'Likely_pathogenic',
-                    'Uncertain_significance',
-                    'Likely_benign',
-                    'Benign/Likely_benign',
-                    'Benign'
-                ]
-            },
-            // color: {field: 'significance', type: 'nominal'},
-            opacity: { field: 'count', type: 'quantitative', range: [0.05, 1] },
+            y: { field: 'count', type: 'quantitative' },
+            // row: {
+            //     field: 'significance',
+            //     type: 'nominal',
+            //     domain: [
+            //         'Pathogenic',
+            //         'Pathogenic/Likely_pathogenic',
+            //         'Likely_pathogenic',
+            //         'Uncertain_significance',
+            //         'Likely_benign',
+            //         'Benign/Likely_benign',
+            //         'Benign'
+            //     ]
+            // },
+            // opacity: { field: 'count', type: 'quantitative', range: [0.05, 1] },
             color: {
                 field: 'significance',
                 type: 'nominal',

--- a/src/editor/example/semantic-zoom.ts
+++ b/src/editor/example/semantic-zoom.ts
@@ -239,7 +239,8 @@ export const EXAMPLE_TRACK_SEMANTIC_ZOOM = {
 };
 
 export const EX_SPEC_SEMANTIC_ZOOM: GoslingSpec = {
-    vconcatViews: [
+    arrangement: 'vertical',
+    views: [
         {
             layout: 'linear',
             xDomain: { chromosome: '1', interval: [3000000, 3000010] },

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -51,7 +51,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             this.textGraphics = [];
             this.textsBeingUsed = 0; // this variable is being used to improve the performance of text rendering
 
-            HGC.libraries.PIXI.GRAPHICS_CURVES.adaptive = false;
+            // HGC.libraries.PIXI.GRAPHICS_CURVES.adaptive = false;
         }
 
         initTile(tile: any) {


### PR DESCRIPTION
Fix #217 
Fix #222  
Toward #171 (ill-defined scales handled)

Other updates:
- Add examples to play with `layout` and `arrangement`
- Override `spacing` to child views but not to tracks
- Update spacing so that spacing in the origin is the same between tracks
- Update the lollipop example to use stacked bar charts when zoomed out