### PR TITLE
fix: correctly auto-generate gosling.schema.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "test": "jest src/",
         "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
         "format": "eslint src/ --fix && prettier 'src/**/*.css' --write",
-        "schema": "mkdir -p schema & ts-json-schema-generator -p src/core/gosling.schema.ts -f tsconfig.json -t GoslingSpec > schema/gosling.schema.json",
+        "schema": "mkdir -p schema & ts-json-schema-generator -p src/index.ts -f tsconfig.json -t GoslingSpec --no-type-check --no-ref-encode > schema/gosling.schema.json",
+        "schema-2": "mkdir -p schema & typescript-json-schema src/index.ts GoslingSpec --include src > schema/gosling.schema.json",
         "predeploy": "yarn build-editor; echo \"gosling.js.org\" >> build/CNAME",
         "deploy": "gh-pages -d build"
     },
@@ -107,6 +108,7 @@
         "ts-json-schema-generator": "^0.75.0",
         "ts-loader": "^8.0.2",
         "typescript": "~4.1.2",
+        "typescript-json-schema": "^0.49.0",
         "unminified-webpack-plugin": "^2.0.0",
         "webpack": "^4.44.1",
         "webpack-bundle-analyzer": "^3.8.0",

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -905,77 +905,10 @@
     "GoslingSpec": {
       "anyOf": [
         {
-          "additionalProperties": false,
-          "properties": {
-            "assembly": {
-              "$ref": "#/definitions/Assembly"
-            },
-            "centerRadius": {
-              "description": "Proportion of the radius of the center white space.",
-              "type": "number"
-            },
-            "description": {
-              "type": "string"
-            },
-            "layout": {
-              "$ref": "#/definitions/Layout"
-            },
-            "spacing": {
-              "type": "number"
-            },
-            "static": {
-              "type": "boolean"
-            },
-            "subtitle": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            },
-            "tracks": {
-              "items": {
-                "$ref": "#/definitions/Track"
-              },
-              "type": "array"
-            },
-            "xAxis": {
-              "$ref": "#/definitions/AxisPosition"
-            },
-            "xDomain": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/DomainInterval"
-                },
-                {
-                  "$ref": "#/definitions/DomainChrInterval"
-                },
-                {
-                  "$ref": "#/definitions/DomainChr"
-                }
-              ]
-            },
-            "xLinkID": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "tracks"
-          ],
-          "type": "object"
+          "$ref": "#/definitions/RootSpecWithSingleView"
         },
         {
-          "properties": {
-            "description": {
-              "type": "string"
-            },
-            "subtitle": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/RootSpecWithMultipleViews"
         }
       ]
     },
@@ -1244,6 +1177,72 @@
       },
       "required": [
         "type"
+      ],
+      "type": "object"
+    },
+    "MultipleViews": {
+      "additionalProperties": false,
+      "properties": {
+        "arrangement": {
+          "enum": [
+            "parallel",
+            "serial",
+            "horizontal",
+            "vertical"
+          ],
+          "type": "string"
+        },
+        "assembly": {
+          "$ref": "#/definitions/Assembly"
+        },
+        "centerRadius": {
+          "description": "Proportion of the radius of the center white space.",
+          "type": "number"
+        },
+        "layout": {
+          "$ref": "#/definitions/Layout"
+        },
+        "spacing": {
+          "type": "number"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "views": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SingleView"
+              },
+              {
+                "$ref": "#/definitions/MultipleViews"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "xAxis": {
+          "$ref": "#/definitions/AxisPosition"
+        },
+        "xDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ]
+        },
+        "xLinkID": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "views"
       ],
       "type": "object"
     },
@@ -1700,6 +1699,140 @@
       ],
       "type": "object"
     },
