### PR TITLE
fix: allow using track title in circular layouts

### DIFF
--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -54,8 +54,7 @@ export function goslingToHiGlass(
                 mousePositionColor: '#B8BCC1',
                 /* Track title */
                 name: firstResolvedSpec.title,
-                // TODO: Support for circular layouts
-                labelPosition: firstResolvedSpec.layout !== 'circular' && firstResolvedSpec.title ? 'topLeft' : 'none',
+                labelPosition: firstResolvedSpec.title ? 'topLeft' : 'none',
                 fontSize: 12,
                 labelColor: 'black',
                 labelBackgroundColor: 'white',


### PR DESCRIPTION
Allowed to use track titles in circular layouts (i.e., a text label on the top-left corner of a track when a track-level prop `title` is used).