### PR TITLE
fix: override `arrangement` from parents

### DIFF
--- a/src/core/utils/spec-preprocess.test.ts
+++ b/src/core/utils/spec-preprocess.test.ts
@@ -40,6 +40,27 @@ describe('Fix Spec Downstream', () => {
         }
     });
 
+    it('arrangement should be overriden', () => {
+        {
+            const spec: GoslingSpec = {
+                static: true,
+                arrangement: 'serial',
+                views: [{ views: [{ tracks: [{ overlay: [], width: 0, height: 0 }] }] }]
+            };
+            traverseToFixSpecDownstream(spec);
+            expect((spec.views[0] as any).arrangement).toEqual('serial');
+        }
+        {
+            const spec: GoslingSpec = {
+                static: true,
+                views: [{ views: [{ tracks: [{ overlay: [], width: 0, height: 0 }] }] }]
+            };
+            traverseToFixSpecDownstream(spec);
+            expect(spec.arrangement).toEqual('vertical'); // default one
+            expect((spec.views[0] as any).arrangement).toEqual('vertical'); // default one is overriden
+        }
+    });
+
     it('spacing should be overriden to views but not tracks', () => {
         {
             const spec: GoslingSpec = {

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -61,7 +61,7 @@ export function traverseViewArrangements(spec: GoslingSpec, callback: (tv: Multi
  * @param spec
  * @param callback
  */
-export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, parentDef?: CommonViewDef) {
+export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, parentDef?: CommonViewDef | MultipleViews) {
     if (parentDef) {
         // For assembly and layout, we use the ones defiend by the parents if missing
         if (spec.assembly === undefined) spec.assembly = parentDef.assembly;
@@ -72,6 +72,8 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
         if (spec.xLinkID === undefined) spec.xLinkID = parentDef.xLinkID;
         if (spec.centerRadius === undefined) spec.centerRadius = parentDef.centerRadius;
         if (spec.spacing === undefined && !('tracks' in spec)) spec.spacing = parentDef.spacing;
+        if ('views' in spec && 'arrangement' in parentDef && spec.arrangement === undefined)
+            spec.arrangement = parentDef.arrangement;
     } else {
         // This means we are at the rool level, so assign default values if missing
         if (spec.assembly === undefined) spec.assembly = 'hg38';
@@ -79,6 +81,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
         if (spec.static === undefined) spec.static = spec.layout === 'circular' ? true : false;
         if (spec.centerRadius === undefined) spec.centerRadius = DEFAULT_INNER_HOLE_PROP;
         if (spec.spacing === undefined) spec.spacing = DEFAULT_VIEW_SPACING;
+        if ('views' in spec && spec.arrangement === undefined) spec.arrangement = 'vertical';
         // Nothing to do when `xDomain` not suggested
         // Nothing to do when `xLinkID` not suggested
     }


### PR DESCRIPTION
Fix #236 