### PR TITLE
feat: data transform as ordered array

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -502,28 +502,17 @@
       "type": "object"
     },
     "DataTransform": {
-      "additionalProperties": false,
-      "properties": {
-        "displace": {
-          "items": {
-            "$ref": "#/definitions/DisplaceTransform"
-          },
-          "type": "array"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FilterTransform"
         },
-        "filter": {
-          "items": {
-            "$ref": "#/definitions/FilterTransform"
-          },
-          "type": "array"
+        {
+          "$ref": "#/definitions/LogTransform"
         },
-        "log": {
-          "items": {
-            "$ref": "#/definitions/LogTransform"
-          },
-          "type": "array"
+        {
+          "$ref": "#/definitions/DisplaceTransform"
         }
-      },
-      "type": "object"
+      ]
     },
     "Datum": {
       "additionalProperties": {
@@ -559,16 +548,21 @@
         "maxRows": {
           "type": "number"
         },
+        "method": {
+          "$ref": "#/definitions/DisplacementType"
+        },
         "newField": {
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/DisplacementType"
+          "const": "displace",
+          "type": "string"
         }
       },
       "required": [
-        "boundingBox",
         "type",
+        "boundingBox",
+        "method",
         "newField"
       ],
       "type": "object"
@@ -1092,9 +1086,14 @@
         },
         "not": {
           "type": "boolean"
+        },
+        "type": {
+          "const": "filter",
+          "type": "string"
         }
       },
       "required": [
+        "type",
         "field",
         "include"
       ],
@@ -1189,9 +1188,14 @@
         },
         "newField": {
           "type": "string"
+        },
+        "type": {
+          "const": "log",
+          "type": "string"
         }
       },
       "required": [
+        "type",
         "field"
       ],
       "type": "object"
@@ -1525,9 +1529,14 @@
               "type": "array"
             }
           ]
+        },
+        "type": {
+          "const": "filter",
+          "type": "string"
         }
       },
       "required": [
+        "type",
         "field",
         "oneOf"
       ],
@@ -1561,7 +1570,10 @@
           "$ref": "#/definitions/DataDeep"
         },
         "dataTransform": {
-          "$ref": "#/definitions/DataTransform"
+          "items": {
+            "$ref": "#/definitions/DataTransform"
+          },
+          "type": "array"
         },
         "displacement": {
           "$ref": "#/definitions/Displacement"
@@ -1620,7 +1632,10 @@
                 "$ref": "#/definitions/DataDeep"
               },
               "dataTransform": {
-                "$ref": "#/definitions/DataTransform"
+                "items": {
+                  "$ref": "#/definitions/DataTransform"
+                },
+                "type": "array"
               },
               "displacement": {
                 "$ref": "#/definitions/Displacement"
@@ -1912,7 +1927,10 @@
           "$ref": "#/definitions/DataDeep"
         },
         "dataTransform": {
-          "$ref": "#/definitions/DataTransform"
+          "items": {
+            "$ref": "#/definitions/DataTransform"
+          },
+          "type": "array"
         },
         "displacement": {
           "$ref": "#/definitions/Displacement"
@@ -2038,7 +2056,10 @@
                 "$ref": "#/definitions/DataDeep"
               },
               "dataTransform": {
-                "$ref": "#/definitions/DataTransform"
+                "items": {
+                  "$ref": "#/definitions/DataTransform"
+                },
+                "type": "array"
               },
               "displacement": {
                 "$ref": "#/definitions/Displacement"
@@ -2097,7 +2118,10 @@
                       "$ref": "#/definitions/DataDeep"
                     },
                     "dataTransform": {
-                      "$ref": "#/definitions/DataTransform"
+                      "items": {
+                        "$ref": "#/definitions/DataTransform"
+                      },
+                      "type": "array"
                     },
                     "displacement": {
                       "$ref": "#/definitions/Displacement"
@@ -2465,9 +2489,14 @@
         },
         "not": {
           "type": "boolean"
+        },
+        "type": {
+          "const": "filter",
+          "type": "string"
         }
       },
       "required": [
+        "type",
         "field",
         "inRange"
       ],
@@ -2577,7 +2606,10 @@
               "$ref": "#/definitions/DataDeep"
             },
             "dataTransform": {
-              "$ref": "#/definitions/DataTransform"
+              "items": {
+                "$ref": "#/definitions/DataTransform"
+              },
+              "type": "array"
             },
             "description": {
               "type": "string"
@@ -2706,7 +2738,10 @@
                     "$ref": "#/definitions/DataDeep"
                   },
                   "dataTransform": {
-                    "$ref": "#/definitions/DataTransform"
+                    "items": {
+                      "$ref": "#/definitions/DataTransform"
+                    },
+                    "type": "array"
                   },
                   "displacement": {
                     "$ref": "#/definitions/Displacement"
@@ -2765,7 +2800,10 @@
                           "$ref": "#/definitions/DataDeep"
                         },
                         "dataTransform": {
-                          "$ref": "#/definitions/DataTransform"
+                          "items": {
+                            "$ref": "#/definitions/DataTransform"
+                          },
+                          "type": "array"
                         },
                         "displacement": {
                           "$ref": "#/definitions/Displacement"
@@ -3112,7 +3150,10 @@
               "$ref": "#/definitions/DataDeep"
             },
             "dataTransform": {
-              "$ref": "#/definitions/DataTransform"
+              "items": {
+                "$ref": "#/definitions/DataTransform"
+              },
+              "type": "array"
             },
             "description": {
               "type": "string"
@@ -3243,7 +3284,10 @@
                         "$ref": "#/definitions/DataDeep"
                       },
                       "dataTransform": {
-                        "$ref": "#/definitions/DataTransform"
+                        "items": {
+                          "$ref": "#/definitions/DataTransform"
+                        },
+                        "type": "array"
                       },
                       "displacement": {
                         "$ref": "#/definitions/Displacement"
@@ -3302,7 +3346,10 @@
                               "$ref": "#/definitions/DataDeep"
                             },
                             "dataTransform": {
-                              "$ref": "#/definitions/DataTransform"
+                              "items": {
+                                "$ref": "#/definitions/DataTransform"
+                              },
+                              "type": "array"
                             },
                             "displacement": {
                               "$ref": "#/definitions/Displacement"
@@ -3711,7 +3758,10 @@
           "$ref": "#/definitions/DataDeep"
         },
         "dataTransform": {
-          "$ref": "#/definitions/DataTransform"
+          "items": {
+            "$ref": "#/definitions/DataTransform"
+          },
+          "type": "array"
         },
         "displacement": {
           "$ref": "#/definitions/Displacement"
@@ -3957,7 +4007,10 @@
           "$ref": "#/definitions/DataDeep"
         },
         "dataTransform": {
-          "$ref": "#/definitions/DataTransform"
+          "items": {
+            "$ref": "#/definitions/DataTransform"
+          },
+          "type": "array"
         },
         "displacement": {
           "$ref": "#/definitions/Displacement"
@@ -4085,7 +4138,10 @@
                     "$ref": "#/definitions/DataDeep"
                   },
                   "dataTransform": {
-                    "$ref": "#/definitions/DataTransform"
+                    "items": {
+                      "$ref": "#/definitions/DataTransform"
+                    },
+                    "type": "array"
                   },
                   "displacement": {
                     "$ref": "#/definitions/Displacement"
@@ -4144,7 +4200,10 @@
                           "$ref": "#/definitions/DataDeep"
                         },
                         "dataTransform": {
-                          "$ref": "#/definitions/DataTransform"
+                          "items": {
+                            "$ref": "#/definitions/DataTransform"
+                          },
+                          "type": "array"
                         },
                         "displacement": {
                           "$ref": "#/definitions/Displacement"

--- a/schema/history/0.7.4/gosling0.7.4.schema.json
+++ b/schema/history/0.7.4/gosling0.7.4.schema.json
@@ -502,28 +502,17 @@
       "type": "object"
     },
     "DataTransform": {
-      "additionalProperties": false,
-      "properties": {
-        "displace": {
-          "items": {
-            "$ref": "#/definitions/DisplaceTransform"
-          },
-          "type": "array"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FilterTransform"
         },
-        "filter": {
-          "items": {
-            "$ref": "#/definitions/FilterTransform"
-          },
-          "type": "array"
+        {
+          "$ref": "#/definitions/LogTransform"
         },
-        "log": {
-          "items": {
-            "$ref": "#/definitions/LogTransform"
-          },
-          "type": "array"
+        {
+          "$ref": "#/definitions/DisplaceTransform"
         }
-      },
-      "type": "object"
+      ]
     },
     "Datum": {
       "additionalProperties": {
@@ -559,16 +548,21 @@
         "maxRows": {
           "type": "number"
         },
+        "method": {
+          "$ref": "#/definitions/DisplacementType"
+        },
         "newField": {
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/DisplacementType"
+          "const": "displace",
+          "type": "string"
         }
       },
       "required": [
-        "boundingBox",
         "type",
+        "boundingBox",
+        "method",
         "newField"
       ],
       "type": "object"
@@ -1092,9 +1086,14 @@
         },
         "not": {
           "type": "boolean"
+        },
+        "type": {
+          "const": "filter",
+          "type": "string"
         }
       },
       "required": [
+        "type",
         "field",
         "include"
       ],