+    "RootSpecWithMultipleViews": {
+      "additionalProperties": false,
+      "properties": {
+        "assembly": {
+          "$ref": "#/definitions/Assembly"
+        },
+        "centerRadius": {
+          "description": "Proportion of the radius of the center white space.",
+          "type": "number"
+        },
+        "description": {
+          "type": "string"
+        },
+        "layout": {
+          "$ref": "#/definitions/Layout"
+        },
+        "spacing": {
+          "type": "number"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "tracks": {
+          "items": {
+            "$ref": "#/definitions/Track"
+          },
+          "type": "array"
+        },
+        "xAxis": {
+          "$ref": "#/definitions/AxisPosition"
+        },
+        "xDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ]
+        },
+        "xLinkID": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tracks"
+      ],
+      "type": "object"
+    },
+    "RootSpecWithSingleView": {
+      "additionalProperties": false,
+      "properties": {
+        "arrangement": {
+          "enum": [
+            "parallel",
+            "serial",
+            "horizontal",
+            "vertical"
+          ],
+          "type": "string"
+        },
+        "assembly": {
+          "$ref": "#/definitions/Assembly"
+        },
+        "centerRadius": {
+          "description": "Proportion of the radius of the center white space.",
+          "type": "number"
+        },
+        "description": {
+          "type": "string"
+        },
+        "layout": {
+          "$ref": "#/definitions/Layout"
+        },
+        "spacing": {
+          "type": "number"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "views": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SingleView"
+              },
+              {
+                "$ref": "#/definitions/MultipleViews"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "xAxis": {
+          "$ref": "#/definitions/AxisPosition"
+        },
+        "xDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ]
+        },
+        "xLinkID": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "views"
+      ],
+      "type": "object"
+    },
     "SingleTrack": {
       "additionalProperties": false,
       "properties": {
@@ -1868,6 +2001,56 @@
         "height",
         "mark",
         "width"
+      ],
+      "type": "object"
+    },
+    "SingleView": {
+      "additionalProperties": false,
+      "properties": {
+        "assembly": {
+          "$ref": "#/definitions/Assembly"
+        },
+        "centerRadius": {
+          "description": "Proportion of the radius of the center white space.",
+          "type": "number"
+        },
+        "layout": {
+          "$ref": "#/definitions/Layout"
+        },
+        "spacing": {
+          "type": "number"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "tracks": {
+          "items": {
+            "$ref": "#/definitions/Track"
+          },
+          "type": "array"
+        },
+        "xAxis": {
+          "$ref": "#/definitions/AxisPosition"
+        },
+        "xDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ]
+        },
+        "xLinkID": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tracks"
       ],
       "type": "object"
     },

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1393,14 +1393,8 @@
               "endAngle": {
                 "type": "number"
               },
