### PR TITLE
feat(editor): allow clicking on the title to open a new tab

### DIFF
--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -356,8 +356,10 @@ function Editor(props: any) {
     return (
         <>
             <div className="demo-navbar">
-                <span className="logo">{LogoSVG}</span>
-                Gosling.js Editor
+                <span style={{ cursor: 'pointer' }} onClick={() => window.open('https://gosling.js.org', '_blank')}>
+                    <span className="logo">{LogoSVG}</span>
+                    Gosling.js Editor
+                </span>
                 {urlSpec && <small> Displaying a custom spec contained in URL</small>}
                 {gistTitle && !IS_SMALL_SCREEN && (
                     <>


### PR DESCRIPTION
This allows to click on the editor's title to open the editor in a new tab.