@@ -1189,9 +1188,14 @@
         },
         "newField": {
           "type": "string"
+        },
+        "type": {
+          "const": "log",
+          "type": "string"
         }
       },
       "required": [
+        "type",
         "field"
       ],
       "type": "object"
@@ -1525,9 +1529,14 @@
               "type": "array"
             }
           ]
+        },
+        "type": {
+          "const": "filter",
+          "type": "string"
         }
       },
       "required": [
+        "type",
         "field",
         "oneOf"
       ],
@@ -1561,7 +1570,10 @@
           "$ref": "#/definitions/DataDeep"
         },
         "dataTransform": {
-          "$ref": "#/definitions/DataTransform"
+          "items": {
+            "$ref": "#/definitions/DataTransform"
+          },
+          "type": "array"
         },
         "displacement": {
           "$ref": "#/definitions/Displacement"
@@ -1620,7 +1632,10 @@
                 "$ref": "#/definitions/DataDeep"
               },
               "dataTransform": {
-                "$ref": "#/definitions/DataTransform"
+                "items": {
+                  "$ref": "#/definitions/DataTransform"
+                },
+                "type": "array"
               },
               "displacement": {
                 "$ref": "#/definitions/Displacement"
@@ -1912,7 +1927,10 @@
           "$ref": "#/definitions/DataDeep"
         },
         "dataTransform": {
-          "$ref": "#/definitions/DataTransform"
+          "items": {
+            "$ref": "#/definitions/DataTransform"
+          },
+          "type": "array"
         },
         "displacement": {
           "$ref": "#/definitions/Displacement"
@@ -2038,7 +2056,10 @@
                 "$ref": "#/definitions/DataDeep"
               },
               "dataTransform": {
-                "$ref": "#/definitions/DataTransform"
+                "items": {
+                  "$ref": "#/definitions/DataTransform"
+                },
+                "type": "array"
               },
               "displacement": {
                 "$ref": "#/definitions/Displacement"
@@ -2097,7 +2118,10 @@
                       "$ref": "#/definitions/DataDeep"
                     },
                     "dataTransform": {
-                      "$ref": "#/definitions/DataTransform"
+                      "items": {
+                        "$ref": "#/definitions/DataTransform"
+                      },
+                      "type": "array"
                     },
                     "displacement": {
                       "$ref": "#/definitions/Displacement"
@@ -2465,9 +2489,14 @@
         },
         "not": {
           "type": "boolean"
+        },
+        "type": {
+          "const": "filter",
+          "type": "string"
         }
       },
       "required": [
+        "type",
         "field",
         "inRange"
       ],