-              "height": {
-                "type": "number"
-              },
               "innerRadius": {
                 "type": "number"
-              },
-              "layout": {
-                "$ref": "#/definitions/Layout"
               },
               "mark": {
                 "$ref": "#/definitions/Mark"
@@ -1447,14 +1441,8 @@
               "style": {
                 "$ref": "#/definitions/TrackStyle"
               },
-              "subtitle": {
-                "type": "string"
-              },
               "text": {
                 "$ref": "#/definitions/Channel"
-              },
-              "title": {
-                "type": "string"
               },
               "tooltip": {
                 "items": {
@@ -1483,9 +1471,6 @@
                   "$ref": "#/definitions/VisibilityCondition"
                 },
                 "type": "array"
-              },
-              "width": {
-                "type": "number"
               },
               "x": {
                 "$ref": "#/definitions/Channel"

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -1,15 +1,35 @@
 import { GLYPH_LOCAL_PRESET_TYPE, GLYPH_HIGLASS_PRESET_TYPE } from '../editor/example/glyph';
 
 /* ----------------------------- ROOT SPEC ----------------------------- */
-export type GoslingSpec = (View | ArrangedViews) & CommonRootDef;
+export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
 
-export interface CommonRootDef {
+export interface RootSpecWithSingleView extends MultipleViews {
+    title?: string;
+    subtitle?: string;
+    description?: string;
+}
+
+export interface RootSpecWithMultipleViews extends SingleView {
     title?: string;
     subtitle?: string;
     description?: string;
 }
 
 /* ----------------------------- VIEW ----------------------------- */
+export type View = SingleView | MultipleViews;
+
+/*
+ * View is a group of tracks that share the same genomic axes and are linked each other by default.
+ */
+export interface SingleView extends CommonViewDef {
+    tracks: Track[];
+}
+
+export interface MultipleViews extends CommonViewDef {
+    arrangement?: 'parallel' | 'serial' | 'horizontal' | 'vertical';
+    views: Array<SingleView | MultipleViews>;
+}
+
 export type Layout = 'linear' | 'circular';
 export type Assembly = 'hg38' | 'hg19' | 'hg18' | 'hg17' | 'hg16' | 'mm10' | 'mm9';
 
@@ -29,34 +49,6 @@ export interface CommonViewDef {
      * Proportion of the radius of the center white space.
      */
     centerRadius?: number; // [0, 1] (default: 0.3)
-}
-export type ArrangedViews = ParallalViews | SerialViews | HorizontalViews | VerticalViews;
-
-export interface ParallalViews extends CommonViewDef {
-    arrangement: 'parallel';
-    views: (View | ArrangedViews)[];
-}
-
-export interface SerialViews extends CommonViewDef {
-    arrangement: 'serial';
-    views: (View | ArrangedViews)[];
-}
-
-export interface HorizontalViews extends CommonViewDef {
-    arrangement: 'horizontal';
-    views: (View | ArrangedViews)[];
-}
-
-export interface VerticalViews extends CommonViewDef {
-    arrangement: 'vertical';
-    views: (View | ArrangedViews)[];
-}
-
-/*
- * View is a group of tracks that share the same genomic axes and are linked each other by default.
- */
-export interface View extends CommonViewDef {
-    tracks: Track[];
 }
 
 /* ----------------------------- TRACK ----------------------------- */

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -160,12 +160,14 @@ export interface SingleTrack extends CommonTrackDef {
     overrideTemplate?: boolean;
 }
 
+// TODO: Check whether `Omit` is properly included in the generated `gosling.schema.json`
+// https://github.com/vega/ts-json-schema-generator/issues/101
 /**
  * Superposing multiple tracks.
  */
 export type OverlaidTrack = Partial<SingleTrack> &
     CommonRequiredTrackDef & {
-        overlay: Partial<SingleTrack>[];
+        overlay: Partial<Omit<SingleTrack, 'height' | 'width' | 'layout' | 'title' | 'subtitle'>>[];
     };
 
 export interface TrackStyle {

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -1,4 +1,4 @@
-import { ArrangedViews, CommonViewDef, GoslingSpec, Track, View } from '../gosling.schema';
+import { MultipleViews, CommonViewDef, GoslingSpec, Track, SingleView } from '../gosling.schema';
 import { IsXAxis } from '../gosling.schema.guards';
 import { HIGLASS_AXIS_SIZE } from '../higlass-model';
 import {
@@ -128,7 +128,7 @@ export function getRelativeTrackInfo(spec: GoslingSpec): TrackInfo[] {
  * @param circularRootNotFound
  */
 function traverseAndCollectTrackInfo(
-    spec: GoslingSpec | View,
+    spec: GoslingSpec | SingleView,
     output: TrackInfo[],
     dx = 0,
     dy = 0,
@@ -148,7 +148,7 @@ function traverseAndCollectTrackInfo(
     });
 
     let noChildConcatArrangement = true; // if v/hconcat is being used by children, circular visualizations should be adjacently placed.
-    traverseViewArrangements(spec, (a: ArrangedViews) => {
+    traverseViewArrangements(spec, (a: MultipleViews) => {
         if (a.arrangement === 'vertical' || a.arrangement === 'horizontal') {
             noChildConcatArrangement = false;
         }

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -1,6 +1,6 @@
 import assign from 'lodash/assign';
 import uuid from 'uuid';
-import { SingleTrack, GoslingSpec, View, Track, CommonViewDef, ArrangedViews } from '../gosling.schema';
+import { SingleTrack, GoslingSpec, SingleView, Track, CommonViewDef, MultipleViews } from '../gosling.schema';
 import { IsTemplate, IsDataDeepTileset, IsSingleTrack, IsChannelDeep, IsOverlaidTrack } from '../gosling.schema.guards';
 import {
     DEFAULT_INNER_HOLE_PROP,
@@ -44,7 +44,7 @@ export function traverseTracksAndViews(spec: GoslingSpec, callback: (tv: CommonV
  * @param spec
  * @param callback
  */
-export function traverseViewArrangements(spec: GoslingSpec, callback: (tv: ArrangedViews) => void) {
+export function traverseViewArrangements(spec: GoslingSpec, callback: (tv: MultipleViews) => void) {
     if ('tracks' in spec) {
         // No need to do anything
     } else {
@@ -61,7 +61,7 @@ export function traverseViewArrangements(spec: GoslingSpec, callback: (tv: Arran
  * @param spec
  * @param callback
  */
-export function traverseToFixSpecDownstream(spec: GoslingSpec | View, parentDef?: CommonViewDef) {
+export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, parentDef?: CommonViewDef) {
     if (parentDef) {
         // For assembly and layout, we use the ones defiend by the parents if missing
         if (spec.assembly === undefined) spec.assembly = parentDef.assembly;

--- a/src/core/utils/validate.test.ts
+++ b/src/core/utils/validate.test.ts
@@ -1,0 +1,9 @@
+import { validateGoslingSpec } from './validate';
+import { EX_SPEC_CYTOBANDS } from '../../editor/example/ideograms';
+
+describe('Validate Spec', () => {
+    it('Example Specs', () => {
+        expect(validateGoslingSpec(EX_SPEC_CYTOBANDS).state).toEqual('success');
+        expect(validateGoslingSpec(delete (EX_SPEC_CYTOBANDS as any).views).state).not.toEqual('success');
+    });
+});

--- a/src/editor/example/circular-overview-linear-detail-views.ts
+++ b/src/editor/example/circular-overview-linear-detail-views.ts
@@ -170,4 +170,4 @@ export const EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL: GoslingSpec = {
             ]
         }
     ]
-} as GoslingSpec;
+};

--- a/src/editor/example/layout-and-arrangement.ts
+++ b/src/editor/example/layout-and-arrangement.ts
@@ -1,5 +1,5 @@
 import { GoslingSpec } from '../..';
-import { View } from '../../core/gosling.schema';
+import { SingleView } from '../../core/gosling.schema';
 import { DEFAULT_VIEW_SPACING } from '../../core/layout/defaults';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
@@ -15,7 +15,7 @@ export const getSingleView: (
     height: number,
     numHSpacing: number,
     numVSpacing: number
-) => View = (color, width, height, numHSpacing, numVSpacing) => {
+) => SingleView = (color, width, height, numHSpacing, numVSpacing) => {
     return {
         tracks: Array(1).fill({
             data: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3804,6 +3804,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -5472,6 +5477,15 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
@@ -6093,6 +6107,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@^3.0.6:
   version "3.0.6"
@@ -7733,6 +7752,11 @@ escalade@^3.0.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.2.tgz#6a580d70edb87880f22b4c91d0d56078df6962c4"
   integrity sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==
 
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -8928,7 +8952,7 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -12349,7 +12373,7 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -16991,7 +17015,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -18044,6 +18068,18 @@ ts-loader@^8.0.2:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 ts-pnp@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.6.tgz#389a24396d425a0d3162e96d2b4638900fdc289a"
@@ -18169,6 +18205,23 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript-json-schema@^0.49.0:
+  version "0.49.0"
+  resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.49.0.tgz#442f6347ca85fb0d9811f217fb0d6537b68734b3"
+  integrity sha512-PumZkTmEE3T8TVyoJU6ZCp3K6VCmCb3Ei6fUaRIuDsIzYtmdJc6jV1D0RyBe5sd5mJ1iB6Zckm4KAKbqXs9oDw==
+  dependencies:
+    "@types/json-schema" "^7.0.6"
+    glob "^7.1.6"
+    json-stable-stringify "^1.0.1"
+    ts-node "^9.1.1"
+    typescript "^4.1.3"
+    yargs "^16.2.0"
+
+typescript@^4.1.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 typescript@~4.0.3:
   version "4.0.3"
@@ -19373,6 +19426,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -19481,6 +19543,11 @@ xtend@~2.1.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+y18n@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -19524,6 +19591,11 @@ yargs-parser@^13.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2:
+  version "20.2.5"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.5.tgz#5d37729146d3f894f39fc94b6796f5b239513186"
+  integrity sha512-jYRGS3zWy20NtDtK2kBgo/TlAoy5YUuhD9/LZ7z7W4j1Fdw2cqD0xEEclf8fxc8xjD6X5Qr+qQQwCEsP8iRiYg==
 
 yargs-parser@^20.2.3:
   version "20.2.4"
@@ -19581,6 +19653,19 @@ yargs@^15.1.0, yargs@^15.3.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
+yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
 yargs@~3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
@@ -19595,6 +19680,11 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Toward #171 (This allows to prevent from compiling ill-defined spec).
Fix #233 

`ts-json-schema-generator` module was generating gosling.schema.json incorrectly which allowed to pass an ill-defined spec to be compiled in the editor (e.g., removing `overlay` in the CytoBands example as @wangqianwen0418 found).