### PR TITLE
fix: show dropdown menu and disable screen zoom for proper pinch zoom in visualizations in mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link rel="icon" href="./favicon.ico" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
         <meta name="theme-color" content="lightgray" />
         <script>
             // Copyright

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -21,6 +21,21 @@
     color: #e18343 !important;
 }
 
+.description-button {
+    position: fixed;
+    right: 0;
+    top: 0;
+    color: #e18343;
+    display: inline-block;
+    vertical-align: middle;
+    padding-top: 8px;
+    padding-left: 8px;
+    padding-right: 8px;
+    margin-left: 10px;
+    cursor: pointer;
+    background-color: white;
+}
+
 .editor-nav-button {
     display: inline-block;
     vertical-align: middle;
@@ -125,6 +140,7 @@
     background: #fafafa;
     border-bottom: 1px solid lightgray;
     height: 30px;
+    overflow-x: auto;
 }
 
 .data-preview-refresh-button {

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -30,7 +30,6 @@ const LIMIT_CLIPBOARD_LEN = 4096;
 // ! these should be updated upon change in css files
 const EDITOR_HEADER_HEIGHT = 40;
 const BOTTOM_PANEL_HEADER_HEIGHT = 30;
-const DESCRIPTION_PANEL_DEFAULT_WIDTH = 500;
 
 const LogoSVG = (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width={20} height={20}>
@@ -83,6 +82,8 @@ const getIconSVG = (d: ICON_INFO, w?: number, h?: number, f?: string) => (
 
 const emptySpec = (message?: string) => (message !== undefined ? `{\n\t// ${message}\n}` : '{}');
 
+const getDescPanelDefultWidth = () => Math.min(500, window.innerWidth);
+
 const fetchSpecFromGist = async (gist: string) => {
     let metadata: any = null;
     try {
@@ -126,6 +127,9 @@ interface PreviewData {
  * React component for editing Gosling specs
  */
 function Editor(props: any) {
+    // Determines whether the screen is too small (e.g., mobile)
+    const IS_SMALL_SCREEN = window.innerWidth <= 500;
+
     // custom spec contained in the URL
     const urlParams = qs.parse(props.location.search, { ignoreQueryPrefix: true });
     const urlSpec = urlParams?.spec ? JSONUncrush(urlParams.spec as string) : null;
@@ -146,12 +150,11 @@ function Editor(props: any) {
     const [gistTitle, setGistTitle] = useState<string>();
     const [description, setDescription] = useState<string | null>();
 
-    // This parameter only matter when a markdown description was loaded from
-    // a gist but the user wants to hide it
-    const [hideDescription, setHideDescription] = useState(false);
+    // This parameter only matter when a markdown description was loaded from a gist but the user wants to hide it
+    const [hideDescription, setHideDescription] = useState<boolean>(IS_SMALL_SCREEN || false);
 
     // Determine the size of description panel
-    const [descPanelWidth, setDescPanelWidth] = useState(DESCRIPTION_PANEL_DEFAULT_WIDTH);
+    const [descPanelWidth, setDescPanelWidth] = useState(getDescPanelDefultWidth());
 
     // whether to show HiGlass' viewConfig on the left-bottom
     const [showVC, setShowVC] = useState<boolean>(false);
@@ -160,7 +163,9 @@ function Editor(props: any) {
     const [readOnly, setReadOnly] = useState<boolean>(false);
 
     // whether to hide source code on the left
-    const [isHideCode, setIsHideCode] = useState<boolean>((urlParams?.full as string) === 'true' || false);
+    const [isHideCode, setIsHideCode] = useState<boolean>(
+        IS_SMALL_SCREEN || (urlParams?.full as string) === 'true' || false
+    );
 
     // whether to show data preview on the right-bottom
     const [isShowDataPreview, setIsShowDataPreview] = useState<boolean>(false);
@@ -336,7 +341,7 @@ function Editor(props: any) {
     }, [descResizerRef, started, dragged, ended]);
 
     function openDescription() {
-        setDescPanelWidth(DESCRIPTION_PANEL_DEFAULT_WIDTH);
+        setDescPanelWidth(getDescPanelDefultWidth());
         setHideDescription(false);
     }
 
@@ -351,7 +356,7 @@ function Editor(props: any) {
                 <span className="logo">{LogoSVG}</span>
                 Gosling.js Editor
                 {urlSpec && <small> Displaying a custom spec contained in URL</small>}
-                {gistTitle && (
+                {gistTitle && !IS_SMALL_SCREEN && (
                     <span className="gist-title">
                         : <em>{gistTitle}</em>
                     </span>
@@ -393,12 +398,7 @@ function Editor(props: any) {
                 </span>
                 <input type="hidden" id="spec-url-exporter" />
                 {description ? (
-                    <span
-                        title="Open Textual Description"
-                        className="editor-nav-button gosling-color"
-                        style={{ position: 'absolute', right: 0 }}
-                        onClick={openDescription}
-                    >
+                    <span title="Open Textual Description" className="description-button" onClick={openDescription}>
                         {getIconSVG(ICONS.INFO_CIRCLE, 23, 23)}
                     </span>
                 ) : null}

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -160,7 +160,7 @@ function Editor(props: any) {
     const [showVC, setShowVC] = useState<boolean>(false);
 
     // whether the code editor is read-only
-    const [readOnly, setReadOnly] = useState<boolean>(false);
+    const [readOnly, setReadOnly] = useState<boolean>(urlGist ? true : false);
 
     // whether to hide source code on the left
     const [isHideCode, setIsHideCode] = useState<boolean>(
@@ -204,24 +204,21 @@ function Editor(props: any) {
 
         if (!urlGist || typeof urlGist !== 'string') return undefined;
 
-        setCode('');
-        setReadOnly(true);
-
         fetchSpecFromGist(urlGist)
             .then(({ code, description, title }) => {
                 if (active && !!code) {
+                    setReadOnly(false);
                     setCode(code);
                     setGistTitle(title);
                     setDescription(description);
-                    setReadOnly(false);
                 }
             })
             .catch(error => {
                 if (active) {
+                    setReadOnly(false);
                     setCode(emptySpec(error));
                     setDescription(undefined);
                     setGistTitle('Error loading gist! See code for details.');
-                    setReadOnly(false);
                 }
             });
 
@@ -233,6 +230,11 @@ function Editor(props: any) {
 
     const runSpecUpdateVis = useCallback(
         (run?: boolean) => {
+            if (readOnly) {
+                // this means we do not have to compile. This is when we are in the middle of loading data from gist.
+                return;
+            }
+
             let editedGos;
             let valid;
             try {
@@ -248,7 +250,7 @@ function Editor(props: any) {
 
             setGoslingSpec(editedGos);
         },
-        [code, autoRun]
+        [code, autoRun, readOnly]
     );
 
     /**
@@ -362,6 +364,7 @@ function Editor(props: any) {
                     </span>
                 )}
                 <select
+                    style={{ maxWidth: IS_SMALL_SCREEN ? window.innerWidth - 180 : 'none' }}
                     onChange={e => {
                         setDemo(examples.find(d => d.name === e.target.value) as any);
                     }}


### PR DESCRIPTION
Toward #268 

This PR (1) properly shows dropdown menu for selecting examples in the mobile and (2) disable browser zoom to allow properly using pinch zoom in the visualizations for mobile devices.