@@ -2577,7 +2606,10 @@
               "$ref": "#/definitions/DataDeep"
             },
             "dataTransform": {
-              "$ref": "#/definitions/DataTransform"
+              "items": {
+                "$ref": "#/definitions/DataTransform"
+              },
+              "type": "array"
             },
             "description": {
               "type": "string"
@@ -2706,7 +2738,10 @@
                     "$ref": "#/definitions/DataDeep"
                   },
                   "dataTransform": {
-                    "$ref": "#/definitions/DataTransform"
+                    "items": {
+                      "$ref": "#/definitions/DataTransform"
+                    },
+                    "type": "array"
                   },
                   "displacement": {
                     "$ref": "#/definitions/Displacement"
@@ -2765,7 +2800,10 @@
                           "$ref": "#/definitions/DataDeep"
                         },
                         "dataTransform": {
-                          "$ref": "#/definitions/DataTransform"
+                          "items": {
+                            "$ref": "#/definitions/DataTransform"
+                          },
+                          "type": "array"
                         },
                         "displacement": {
                           "$ref": "#/definitions/Displacement"
@@ -3112,7 +3150,10 @@
               "$ref": "#/definitions/DataDeep"
             },
             "dataTransform": {
-              "$ref": "#/definitions/DataTransform"
+              "items": {
+                "$ref": "#/definitions/DataTransform"
+              },
+              "type": "array"
             },
             "description": {
               "type": "string"
@@ -3243,7 +3284,10 @@
                         "$ref": "#/definitions/DataDeep"
                       },
                       "dataTransform": {
-                        "$ref": "#/definitions/DataTransform"
+                        "items": {
+                          "$ref": "#/definitions/DataTransform"
+                        },
+                        "type": "array"
                       },
                       "displacement": {
                         "$ref": "#/definitions/Displacement"
@@ -3302,7 +3346,10 @@
                               "$ref": "#/definitions/DataDeep"
                             },
                             "dataTransform": {
-                              "$ref": "#/definitions/DataTransform"
+                              "items": {
+                                "$ref": "#/definitions/DataTransform"
+                              },
+                              "type": "array"
                             },
                             "displacement": {
                               "$ref": "#/definitions/Displacement"
@@ -3711,7 +3758,10 @@
           "$ref": "#/definitions/DataDeep"
         },
         "dataTransform": {
-          "$ref": "#/definitions/DataTransform"
+          "items": {
+            "$ref": "#/definitions/DataTransform"
+          },
+          "type": "array"
         },
         "displacement": {
           "$ref": "#/definitions/Displacement"
@@ -3957,7 +4007,10 @@
           "$ref": "#/definitions/DataDeep"
         },
         "dataTransform": {
-          "$ref": "#/definitions/DataTransform"
+          "items": {
+            "$ref": "#/definitions/DataTransform"
+          },
+          "type": "array"
         },
         "displacement": {
           "$ref": "#/definitions/Displacement"
@@ -4085,7 +4138,10 @@
                     "$ref": "#/definitions/DataDeep"
                   },
                   "dataTransform": {
-                    "$ref": "#/definitions/DataTransform"
+                    "items": {
+                      "$ref": "#/definitions/DataTransform"
+                    },
+                    "type": "array"
                   },
                   "displacement": {
                     "$ref": "#/definitions/Displacement"
@@ -4144,7 +4200,10 @@
                           "$ref": "#/definitions/DataDeep"
                         },
                         "dataTransform": {
-                          "$ref": "#/definitions/DataTransform"
+                          "items": {
+                            "$ref": "#/definitions/DataTransform"
+                          },
+                          "type": "array"
                         },
                         "displacement": {
                           "$ref": "#/definitions/Displacement"

--- a/schema/history/0.7.4/gosling0.7.4.schema.ts
+++ b/schema/history/0.7.4/gosling0.7.4.schema.ts
@@ -122,7 +122,7 @@ export interface SingleTrack extends CommonTrackDef {
     data: DataDeep;
 
     // Data transformation
-    dataTransform?: DataTransform;
+    dataTransform?: DataTransform[];
 
     tooltip?: { field: string; type: FieldType; alt?: string }[];
 
@@ -410,28 +410,26 @@ export interface MatrixData {
     url: string;
 }
 
-// !!! Transformation is applied in the same order (i.e., stack, filter, and then log)
-export interface DataTransform {
-    filter?: FilterTransform[];
-    log?: LogTransform[];
-    displace?: DisplaceTransform[]; // Mainly for internal usage. // We can call this 'dynamic' data transform.
-}
+export type DataTransform = FilterTransform | LogTransform | DisplaceTransform;
 
 export type FilterTransform = OneOfFilter | RangeFilter | IncludeFilter;
 
 export interface RangeFilter {
+    type: 'filter';
     field: string;
     inRange: number[];
     not?: boolean;
 }
 
 export interface IncludeFilter {
+    type: 'filter';
     field: string;
     include: string;
     not?: boolean;
 }
 
 export interface OneOfFilter {
+    type: 'filter';
     field: string;
     oneOf: string[] | number[];
     not?: boolean;
@@ -439,19 +437,21 @@ export interface OneOfFilter {
 
 export type LogBase = number | 'e';
 export interface LogTransform {
+    type: 'log';
     field: string;
     base?: LogBase; // If not specified, 10 is used
     newField?: string; // If specified, store transformed values in a new field.
 }
 
 export interface DisplaceTransform {
+    type: 'displace';
     // We could support different types of bounding boxes (e.g., using a center position and a size)
     boundingBox: {
         startField: string; // The name of a quantitative field that represents the start position
         endField: string; // The name of a quantitative field that represents the end position
         padding?: number; // TODO: this should be considered as a pixel value
     };
-    type: DisplacementType;
+    method: DisplacementType;
     newField: string;
 
     // "pile" specific parameters (TODO: make this a separate interface)

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -2,7 +2,7 @@ import uuid from 'uuid';
 import { Track as HiGlassTrack } from './higlass.schema';
 import { HiGlassModel, HIGLASS_AXIS_SIZE } from './higlass-model';
 import { parseServerAndTilesetUidFromUrl } from './utils';
-import { Track, Domain } from './gosling.schema';
+import { Track, Domain, DataTransform } from './gosling.schema';
 import { BoundingBox, RelativePosition } from './utils/bounding-box';
 import { resolveSuperposedTracks } from './utils/overlay';
 import { getGenomicChannelKeyFromTrack, getGenomicChannelFromTrack } from './utils/validate';
@@ -83,7 +83,7 @@ export function goslingToHiGlass(
                 // Additionally, add assembly, otherwise, a default build is used
                 assembly,
                 // Add a data transformation spec so that the fetcher can properly sample datasets
-                filter: (gosTrack as any).dataTransform?.filter
+                filter: (gosTrack as any).dataTransform?.filter((f: DataTransform) => f.type === 'filter')
             };
         }
 

--- a/src/core/gosling.schema.guards.test.ts
+++ b/src/core/gosling.schema.guards.test.ts
@@ -15,7 +15,7 @@ describe('Type Guard', () => {
                 overlay: [
                     {
                         mark: 'rect',
-                        dataTransform: { filter: [{ field: 'Stain', oneOf: ['acen-1', 'acen-2'], not: true }] },
+                        dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-1', 'acen-2'], not: true }],
                         color: {
                             field: 'Density',
                             type: 'nominal',
@@ -26,25 +26,19 @@ describe('Type Guard', () => {
                     },
                     {
                         mark: 'rect',
-                        dataTransform: {
-                            filter: [{ field: 'Stain', oneOf: ['gvar'] }]
-                        },
+                        dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['gvar'] }],
                         color: { value: '#A0A0F2' },
                         size: { value: 20 }
                     },
                     {
                         mark: 'triangleRight',
-                        dataTransform: {
-                            filter: [{ field: 'Stain', oneOf: ['acen-1'] }]
-                        },
+                        dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-1'] }],
                         color: { value: '#B40101' },
                         size: { value: 20 }
                     },
                     {
                         mark: 'triangleLeft',
-                        dataTransform: {
-                            filter: [{ field: 'Stain', oneOf: ['acen-2'] }]
-                        },
+                        dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-2'] }],
                         color: { value: '#B40101' },
                         size: { value: 20 }
                     },

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -122,7 +122,7 @@ export interface SingleTrack extends CommonTrackDef {
     data: DataDeep;
 
     // Data transformation
-    dataTransform?: DataTransform;
+    dataTransform?: DataTransform[];
 
     tooltip?: { field: string; type: FieldType; alt?: string }[];
 
@@ -410,28 +410,26 @@ export interface MatrixData {
     url: string;
 }
 
-// !!! Transformation is applied in the same order (i.e., stack, filter, and then log)
-export interface DataTransform {
-    filter?: FilterTransform[];
-    log?: LogTransform[];
-    displace?: DisplaceTransform[]; // Mainly for internal usage. // We can call this 'dynamic' data transform.
-}
+export type DataTransform = FilterTransform | LogTransform | DisplaceTransform;
 
 export type FilterTransform = OneOfFilter | RangeFilter | IncludeFilter;
 
 export interface RangeFilter {
+    type: 'filter';
     field: string;
     inRange: number[];
     not?: boolean;
 }
 
 export interface IncludeFilter {
+    type: 'filter';
     field: string;
     include: string;
     not?: boolean;
 }
 
 export interface OneOfFilter {
+    type: 'filter';
     field: string;
     oneOf: string[] | number[];
     not?: boolean;
@@ -439,19 +437,21 @@ export interface OneOfFilter {
 
 export type LogBase = number | 'e';
 export interface LogTransform {
+    type: 'log';
     field: string;
     base?: LogBase; // If not specified, 10 is used
     newField?: string; // If specified, store transformed values in a new field.
 }
 
 export interface DisplaceTransform {
+    type: 'displace';
     // We could support different types of bounding boxes (e.g., using a center position and a size)
     boundingBox: {
         startField: string; // The name of a quantitative field that represents the start position
         endField: string; // The name of a quantitative field that represents the end position
         padding?: number; // TODO: this should be considered as a pixel value
     };
-    type: DisplacementType;
+    method: DisplacementType;
     newField: string;
 
     // "pile" specific parameters (TODO: make this a separate interface)

--- a/src/core/utils/data-transform.test.ts
+++ b/src/core/utils/data-transform.test.ts
@@ -2,24 +2,19 @@ import { filterData, calculateData, aggregateData } from './data-transform';
 
 describe('Data Transformation', () => {
     it('Filter', () => {
-        const filtered = filterData(
-            [
-                { field: 'c', oneOf: ['a'] },
-                { field: 'q', inRange: [1, 3.5] }
-            ],
-            [
-                { c: 'a', q: 1 },
-                { c: 'a', q: 3 },
-                { c: 'b', q: 4 }
-            ]
-        );
+        let filtered = filterData({ type: 'filter', field: 'c', oneOf: ['a'] }, [
+            { c: 'a', q: 1 },
+            { c: 'a', q: 3 },
+            { c: 'b', q: 4 }
+        ]);
+        filtered = filterData({ type: 'filter', field: 'q', inRange: [1, 3.5] }, filtered);
         expect(filtered).toHaveLength(2);
         expect(filtered.filter(d => d['c'] === 'b')).toHaveLength(0);
         expect(filtered.filter(d => d['q'] === 4)).toHaveLength(0);
     });
     it('Log', () => {
         {
-            const log = calculateData({ log: [{ field: 'q', base: 2 }] }, [
+            const log = calculateData({ type: 'log', field: 'q', base: 2 }, [
                 { c: 'a', q: 1 },
                 { c: 'a', q: 3 },
                 { c: 'b', q: 4 }
@@ -28,18 +23,12 @@ describe('Data Transformation', () => {
             expect(log.filter(d => d['c'] === 'b')[0]['q']).toBeCloseTo(Math.log2(4), 10);
         }
         {
-            const log = calculateData(
-                {
-                    log: [
-                        { field: 'q' } // default: 10
-                    ]
-                },
-                [
-                    { c: 'a', q: 1 },
-                    { c: 'a', q: 3 },
-                    { c: 'b', q: 4 }
-                ]
-            );
+            // default base is 10
+            const log = calculateData({ type: 'log', field: 'q' }, [
+                { c: 'a', q: 1 },
+                { c: 'a', q: 3 },
+                { c: 'b', q: 4 }
+            ]);
             expect(log).toHaveLength(3);
             expect(log.filter(d => d['c'] === 'b')[0]['q']).toBeCloseTo(Math.log10(4), 10);
         }

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -179,23 +179,18 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
                     const startField = track.x.field;
                     const endField = track.xe.field;
                     const padding = track.displacement.padding;
-                    const stackTransform: DisplaceTransform = {
+                    const displaceTransform: DisplaceTransform = {
+                        type: 'displace',
                         newField,
                         boundingBox: { startField, endField, padding },
-                        type: 'pile'
+                        method: 'pile'
                     };
 
                     // Add a data transform for stacking
-                    track.dataTransform = track.dataTransform
-                        ? {
-                              ...track.dataTransform,
-                              displace: track.dataTransform.displace
-                                  ? [...track.dataTransform.displace, stackTransform]
-                                  : [stackTransform]
-                          }
-                        : {
-                              displace: [stackTransform]
-                          };
+                    if (!track.dataTransform) {
+                        track.dataTransform = [];
+                    }
+                    track.dataTransform = [...track.dataTransform, displaceTransform];
                     track.row = { field: newField, type: 'nominal' };
                 } else if (track.displacement?.type === 'spread') {
                     // ...

--- a/src/editor/example/circos.ts
+++ b/src/editor/example/circos.ts
@@ -42,7 +42,7 @@ export const EX_SPEC_CIRCOS: GoslingSpec = {
                     'sample 8'
                 ]
             },
-            dataTransform: { filter: [{ field: 'peak', inRange: [0, 0.001] }] },
+            dataTransform: [{ type: 'filter', field: 'peak', inRange: [0, 0.001] }],
             mark: 'rect',
             x: { field: 'start', type: 'genomic' },
             xe: { field: 'end', type: 'genomic' },
@@ -90,9 +90,14 @@ export const EX_SPEC_CIRCOS: GoslingSpec = {
             opacity: { value: 0.4 },
             tracks: [
                 {
-                    dataTransform: {
-                        filter: [{ field: 'chr', oneOf: ['hs1'], not: true }]
-                    },
+                    dataTransform: [
+                        {
+                            type: 'filter',
+                            field: 'chr',
+                            oneOf: ['hs1'],
+                            not: true
+                        }
+                    ],
                     mark: 'link',
                     x: { field: 'p1', type: 'genomic' },
                     xe: { field: 'p1_2', type: 'genomic' },
@@ -102,7 +107,7 @@ export const EX_SPEC_CIRCOS: GoslingSpec = {
                     strokeWidth: { value: 1 }
                 },
                 {
-                    dataTransform: { filter: [{ field: 'chr', oneOf: ['hs1'] }] },
+                    dataTransform: [{ type: 'filter', field: 'chr', oneOf: ['hs1'] }],
                     mark: 'link',
                     x: { field: 'p1', type: 'genomic' },
                     xe: { field: 'p1_2', type: 'genomic' },

--- a/src/editor/example/circular-overview-linear-detail-views.ts
+++ b/src/editor/example/circular-overview-linear-detail-views.ts
@@ -73,12 +73,10 @@ export const EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL: GoslingSpec = {
                             { chromosomeField: 'chr2', genomicFields: ['p2s', 'p2e'] }
                         ]
                     },
-                    dataTransform: {
-                        filter: [
-                            { field: 'chr1', oneOf: ['1', '16', '14', '9', '6', '5', '3'] },
-                            { field: 'chr2', oneOf: ['1', '16', '14', '9', '6', '5', '3'] }
-                        ]
-                    },
+                    dataTransform: [
+                        { type: 'filter', field: 'chr1', oneOf: ['1', '16', '14', '9', '6', '5', '3'] },
+                        { type: 'filter', field: 'chr2', oneOf: ['1', '16', '14', '9', '6', '5', '3'] }
+                    ],
                     mark: 'link',
                     x: { field: 'p1s', type: 'genomic' },
                     xe: { field: 'p1e', type: 'genomic' },

--- a/src/editor/example/corces.ts
+++ b/src/editor/example/corces.ts
@@ -30,7 +30,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                     tracks: [
                         {
                             mark: 'rect',
-                            dataTransform: { filter: [{ field: 'Stain', oneOf: ['acen-1', 'acen-2'], not: true }] },
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-1', 'acen-2'], not: true }],
                             color: {
                                 field: 'Density',
                                 type: 'nominal',
@@ -41,25 +41,19 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                         },
                         {
                             mark: 'rect',
-                            dataTransform: {
-                                filter: [{ field: 'Stain', oneOf: ['gvar'] }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['gvar'] }],
                             color: { value: '#A0A0F2' },
                             size: { value: 20 }
                         },
                         {
                             mark: 'triangleRight',
-                            dataTransform: {
-                                filter: [{ field: 'Stain', oneOf: ['acen-1'] }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-1'] }],
                             color: { value: '#B40101' },
                             size: { value: 20 }
                         },
                         {
                             mark: 'triangleLeft',
-                            dataTransform: {
-                                filter: [{ field: 'Stain', oneOf: ['acen-2'] }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-2'] }],
                             color: { value: '#B40101' },
                             size: { value: 20 }
                         },
@@ -194,12 +188,10 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                     },
                     tracks: [
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['+'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['+'] }
+                            ],
                             mark: 'text',
                             text: { field: 'name', type: 'nominal' },
                             x: {
@@ -210,12 +202,10 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                             style: { textFontSize: 8, dy: -12 }
                         },
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['-'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['-'] }
+                            ],
                             mark: 'text',
                             text: { field: 'name', type: 'nominal' },
                             x: { field: 'start', type: 'genomic' },
@@ -223,36 +213,32 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                             style: { textFontSize: 8, dy: 10 }
                         },
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['+'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['+'] }
+                            ],
                             mark: 'rect',
                             x: { field: 'end', type: 'genomic' },
                             size: { value: 7 }
                         },
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['-'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['-'] }
+                            ],
                             mark: 'rect',
                             x: { field: 'start', type: 'genomic' },
                             size: { value: 7 }
                         },
                         {
-                            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+                            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
                             mark: 'rect',
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
                             size: { value: 14 }
                         },
                         {
-                            dataTransform: { filter: [{ field: 'type', oneOf: ['gene'] }] },
+                            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
                             mark: 'rule',
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },

--- a/src/editor/example/gene-annotation.ts
+++ b/src/editor/example/gene-annotation.ts
@@ -27,12 +27,10 @@ const HiGlass: OverlaidTracks = {
     data,
     tracks: [
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['+'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['+'] }
+            ],
             mark: 'triangleRight',
             x: {
                 field: 'end',
@@ -43,9 +41,7 @@ const HiGlass: OverlaidTracks = {
             size: { value: 15 }
         },
         {
-            dataTransform: {
-                filter: [{ field: 'type', oneOf: ['gene'] }]
-            },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'text',
             text: { field: 'name', type: 'nominal' },
             x: {
@@ -61,12 +57,10 @@ const HiGlass: OverlaidTracks = {
             }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['-'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['-'] }
+            ],
             mark: 'triangleLeft',
             x: {
                 field: 'start',
@@ -76,7 +70,7 @@ const HiGlass: OverlaidTracks = {
             style: { align: 'right' }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
             mark: 'rect',
             x: {
                 field: 'start',
@@ -89,12 +83,10 @@ const HiGlass: OverlaidTracks = {
             }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['+'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['+'] }
+            ],
             mark: 'rule',
             x: {
                 field: 'start',
@@ -110,12 +102,10 @@ const HiGlass: OverlaidTracks = {
             }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['-'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['-'] }
+            ],
             mark: 'rule',
             x: {
                 field: 'start',
@@ -153,9 +143,7 @@ const IGV: OverlaidTracks = {
     data,
     tracks: [
         {
-            dataTransform: {
-                filter: [{ field: 'type', oneOf: ['gene'] }]
-            },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'text',
             text: { field: 'name', type: 'nominal' },
             x: {
@@ -170,7 +158,7 @@ const IGV: OverlaidTracks = {
             }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['gene'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'rect',
             x: {
                 field: 'start',
@@ -184,12 +172,10 @@ const IGV: OverlaidTracks = {
             }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['-'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['-'] }
+            ],
             mark: 'rule',
             x: {
                 field: 'start',
@@ -208,12 +194,10 @@ const IGV: OverlaidTracks = {
             }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['+'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['+'] }
+            ],
             mark: 'rule',
             x: {
                 field: 'start',
@@ -254,9 +238,7 @@ const CyverseQUBES: OverlaidTracks = {
     data,
     tracks: [
         {
-            dataTransform: {
-                filter: [{ field: 'type', oneOf: ['gene'] }]
-            },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'text',
             text: { field: 'name', type: 'nominal' },
             x: {
@@ -271,12 +253,10 @@ const CyverseQUBES: OverlaidTracks = {
             color: { value: 'black' }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['+'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['+'] }
+            ],
             mark: 'triangleRight',
             x: {
                 field: 'end',
@@ -286,12 +266,10 @@ const CyverseQUBES: OverlaidTracks = {
             color: { value: '#999999' }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['-'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['-'] }
+            ],
             mark: 'triangleLeft',
             x: {
                 field: 'start',
@@ -304,7 +282,7 @@ const CyverseQUBES: OverlaidTracks = {
             }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['gene'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'rect',
             x: {
                 field: 'start',
@@ -318,7 +296,7 @@ const CyverseQUBES: OverlaidTracks = {
             color: { value: 'lightgray' }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['gene'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'rule',
             x: {
                 field: 'start',
@@ -333,7 +311,7 @@ const CyverseQUBES: OverlaidTracks = {
             color: { value: 'gray' }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
             mark: 'rect',
             x: {
                 field: 'start',
@@ -370,9 +348,7 @@ const GmGDB: OverlaidTracks = {
     data,
     tracks: [
         {
-            dataTransform: {
-                filter: [{ field: 'type', oneOf: ['gene'] }]
-            },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'text',
             text: { field: 'name', type: 'nominal' },
             x: {
@@ -390,12 +366,10 @@ const GmGDB: OverlaidTracks = {
             }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['+'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['+'] }
+            ],
             mark: 'triangleRight',
             x: {
                 field: 'end',
@@ -405,12 +379,10 @@ const GmGDB: OverlaidTracks = {
             size: { value: 15 }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['-'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['-'] }
+            ],
             mark: 'triangleLeft',
             x: {
                 field: 'start',
@@ -423,7 +395,7 @@ const GmGDB: OverlaidTracks = {
             }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
             mark: 'rect',
             x: {
                 field: 'start',
@@ -437,7 +409,7 @@ const GmGDB: OverlaidTracks = {
             }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['gene'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'rule',
             x: {
                 field: 'start',
@@ -477,9 +449,7 @@ const g6: OverlaidTracks = {
     data,
     tracks: [
         {
-            dataTransform: {
-                filter: [{ field: 'type', oneOf: ['gene'] }]
-            },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'text',
             text: { field: 'name', type: 'nominal' },
             x: {
@@ -497,7 +467,7 @@ const g6: OverlaidTracks = {
             }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
             mark: 'rect',
             x: {
                 field: 'start',
@@ -511,7 +481,7 @@ const g6: OverlaidTracks = {
             }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['intron'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['intron'] }],
             mark: 'rule',
             x: {
                 field: 'start',
@@ -547,9 +517,7 @@ const g7: OverlaidTracks = {
     data,
     tracks: [
         {
-            dataTransform: {
-                filter: [{ field: 'type', oneOf: ['gene'] }]
-            },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'text',
             text: { field: 'name', type: 'nominal' },
             x: {
@@ -565,7 +533,7 @@ const g7: OverlaidTracks = {
             }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['gene'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'rect',
             x: {
                 field: 'start',
@@ -579,7 +547,7 @@ const g7: OverlaidTracks = {
             color: { value: '#666666' }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
             mark: 'rect',
             x: {
                 field: 'start',
@@ -593,7 +561,7 @@ const g7: OverlaidTracks = {
             color: { value: '#FF6666' }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['intron'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['intron'] }],
             mark: 'rect',
             x: {
                 field: 'start',
@@ -630,12 +598,10 @@ const GIVE: OverlaidTracks = {
     data,
     tracks: [
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['+'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['+'] }
+            ],
             mark: 'rect',
             x: {
                 field: 'end',
@@ -645,25 +611,23 @@ const GIVE: OverlaidTracks = {
             size: { value: 7 }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['-'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['-'] }
+            ],
             mark: 'rect',
             x: { field: 'start', type: 'genomic' },
             size: { value: 7 }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
             mark: 'rect',
             x: { field: 'start', type: 'genomic' },
             xe: { field: 'end', type: 'genomic' },
             size: { value: 14 }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['gene'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'rule',
             x: { field: 'start', type: 'genomic' },
             xe: { field: 'end', type: 'genomic' },
@@ -682,12 +646,10 @@ const CorcesEtAl: OverlaidTracks = {
     data,
     tracks: [
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['+'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['+'] }
+            ],
             mark: 'text',
             text: { field: 'name', type: 'nominal' },
             x: {
@@ -699,12 +661,10 @@ const CorcesEtAl: OverlaidTracks = {
             style: { textFontSize: 8, dy: -12 }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['-'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['-'] }
+            ],
             mark: 'text',
             text: { field: 'name', type: 'nominal' },
             x: { field: 'start', type: 'genomic' },
@@ -712,36 +672,32 @@ const CorcesEtAl: OverlaidTracks = {
             style: { textFontSize: 8, dy: 10 }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['+'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['+'] }
+            ],
             mark: 'rect',
             x: { field: 'end', type: 'genomic' },
             size: { value: 7 }
         },
         {
-            dataTransform: {
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['-'] }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['-'] }
+            ],
             mark: 'rect',
             x: { field: 'start', type: 'genomic' },
             size: { value: 7 }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
             mark: 'rect',
             x: { field: 'start', type: 'genomic' },
             xe: { field: 'end', type: 'genomic' },
             size: { value: 14 }
         },
         {
-            dataTransform: { filter: [{ field: 'type', oneOf: ['gene'] }] },
+            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
             mark: 'rule',
             x: { field: 'start', type: 'genomic' },
             xe: { field: 'end', type: 'genomic' },

--- a/src/editor/example/gene-transcript.ts
+++ b/src/editor/example/gene-transcript.ts
@@ -16,29 +16,31 @@ export const EX_SPEC_GENE_TRANSCRIPT: GoslingSpec = {
             { index: 3, name: 'name', type: 'nominal' }
         ]
     },
-    dataTransform: {
-        displace: [
-            { type: 'pile', boundingBox: { startField: 'start', endField: 'end' }, newField: 'row', maxRows: 15 }
-        ],
-        filter: [{ field: 'type', oneOf: ['gene'] }]
-    },
+    dataTransform: [
+        { type: 'filter', field: 'type', oneOf: ['gene'] },
+        {
+            type: 'displace',
+            method: 'pile',
+            boundingBox: { startField: 'start', endField: 'end' },
+            newField: 'row',
+            maxRows: 15
+        }
+    ],
     title: 'hg38 | Transcript (Max. 15 Rows)',
     tracks: [
         {
-            dataTransform: {
-                displace: [
-                    {
-                        type: 'pile',
-                        boundingBox: { startField: 'start', endField: 'end' },
-                        newField: 'row',
-                        maxRows: 15
-                    }
-                ],
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['+'] }
-                ]
-            },
+            dataTransform: [
+                {
+                    type: 'displace',
+                    method: 'pile',
+                    boundingBox: { startField: 'start', endField: 'end' },
+                    newField: 'row',
+                    maxRows: 15
+                },
+
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['+'] }
+            ],
             mark: 'triangleRight',
             x: {
                 field: 'end',
@@ -49,17 +51,16 @@ export const EX_SPEC_GENE_TRANSCRIPT: GoslingSpec = {
             size: { value: 15 }
         },
         {
-            dataTransform: {
-                displace: [
-                    {
-                        type: 'pile',
-                        boundingBox: { startField: 'start', endField: 'end' },
-                        newField: 'row',
-                        maxRows: 15
-                    }
-                ],
-                filter: [{ field: 'type', oneOf: ['gene'] }]
-            },
+            dataTransform: [
+                {
+                    type: 'displace',
+                    method: 'pile',
+                    boundingBox: { startField: 'start', endField: 'end' },
+                    newField: 'row',
+                    maxRows: 15
+                },
+                { type: 'filter', field: 'type', oneOf: ['gene'] }
+            ],
             mark: 'text',
             text: { field: 'name', type: 'nominal' },
             x: {
@@ -75,20 +76,17 @@ export const EX_SPEC_GENE_TRANSCRIPT: GoslingSpec = {
             }
         },
         {
-            dataTransform: {
-                displace: [
-                    {
-                        type: 'pile',
-                        boundingBox: { startField: 'start', endField: 'end' },
-                        newField: 'row',
-                        maxRows: 15
-                    }
-                ],
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['-'] }
-                ]
-            },
+            dataTransform: [
+                {
+                    type: 'displace',
+                    method: 'pile',
+                    boundingBox: { startField: 'start', endField: 'end' },
+                    newField: 'row',
+                    maxRows: 15
+                },
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['-'] }
+            ],
             mark: 'triangleLeft',
             x: {
                 field: 'start',
@@ -98,17 +96,16 @@ export const EX_SPEC_GENE_TRANSCRIPT: GoslingSpec = {
             style: { align: 'right' }
         },
         {
-            dataTransform: {
-                displace: [
-                    {
-                        type: 'pile',
-                        boundingBox: { startField: 'start', endField: 'end' },
-                        newField: 'row',
-                        maxRows: 15
-                    }
-                ],
-                filter: [{ field: 'type', oneOf: ['exon'] }]
-            },
+            dataTransform: [
+                {
+                    type: 'displace',
+                    method: 'pile',
+                    boundingBox: { startField: 'start', endField: 'end' },
+                    newField: 'row',
+                    maxRows: 15
+                },
+                { type: 'filter', field: 'type', oneOf: ['exon'] }
+            ],
             mark: 'rect',
             x: {
                 field: 'start',
@@ -120,20 +117,17 @@ export const EX_SPEC_GENE_TRANSCRIPT: GoslingSpec = {
             }
         },
         {
-            dataTransform: {
-                displace: [
-                    {
-                        type: 'pile',
-                        boundingBox: { startField: 'start', endField: 'end' },
-                        newField: 'row',
-                        maxRows: 15
-                    }
-                ],
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['+'] }
-                ]
-            },
+            dataTransform: [
+                {
+                    type: 'displace',
+                    method: 'pile',
+                    boundingBox: { startField: 'start', endField: 'end' },
+                    newField: 'row',
+                    maxRows: 15
+                },
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['+'] }
+            ],
             mark: 'rule',
             x: {
                 field: 'start',
@@ -149,20 +143,17 @@ export const EX_SPEC_GENE_TRANSCRIPT: GoslingSpec = {
             }
         },
         {
-            dataTransform: {
-                displace: [
-                    {
-                        type: 'pile',
-                        boundingBox: { startField: 'start', endField: 'end' },
-                        newField: 'row',
-                        maxRows: 15
-                    }
-                ],
-                filter: [
-                    { field: 'type', oneOf: ['gene'] },
-                    { field: 'strand', oneOf: ['-'] }
-                ]
-            },
+            dataTransform: [
+                {
+                    type: 'displace',
+                    method: 'pile',
+                    boundingBox: { startField: 'start', endField: 'end' },
+                    newField: 'row',
+                    maxRows: 15
+                },
+                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                { type: 'filter', field: 'strand', oneOf: ['-'] }
+            ],
             mark: 'rule',
             x: {
                 field: 'start',

--- a/src/editor/example/give.ts
+++ b/src/editor/example/give.ts
@@ -30,12 +30,10 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     },
                     tracks: [
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['+'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['+'] }
+                            ],
                             mark: 'rect',
                             x: {
                                 field: 'end',
@@ -46,25 +44,23 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                             size: { value: 7 }
                         },
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['-'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['-'] }
+                            ],
                             mark: 'rect',
                             x: { field: 'start', type: 'genomic' },
                             size: { value: 7 }
                         },
                         {
-                            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+                            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
                             mark: 'rect',
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
                             size: { value: 14 }
                         },
                         {
-                            dataTransform: { filter: [{ field: 'type', oneOf: ['gene'] }] },
+                            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
                             mark: 'rule',
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
@@ -146,27 +142,21 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     tracks: [
                         {
                             mark: 'rect',
-                            dataTransform: {
-                                filter: [{ field: 'Stain', oneOf: ['acen'], not: true }]
-                            }
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }]
                         },
                         {
                             mark: 'triangleRight',
-                            dataTransform: {
-                                filter: [
-                                    { field: 'Stain', oneOf: ['acen'] },
-                                    { field: 'Name', include: 'q' }
-                                ]
-                            }
+                            dataTransform: [
+                                { type: 'filter', field: 'Stain', oneOf: ['acen'] },
+                                { type: 'filter', field: 'Name', include: 'q' }
+                            ]
                         },
                         {
                             mark: 'triangleLeft',
-                            dataTransform: {
-                                filter: [
-                                    { field: 'Stain', oneOf: ['acen'] },
-                                    { field: 'Name', include: 'p' }
-                                ]
-                            }
+                            dataTransform: [
+                                { type: 'filter', field: 'Stain', oneOf: ['acen'] },
+                                { type: 'filter', field: 'Name', include: 'p' }
+                            ]
                         }
                     ],
                     x: {
@@ -197,7 +187,7 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                         longToWideId: 'id'
                         //sampleLength: 5000
                     },
-                    dataTransform: { filter: [{ field: 'chr', oneOf: ['hs17'] }] },
+                    dataTransform: [{ type: 'filter', field: 'chr', oneOf: ['hs17'] }],
                     mark: 'rect',
                     x: { field: 'p1', type: 'genomic' },
                     xe: { field: 'p2', type: 'genomic' },
@@ -257,27 +247,21 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     tracks: [
                         {
                             mark: 'rect',
-                            dataTransform: {
-                                filter: [{ field: 'Stain', oneOf: ['acen'], not: true }]
-                            }
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }]
                         },
                         {
                             mark: 'triangleRight',
-                            dataTransform: {
-                                filter: [
-                                    { field: 'Stain', oneOf: ['acen'] },
-                                    { field: 'Name', include: 'q' }
-                                ]
-                            }
+                            dataTransform: [
+                                { type: 'filter', field: 'Stain', oneOf: ['acen'] },
+                                { type: 'filter', field: 'Name', include: 'q' }
+                            ]
                         },
                         {
                             mark: 'triangleLeft',
-                            dataTransform: {
-                                filter: [
-                                    { field: 'Stain', oneOf: ['acen'] },
-                                    { field: 'Name', include: 'p' }
-                                ]
-                            }
+                            dataTransform: [
+                                { type: 'filter', field: 'Stain', oneOf: ['acen'] },
+                                { type: 'filter', field: 'Name', include: 'p' }
+                            ]
                         }
                     ],
                     x: {
@@ -308,7 +292,7 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                         longToWideId: 'id'
                         //sampleLength: 5000
                     },
-                    dataTransform: { filter: [{ field: 'chr_2', oneOf: ['hs1'] }] },
+                    dataTransform: [{ type: 'filter', field: 'chr_2', oneOf: ['hs1'] }],
                     mark: 'rect',
                     x: { field: 'p1_2', type: 'genomic' },
                     xe: { field: 'p2_2', type: 'genomic' },
@@ -429,12 +413,10 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     },
                     tracks: [
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['+'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['+'] }
+                            ],
                             mark: 'rect',
                             x: {
                                 field: 'end',
@@ -445,25 +427,23 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                             size: { value: 7 }
                         },
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['-'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['-'] }
+                            ],
                             mark: 'rect',
                             x: { field: 'start', type: 'genomic' },
                             size: { value: 7 }
                         },
                         {
-                            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+                            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
                             mark: 'rect',
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
                             size: { value: 14 }
                         },
                         {
-                            dataTransform: { filter: [{ field: 'type', oneOf: ['gene'] }] },
+                            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
                             mark: 'rule',
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },

--- a/src/editor/example/gremlin.ts
+++ b/src/editor/example/gremlin.ts
@@ -20,9 +20,7 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                     tracks: [
                         {
                             mark: 'rect',
-                            dataTransform: {
-                                filter: [{ field: 'Stain', oneOf: ['acen'], not: true }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }],
                             color: {
                                 field: 'Stain',
                                 type: 'nominal',
@@ -33,17 +31,13 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                         },
                         {
                             mark: 'rect',
-                            dataTransform: {
-                                filter: [{ field: 'Stain', oneOf: ['acen'] }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'] }],
                             size: { value: 10 },
                             color: { value: '#B74780' }
                         },
                         {
                             mark: 'text',
-                            dataTransform: {
-                                filter: [{ field: 'Stain', oneOf: ['gpos25', 'gpos50', 'gpos100'] }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['gpos25', 'gpos50', 'gpos100'] }],
                             text: { field: 'Name', type: 'nominal' },
                             visibility: [
                                 {
@@ -63,9 +57,7 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                         },
                         {
                             mark: 'text',
-                            dataTransform: {
-                                filter: [{ field: 'Stain', oneOf: ['gneg', 'gpos75', 'gvar'] }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['gneg', 'gpos75', 'gvar'] }],
                             text: { field: 'Name', type: 'nominal' },
                             visibility: [
                                 {
@@ -114,12 +106,10 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                         longToWideId: 'id',
                         sampleLength: 2000
                     },
-                    dataTransform: {
-                        filter: [
-                            { field: 'chr', oneOf: ['hs5', 'hs4', 'hs6'] },
-                            { field: 'chr_2', oneOf: ['hs5', 'hs4', 'hs6'] }
-                        ]
-                    },
+                    dataTransform: [
+                        { type: 'filter', field: 'chr', oneOf: ['hs5', 'hs4', 'hs6'] },
+                        { type: 'filter', field: 'chr_2', oneOf: ['hs5', 'hs4', 'hs6'] }
+                    ],
                     tracks: [
                         { mark: 'rect' },
                         {
@@ -169,12 +159,10 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                         longToWideId: 'id',
                         sampleLength: 1000
                     },
-                    dataTransform: {
-                        filter: [
-                            { field: 'chr', oneOf: ['hs5'] },
-                            { field: 'chr_2', oneOf: ['hs5'] }
-                        ]
-                    },
+                    dataTransform: [
+                        { type: 'filter', field: 'chr', oneOf: ['hs5'] },
+                        { type: 'filter', field: 'chr_2', oneOf: ['hs5'] }
+                    ],
                     tracks: [
                         { mark: 'link' },
                         {
@@ -213,12 +201,10 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                                 longToWideId: 'id',
                                 sampleLength: 1000
                             },
-                            dataTransform: {
-                                filter: [
-                                    { field: 'chr', oneOf: ['hs5', 'hs4', 'hs6'] },
-                                    { field: 'chr_2', oneOf: ['hs5', 'hs4', 'hs6'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'chr', oneOf: ['hs5', 'hs4', 'hs6'] },
+                                { type: 'filter', field: 'chr_2', oneOf: ['hs5', 'hs4', 'hs6'] }
+                            ],
                             mark: 'link',
                             x: {
                                 field: 'p1',
@@ -270,9 +256,7 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                                         longToWideId: 'id',
                                         sampleLength: 1000
                                     },
-                                    dataTransform: {
-                                        filter: [{ field: 'chr', oneOf: ['hs5'] }]
-                                    },
+                                    dataTransform: [{ type: 'filter', field: 'chr', oneOf: ['hs5'] }],
                                     mark: 'link',
                                     x: {
                                         field: 'p1',

--- a/src/editor/example/ideograms.ts
+++ b/src/editor/example/ideograms.ts
@@ -13,9 +13,7 @@ export const CytoBands: OverlaidTracks = {
     tracks: [
         {
             mark: 'text',
-            dataTransform: {
-                filter: [{ field: 'Stain', oneOf: ['acen-1', 'acen-2'], not: true }]
-            },
+            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-1', 'acen-2'], not: true }],
             text: { field: 'Band', type: 'nominal' },
             color: { value: 'black' },
             visibility: [
@@ -33,9 +31,7 @@ export const CytoBands: OverlaidTracks = {
         },
         {
             mark: 'rect',
-            dataTransform: {
-                filter: [{ field: 'Stain', oneOf: ['acen-1', 'acen-2'], not: true }]
-            },
+            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-1', 'acen-2'], not: true }],
             color: {
                 field: 'Density',
                 type: 'nominal',
@@ -45,23 +41,17 @@ export const CytoBands: OverlaidTracks = {
         },
         {
             mark: 'rect',
-            dataTransform: {
-                filter: [{ field: 'Stain', oneOf: ['gvar'] }]
-            },
+            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['gvar'] }],
             color: { value: '#A0A0F2' }
         },
         {
             mark: 'triangleRight',
-            dataTransform: {
-                filter: [{ field: 'Stain', oneOf: ['acen-1'] }]
-            },
+            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-1'] }],
             color: { value: '#B40101' }
         },
         {
             mark: 'triangleLeft',
-            dataTransform: {
-                filter: [{ field: 'Stain', oneOf: ['acen-2'] }]
-            },
+            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-2'] }],
             color: { value: '#B40101' }
         }
     ],

--- a/src/editor/example/mark-displacement.ts
+++ b/src/editor/example/mark-displacement.ts
@@ -39,16 +39,15 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                             // { type: 'nominal', index: 13, name: '13' },
                         ]
                     },
-                    dataTransform: {
-                        filter: [{ field: 'significance', oneOf: ['Likely_benign'] }],
-                        displace: [
-                            {
-                                boundingBox: { startField: 'start', endField: 'end', padding: 5 },
-                                type: 'spread',
-                                newField: 'a'
-                            }
-                        ]
-                    },
+                    dataTransform: [
+                        { type: 'filter', field: 'significance', oneOf: ['Likely_benign'] },
+                        {
+                            type: 'displace',
+                            boundingBox: { startField: 'start', endField: 'end', padding: 5 },
+                            method: 'spread',
+                            newField: 'a'
+                        }
+                    ],
                     tracks: [
                         { mark: 'point', size: { value: 4 }, color: { value: '#029F73' } },
                         {
@@ -85,16 +84,15 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                         ],
                         valueFields: [{ index: 7, name: 'significance', type: 'nominal' }]
                     },
-                    dataTransform: {
-                        filter: [{ field: 'significance', oneOf: ['Likely_benign'] }],
-                        displace: [
-                            {
-                                boundingBox: { startField: 'start', endField: 'end', padding: 5 },
-                                type: 'spread',
-                                newField: 'a'
-                            }
-                        ]
-                    },
+                    dataTransform: [
+                        { type: 'filter', field: 'significance', oneOf: ['Likely_benign'] },
+                        {
+                            type: 'displace',
+                            boundingBox: { startField: 'start', endField: 'end', padding: 5 },
+                            method: 'spread',
+                            newField: 'a'
+                        }
+                    ],
                     mark: 'link',
                     xe: { field: 'start', type: 'genomic' },
                     x: { field: 'aStart', type: 'genomic' },
@@ -122,9 +120,7 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                 ],
                                 valueFields: [{ index: 7, name: 'significance', type: 'nominal' }]
                             },
-                            dataTransform: {
-                                filter: [{ field: 'significance', oneOf: ['Likely_benign'] }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'significance', oneOf: ['Likely_benign'] }],
                             mark: 'rect',
                             color: { value: 'lightgray' },
                             stroke: { value: 'lightgray' },
@@ -168,12 +164,10 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                 }
                             ],
                             opacity: { value: 0.8 },
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['+'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['+'] }
+                            ],
                             mark: 'triangleRight',
                             x: {
                                 field: 'end',
@@ -217,9 +211,7 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                 }
                             ],
                             opacity: { value: 0.8 },
-                            dataTransform: {
-                                filter: [{ field: 'type', oneOf: ['gene'] }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
                             mark: 'text',
                             text: { field: 'name', type: 'nominal' },
                             x: {
@@ -252,7 +244,6 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                     { index: 13, name: 'end' }
                                 ]
                             },
-
                             row: { field: 'strand', type: 'nominal', domain: ['+', '-'] },
                             color: {
                                 field: 'strand',
@@ -270,12 +261,10 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                 }
                             ],
                             opacity: { value: 0.8 },
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['-'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['-'] }
+                            ],
                             mark: 'triangleLeft',
                             x: {
                                 field: 'start',
@@ -319,7 +308,7 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                 }
                             ],
                             opacity: { value: 0.8 },
-                            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+                            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
                             mark: 'rect',
                             x: {
                                 field: 'start',
@@ -366,12 +355,10 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                 }
                             ],
                             opacity: { value: 0.8 },
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['+'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['+'] }
+                            ],
                             mark: 'rule',
                             x: {
                                 field: 'start',
@@ -422,12 +409,10 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                 }
                             ],
                             opacity: { value: 0.8 },
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['-'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['-'] }
+                            ],
                             mark: 'rule',
                             x: {
                                 field: 'start',

--- a/src/editor/example/matrix-hffc6.ts
+++ b/src/editor/example/matrix-hffc6.ts
@@ -88,12 +88,12 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                 // },
                                 {
                                     title: 'Genes (hg38)',
-                                    dataTransform: { filter: [{ field: 'strand', oneOf: ['+'] }] },
+                                    dataTransform: [{ type: 'filter', field: 'strand', oneOf: ['+'] }],
                                     mark: 'triangleRight',
                                     color: { value: '#CB7AA7' }
                                 },
                                 {
-                                    dataTransform: { filter: [{ field: 'strand', oneOf: ['-'] }] },
+                                    dataTransform: [{ type: 'filter', field: 'strand', oneOf: ['-'] }],
                                     mark: 'triangleLeft',
                                     color: { value: '#029F73' }
                                 }
@@ -196,7 +196,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                             { index: 3, name: 'name', type: 'nominal' }
                                         ]
                                     },
-                                    dataTransform: { filter: [{ field: 'strand', oneOf: ['+'] }] },
+                                    dataTransform: [{ type: 'filter', field: 'strand', oneOf: ['+'] }],
                                     mark: 'triangleRight',
                                     x: { field: 'start', type: 'genomic' },
                                     size: { value: 13 },
@@ -219,7 +219,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                             { index: 3, name: 'name', type: 'nominal' }
                                         ]
                                     },
-                                    dataTransform: { filter: [{ field: 'strand', oneOf: ['-'] }] },
+                                    dataTransform: [{ type: 'filter', field: 'strand', oneOf: ['-'] }],
                                     mark: 'triangleLeft',
                                     x: { field: 'start', type: 'genomic' },
                                     stroke: { value: 'white' },
@@ -264,7 +264,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                 ],
                                 binSize: 8
                             },
-                            dataTransform: { filter: [{ field: 'value', inRange: [0, 999999] }] },
+                            dataTransform: [{ type: 'filter', field: 'value', inRange: [0, 999999] }],
                             mark: 'bar',
                             x: { field: 'start', type: 'genomic', axis: 'none' },
                             xe: { field: 'end', type: 'genomic' },
@@ -389,7 +389,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                             { index: 3, name: 'name', type: 'nominal' }
                                         ]
                                     },
-                                    dataTransform: { filter: [{ field: 'strand', oneOf: ['+'] }] },
+                                    dataTransform: [{ type: 'filter', field: 'strand', oneOf: ['+'] }],
                                     mark: 'triangleRight',
                                     x: { field: 'start', type: 'genomic' },
                                     size: { value: 13 },
@@ -412,7 +412,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                             { index: 3, name: 'name', type: 'nominal' }
                                         ]
                                     },
-                                    dataTransform: { filter: [{ field: 'strand', oneOf: ['-'] }] },
+                                    dataTransform: [{ type: 'filter', field: 'strand', oneOf: ['-'] }],
                                     mark: 'triangleLeft',
                                     x: { field: 'start', type: 'genomic' },
                                     size: { value: 13 },
@@ -457,7 +457,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                 ],
                                 binSize: 8
                             },
-                            dataTransform: { filter: [{ field: 'value', inRange: [0, 999999] }] },
+                            dataTransform: [{ type: 'filter', field: 'value', inRange: [0, 999999] }],
                             mark: 'bar',
                             x: { field: 'start', type: 'genomic', axis: 'none' },
                             xe: { field: 'end', type: 'genomic' },

--- a/src/editor/example/matrix.ts
+++ b/src/editor/example/matrix.ts
@@ -106,9 +106,7 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                         },
                         {
                             mark: 'text',
-                            dataTransform: {
-                                filter: [{ field: 'Stain', oneOf: ['acen'], not: true }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }],
                             text: { field: 'Name', type: 'nominal' },
                             color: {
                                 field: 'Stain',
@@ -131,9 +129,7 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                         },
                         {
                             mark: 'rect',
-                            dataTransform: {
-                                filter: [{ field: 'Stain', oneOf: ['acen'], not: true }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }],
                             color: {
                                 field: 'Stain',
                                 type: 'nominal',
@@ -143,22 +139,18 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                         },
                         {
                             mark: 'triangleRight',
-                            dataTransform: {
-                                filter: [
-                                    { field: 'Stain', oneOf: ['acen'] },
-                                    { field: 'Name', include: 'q' }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'Stain', oneOf: ['acen'] },
+                                { type: 'filter', field: 'Name', include: 'q' }
+                            ],
                             color: { value: '#B40101' }
                         },
                         {
                             mark: 'triangleLeft',
-                            dataTransform: {
-                                filter: [
-                                    { field: 'Stain', oneOf: ['acen'] },
-                                    { field: 'Name', include: 'p' }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'Stain', oneOf: ['acen'] },
+                                { type: 'filter', field: 'Name', include: 'p' }
+                            ],
                             color: { value: '#B40101' }
                         },
                         {
@@ -238,12 +230,10 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                     },
                     tracks: [
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['+'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['+'] }
+                            ],
                             mark: 'triangleRight',
                             x: {
                                 field: 'end',
@@ -253,9 +243,7 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                             size: { value: 15 }
                         },
                         {
-                            dataTransform: {
-                                filter: [{ field: 'type', oneOf: ['gene'] }]
-                            },
+                            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
                             mark: 'text',
                             text: { field: 'name', type: 'nominal' },
                             x: {
@@ -271,12 +259,10 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                             }
                         },
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['-'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['-'] }
+                            ],
                             mark: 'triangleLeft',
                             x: {
                                 field: 'start',
@@ -286,7 +272,7 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                             style: { align: 'right' }
                         },
                         {
-                            dataTransform: { filter: [{ field: 'type', oneOf: ['exon'] }] },
+                            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
                             mark: 'rect',
                             x: {
                                 field: 'start',
@@ -299,12 +285,10 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                             }
                         },
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['+'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['+'] }
+                            ],
                             mark: 'rule',
                             x: {
                                 field: 'start',
@@ -320,12 +304,10 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                             }
                         },
                         {
-                            dataTransform: {
-                                filter: [
-                                    { field: 'type', oneOf: ['gene'] },
-                                    { field: 'strand', oneOf: ['-'] }
-                                ]
-                            },
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['-'] }
+                            ],
                             mark: 'rule',
                             x: {
                                 field: 'start',

--- a/src/editor/example/semantic-zoom.ts
+++ b/src/editor/example/semantic-zoom.ts
@@ -20,7 +20,7 @@ const ScalableSequenceTrack: OverlaidTracks = {
             y: { field: 'count', type: 'quantitative' }
         },
         {
-            dataTransform: { filter: [{ field: 'count', oneOf: [0], not: true }] },
+            dataTransform: [{ type: 'filter', field: 'count', oneOf: [0], not: true }],
             mark: 'text',
             x: {
                 field: 'start',
@@ -138,9 +138,7 @@ const ScalableCytoBand: OverlaidTracks = {
         },
         {
             mark: 'text',
-            dataTransform: {
-                filter: [{ field: 'Stain', oneOf: ['acen'], not: true }]
-            },
+            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }],
             text: { field: 'Name', type: 'nominal' },
             color: {
                 field: 'Stain',
@@ -163,9 +161,7 @@ const ScalableCytoBand: OverlaidTracks = {
         },
         {
             mark: 'rect',
-            dataTransform: {
-                filter: [{ field: 'Stain', oneOf: ['acen'], not: true }]
-            },
+            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }],
             color: {
                 field: 'Stain',
                 type: 'nominal',
@@ -175,22 +171,18 @@ const ScalableCytoBand: OverlaidTracks = {
         },
         {
             mark: 'triangleRight',
-            dataTransform: {
-                filter: [
-                    { field: 'Stain', oneOf: ['acen'] },
-                    { field: 'Name', include: 'q' }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'Stain', oneOf: ['acen'] },
+                { type: 'filter', field: 'Name', include: 'q' }
+            ],
             color: { value: '#B40101' }
         },
         {
             mark: 'triangleLeft',
-            dataTransform: {
-                filter: [
-                    { field: 'Stain', oneOf: ['acen'] },
-                    { field: 'Name', include: 'p' }
-                ]
-            },
+            dataTransform: [
+                { type: 'filter', field: 'Stain', oneOf: ['acen'] },
+                { type: 'filter', field: 'Name', include: 'p' }
+            ],
             color: { value: '#B40101' }
         }
     ],

--- a/src/higlass-csv-datafetcher/higlass-csv-datafetcher.ts
+++ b/src/higlass-csv-datafetcher/higlass-csv-datafetcher.ts
@@ -264,7 +264,9 @@ function CSVDataFetcher(HGC: any, ...args: any): any {
                 });
 
                 // filter data based on the `DataTransform` spec
-                tabularData = filterData(this.filter, tabularData);
+                this.filter?.forEach(f => {
+                    tabularData = filterData(f, tabularData);
+                });
 
                 const sizeLimit = this.dataConfig.sampleLength ?? 1000;
                 return {


### PR DESCRIPTION
Fix #351 

This change the type of `dataTransform` to an array with an additional prop `type` (either "filter", "log", or "displace").

This allows users to specify the order of data transformations that need to be applied after loading data and before rendering visualizations.

Before: 
```js
dataTransform: {
  displace: [
      {
          type: 'pile',
          boundingBox: { startField: 'start', endField: 'end' },
          newField: 'row',
          maxRows: 15
      }
  ],
  filter: [
      { field: 'type', oneOf: ['gene'] },
      { field: 'strand', oneOf: ['-'] }
  ]
},
```

After:
```js
dataTransform: [
  {
      type: 'displace',
      method: 'pile',
      boundingBox: { startField: 'start', endField: 'end' },
      newField: 'row',
      maxRows: 15
  },
  { type: 'filter', field: 'type', oneOf: ['gene'] },
  { type: 'filter', field: 'strand', oneOf: ['-'] }
],