### PR TITLE
feat: support a dark theme

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -2542,6 +2542,9 @@
         "subtitle": {
           "type": "string"
         },
+        "theme": {
+          "$ref": "#/definitions/Theme"
+        },
         "title": {
           "type": "string"
         },
@@ -2691,6 +2694,9 @@
             },
             "text": {
               "$ref": "#/definitions/Channel"
+            },
+            "theme": {
+              "$ref": "#/definitions/Theme"
             },
             "title": {
               "type": "string"
@@ -3236,6 +3242,9 @@
             "text": {
               "$ref": "#/definitions/Channel"
             },
+            "theme": {
+              "$ref": "#/definitions/Theme"
+            },
             "title": {
               "type": "string"
             },
@@ -3704,6 +3713,9 @@
             },
             "subtitle": {
               "type": "string"
+            },
+            "theme": {
+              "$ref": "#/definitions/Theme"
             },
             "title": {
               "type": "string"
@@ -4527,6 +4539,13 @@
         "tracks"
       ],
       "type": "object"
+    },
+    "Theme": {
+      "enum": [
+        "light",
+        "dark"
+      ],
+      "type": "string"
     },
     "Track": {
       "anyOf": [

--- a/schema/history/0.7.6/gosling0.7.6.schema.json
+++ b/schema/history/0.7.6/gosling0.7.6.schema.json
@@ -2542,6 +2542,9 @@
         "subtitle": {
           "type": "string"
         },
+        "theme": {
+          "$ref": "#/definitions/Theme"
+        },
         "title": {
           "type": "string"
         },
@@ -2691,6 +2694,9 @@
             },
             "text": {
               "$ref": "#/definitions/Channel"
+            },
+            "theme": {
+              "$ref": "#/definitions/Theme"
             },
             "title": {
               "type": "string"
@@ -3236,6 +3242,9 @@
             "text": {
               "$ref": "#/definitions/Channel"
             },
+            "theme": {
+              "$ref": "#/definitions/Theme"
+            },
             "title": {
               "type": "string"
             },
@@ -3704,6 +3713,9 @@
             },
             "subtitle": {
               "type": "string"
+            },
+            "theme": {
+              "$ref": "#/definitions/Theme"
             },
             "title": {
               "type": "string"
@@ -4527,6 +4539,13 @@
         "tracks"
       ],
       "type": "object"
+    },
+    "Theme": {
+      "enum": [
+        "light",
+        "dark"
+      ],
+      "type": "string"
     },
     "Track": {
       "anyOf": [

--- a/schema/history/0.7.6/gosling0.7.6.schema.ts
+++ b/schema/history/0.7.6/gosling0.7.6.schema.ts
@@ -3,16 +3,20 @@ import { Chromosome } from './utils/chrom-size';
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
 
+export type Theme = 'light' | 'dark';
+
 export type RootSpecWithSingleView = SingleView & {
     title?: string;
     subtitle?: string;
     description?: string;
+    theme?: Theme;
 };
 
 export interface RootSpecWithMultipleViews extends MultipleViews {
     title?: string;
     subtitle?: string;
     description?: string;
+    theme?: Theme;
 }
 
 /* ----------------------------- VIEW ----------------------------- */

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -8,6 +8,9 @@ export function compile(spec: GoslingSpec, setHg: (hg: HiGlassSpec, size: Size) 
     // Override default visual encoding (i.e., `DataTrack` => `BasicSingleTrack`)
     overrideTemplates(spec);
 
+    // Use default theme if not specified
+    if (!spec.theme) spec.theme = 'light';
+
     // Fix track specs by looking into the root-level spec
     traverseToFixSpecDownstream(spec);
 

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -15,6 +15,7 @@ gosling.init();
 interface GoslingCompProps {
     spec?: gosling.GoslingSpec;
     compiled?: (goslingSpec: gosling.GoslingSpec, higlassSpec: gosling.HiGlassSpec) => void;
+    padding?: number;
 }
 
 // TODO: specify types other than "any"
@@ -23,6 +24,9 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
     const [gs, setGs] = useState<gosling.GoslingSpec | undefined>(props.spec);
     const [hs, setHs] = useState<gosling.HiGlassSpec>();
     const [size, setSize] = useState({ width: 200, height: 200 });
+
+    // Styling
+    const padding = typeof props.padding !== 'undefined' ? props.padding : 60;
 
     // HiGlass API
     const hgRef = useRef<any>();
@@ -101,10 +105,10 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                 <div
                     style={{
                         position: 'relative',
-                        padding: 60,
-                        background: 'white',
-                        width: size.width + 120,
-                        height: size.height + 120,
+                        padding,
+                        background: gs?.theme === 'dark' ? 'black' : 'white',
+                        width: size.width + padding * 2,
+                        height: size.height + padding * 2,
                         textAlign: 'left'
                     }}
                 >
@@ -113,7 +117,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                         style={{
                             position: 'relative',
                             display: 'block',
-                            background: 'white',
+                            background: gs?.theme === 'dark' ? 'black' : 'white',
                             margin: 0,
                             padding: 0, // non-zero padding acts unexpectedly w/ HiGlassComponent
                             width: size.width,
@@ -135,6 +139,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                                 viewPaddingLeft: 0,
                                 viewPaddingRight: 0,
                                 sizeMode: 'bounded',
+                                theme: gs?.theme,
                                 rangeSelectionOnAlt: true // this allows switching between `selection` and `zoom&pan` mode
                             }}
                             viewConfig={hs}

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -39,7 +39,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
         ref.current = {
             api: {
                 // TODO: Support assemblies (we can infer this from the spec)
-                zoomTo: (viewId: string, position: string) => {
+                zoomTo: (viewId: string, position: string, duration = 1000) => {
                     // Accepted input: 'chr1' or 'chr1:1-1000'
                     if (!position.includes('chr')) {
                         console.warn('Genomic interval you entered is not in a correct form.');
@@ -58,10 +58,10 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     const start = +s + chrStart;
                     const end = +e + chrStart;
 
-                    hgRef?.current?.api?.zoomTo(viewId, start, end, start, end, 1000);
+                    hgRef?.current?.api?.zoomTo(viewId, start, end, start, end, duration);
                 },
-                zoomToGene: (viewId: string, gene: string) => {
-                    hgRef?.current?.api?.zoomToGene(viewId, gene, 1000);
+                zoomToGene: (viewId: string, gene: string, duration = 1000) => {
+                    hgRef?.current?.api?.zoomToGene(viewId, gene, duration);
                 },
                 getViewIds: () => {
                     if (!hs) return [];

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -2,13 +2,14 @@ import uuid from 'uuid';
 import { Track as HiGlassTrack } from './higlass.schema';
 import { HiGlassModel, HIGLASS_AXIS_SIZE } from './higlass-model';
 import { parseServerAndTilesetUidFromUrl } from './utils';
-import { Track, Domain, DataTransform } from './gosling.schema';
+import { Track, Domain, DataTransform, Theme } from './gosling.schema';
 import { BoundingBox, RelativePosition } from './utils/bounding-box';
 import { resolveSuperposedTracks } from './utils/overlay';
 import { getGenomicChannelKeyFromTrack, getGenomicChannelFromTrack } from './utils/validate';
 import { viridisColorMap } from './utils/colors';
 import { IsDataDeep, IsChannelDeep, IsDataDeepTileset } from './gosling.schema.guards';
 import { DEFAULT_SUBTITLE_HEIGHT, DEFAULT_TITLE_HEIGHT } from './layout/defaults';
+import { getThemeColors } from './utils/theme';
 
 /**
  * Convert a gosling track into a HiGlass view and add it into a higlass model.
@@ -17,7 +18,8 @@ export function goslingToHiGlass(
     hgModel: HiGlassModel,
     gosTrack: Track,
     bb: BoundingBox,
-    layout: RelativePosition
+    layout: RelativePosition,
+    theme: Theme = 'light'
 ): HiGlassModel {
     // TODO: check whether there are multiple track.data across superposed tracks
     // ...
@@ -58,7 +60,7 @@ export function goslingToHiGlass(
                 name: firstResolvedSpec.title,
                 labelPosition: firstResolvedSpec.title ? 'topLeft' : 'none',
                 fontSize: 12,
-                labelColor: 'black',
+                labelColor: getThemeColors(theme).main,
                 labelShowResolution: false,
                 labelBackgroundColor: 'white',
                 labelTextOpacity: 1,
@@ -66,9 +68,13 @@ export function goslingToHiGlass(
                 labelTopMargin: 1,
                 labelRightMargin: 0,
                 labelBottomMargin: 0,
+                // TODO: Use this eventually
+                // trackBorderWidth: firstResolvedSpec.style?.outlineWidth ?? 3,
+                // trackBorderColor: firstResolvedSpec.style?.outline ?? '#DBDBDB',
                 /* Others */
                 backgroundColor: 'transparent', // in this way, we can superpose multiple tracks
-                spec: { ...gosTrack }
+                spec: { ...gosTrack },
+                theme
             }
         };
 
@@ -142,7 +148,8 @@ export function goslingToHiGlass(
                     width: firstResolvedSpec.width,
                     height: firstResolvedSpec.height,
                     startAngle: firstResolvedSpec.startAngle,
-                    endAngle: firstResolvedSpec.endAngle
+                    endAngle: firstResolvedSpec.endAngle,
+                    theme
                 });
             }
         });
@@ -152,10 +159,24 @@ export function goslingToHiGlass(
         // `text` tracks are used to show title and subtitle of the views
         hgModel.addDefaultView(gosTrack.id ?? uuid.v1()).setLayout(layout);
         if (typeof firstResolvedSpec.title === 'string') {
-            hgModel.setTextTrack(bb.width, DEFAULT_TITLE_HEIGHT, firstResolvedSpec.title, 'black', 18, 'bold');
+            hgModel.setTextTrack(
+                bb.width,
+                DEFAULT_TITLE_HEIGHT,
+                firstResolvedSpec.title,
+                getThemeColors(theme).main,
+                18,
+                'bold'
+            );
         }
         if (typeof firstResolvedSpec.subtitle === 'string') {
-            hgModel.setTextTrack(bb.width, DEFAULT_SUBTITLE_HEIGHT, firstResolvedSpec.subtitle, 'gray', 14, 'normal');
+            hgModel.setTextTrack(
+                bb.width,
+                DEFAULT_SUBTITLE_HEIGHT,
+                firstResolvedSpec.subtitle,
+                getThemeColors(theme).sub,
+                14,
+                'normal'
+            );
         }
     }
     return hgModel;

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -3,16 +3,20 @@ import { Chromosome } from './utils/chrom-size';
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
 
+export type Theme = 'light' | 'dark';
+
 export type RootSpecWithSingleView = SingleView & {
     title?: string;
     subtitle?: string;
     description?: string;
+    theme?: Theme;
 };
 
 export interface RootSpecWithMultipleViews extends MultipleViews {
     title?: string;
     subtitle?: string;
     description?: string;
+    theme?: Theme;
 }
 
 /* ----------------------------- VIEW ----------------------------- */

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -1,11 +1,12 @@
 import uuid from 'uuid';
 import { HiGlassSpec, Track } from './higlass.schema';
 import HiGlassSchema from './higlass.schema.json';
-import { Assembly, AxisPosition, Domain, Orientation } from './gosling.schema';
+import { Assembly, AxisPosition, Domain, Orientation, Theme } from './gosling.schema';
 import { getNumericDomain } from './utils/scales';
 import { RelativePosition } from './utils/bounding-box';
 import { validateSpec } from './utils/validate';
 import { GET_CHROM_SIZES } from './utils/assembly';
+import { getThemeColors } from './utils/theme';
 
 export const HIGLASS_AXIS_SIZE = 30;
 const getViewTemplate = (assembly?: string) => {
@@ -100,7 +101,7 @@ export class HiGlassModel {
                 width,
                 height,
                 options: {
-                    backgroundColor: 'white',
+                    backgroundColor: 'transparent',
                     textColor,
                     fontSize,
                     fontWeight,
@@ -127,7 +128,8 @@ export class HiGlassModel {
             endAngle?: number;
             innerRadius?: number;
             outerRadius?: number;
-        }
+        },
+        theme: Theme = 'light'
     ) {
         if (!fromViewUid) return;
 
@@ -138,8 +140,8 @@ export class HiGlassModel {
             uid: uuid.v4(),
             fromViewUid,
             options: {
-                projectionFillColor: style?.color ?? '#777',
-                projectionStrokeColor: style?.stroke ?? '#777',
+                projectionFillColor: style?.color ?? getThemeColors(theme).sub,
+                projectionStrokeColor: style?.stroke ?? getThemeColors(theme).main,
                 projectionFillOpacity: style?.opacity ?? 0.3,
                 projectionStrokeOpacity: style?.opacity ?? 0.3,
                 strokeWidth: style?.strokeWidth ?? 1,
@@ -250,6 +252,7 @@ export class HiGlassModel {
             height?: number;
             startAngle?: number;
             endAngle?: number;
+            theme?: Theme;
         }
     ) {
         if (!this.hg.views) return this;
@@ -262,8 +265,9 @@ export class HiGlassModel {
             options: {
                 ...options,
                 assembly: this.getAssembly(),
-                color: 'black',
-                tickColor: 'black',
+                stroke: 'transparent', // text outline
+                color: getThemeColors(options.theme).main,
+                tickColor: getThemeColors(options.theme).main,
                 tickFormat: type === 'narrower' ? 'si' : 'plain',
                 tickPositions: type === 'regular' ? 'even' : 'ends',
                 reverseOrientation: position === 'bottom' || position === 'right' ? true : false

--- a/src/core/layout/higlass.ts
+++ b/src/core/layout/higlass.ts
@@ -21,7 +21,7 @@ export function renderHiGlass(
     /* Update the HiGlass model by iterating tracks */
     trackInfos.forEach(tb => {
         const { track, boundingBox: bb, layout } = tb;
-        goslingToHiGlass(hgModel, track, bb, layout);
+        goslingToHiGlass(hgModel, track, bb, layout, spec.theme);
     });
 
     /* Add linking information to the HiGlass model */
@@ -36,7 +36,8 @@ export function renderHiGlass(
                 info.layout,
                 info.viewId,
                 linkingInfos.find(d => !d.isBrush && d.linkId === info.linkId)?.viewId,
-                info.style
+                info.style,
+                spec.theme
             );
         });
 

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -4,7 +4,7 @@ import { drawLine } from './line';
 import { drawBar } from './bar';
 import { drawArea } from './area';
 import { drawRect } from './rect';
-import { ChannelTypes } from '../gosling.schema';
+import { ChannelTypes, Theme } from '../gosling.schema';
 import { drawTriangle } from './triangle';
 import { drawText } from './text';
 import { drawRule } from './rule';
@@ -45,7 +45,7 @@ export const RESOLUTION = 4;
 /**
  * Draw a track based on the track specification in a Gosling grammar.
  */
-export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrackModel) {
+export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrackModel, theme: Theme = 'light') {
     if (!HGC || !trackInfo || !tile) {
         // We did not receive parameters correctly.
         return;
@@ -73,7 +73,7 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
         drawCircularGrid(HGC, trackInfo, tile, model);
     } else {
         drawGrid(HGC, trackInfo, tile, model);
-        drawChartOutlines(HGC, trackInfo, model);
+        drawChartOutlines(HGC, trackInfo, model, theme);
     }
 
     // DEBUG

--- a/src/core/mark/outline.ts
+++ b/src/core/mark/outline.ts
@@ -1,6 +1,8 @@
 import { GoslingTrackModel } from '../gosling-track-model';
+import { Theme } from '../gosling.schema';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
+import { getThemeColors } from '../utils/theme';
 
 export const TITLE_STYLE = {
     fontSize: '12px',
@@ -11,7 +13,7 @@ export const TITLE_STYLE = {
     lineJoin: 'round'
 };
 
-export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackModel) {
+export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackModel, theme: Theme = 'light') {
     const g = trackInfo.pBorder; // use pBorder not to affected by zoomming
 
     // size and position
@@ -49,7 +51,7 @@ export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackMode
     g.lineStyle(
         tm.spec().style?.outlineWidth ?? 1,
         // TODO: outline not working
-        colorToHex(tm.spec().style?.outline ?? '#DBDBDB'),
+        colorToHex(tm.spec().style?.outline ?? getThemeColors(theme).sub),
         1, // alpha
         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
@@ -61,7 +63,7 @@ export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackMode
 
     g.lineStyle(
         1,
-        colorToHex('black'),
+        colorToHex(getThemeColors(theme).main),
         1, // alpha
         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );

--- a/src/core/mark/text.ts
+++ b/src/core/mark/text.ts
@@ -12,7 +12,7 @@ export const TEXT_STYLE_GLOBAL = {
     background: 'white',
     lineJoin: 'round',
     stroke: '#ffffff',
-    strokeThickness: 2
+    strokeThickness: 0
 };
 
 export function drawText(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel) {

--- a/src/core/utils/theme.ts
+++ b/src/core/utils/theme.ts
@@ -1,0 +1,8 @@
+import { Theme } from '../gosling.schema';
+
+export function getThemeColors(theme: Theme = 'light') {
+    return {
+        main: theme === 'light' ? 'black' : 'white',
+        sub: theme === 'dark' ? 'lightgray' : 'gray'
+    };
+}

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -605,6 +605,7 @@ function Editor(props: any) {
                                     <gosling.GoslingComponent
                                         ref={gosRef}
                                         spec={goslingSpec}
+                                        padding={60}
                                         compiled={(g, h) => {
                                             setHg(h);
                                         }}

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -2,6 +2,7 @@ import { GoslingSpec } from '../../core/gosling.schema';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
+    theme: 'dark', // beta support
     title: 'Visual Encoding',
     subtitle: 'Gosling provides diverse visual encoding methods',
     layout: 'linear',

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -2,7 +2,7 @@ import { GoslingSpec } from '../../core/gosling.schema';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
-    theme: 'dark', // beta support
+    // theme: 'dark', // beta support
     title: 'Visual Encoding',
     subtitle: 'Gosling provides diverse visual encoding methods',
     layout: 'linear',

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -123,7 +123,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                     return;
                 }
 
-                drawMark(HGC, this, tile, tm);
+                drawMark(HGC, this, tile, tm, this.options.theme);
             });
         }
 
@@ -839,6 +839,7 @@ GoslingTrack.config = {
         'backgroundColor',
         'barBorder',
         'sortLargestOnTop',
+        'theme',
         'axisPositionHorizontal' // TODO: support this
     ],
     defaultOptions: {
@@ -850,7 +851,8 @@ GoslingTrack.config = {
         backgroundColor: 'white',
         barBorder: false,
         sortLargestOnTop: true,
-        axisPositionHorizontal: 'left'
+        axisPositionHorizontal: 'left',
+        theme: 'light'
     }
 };
 


### PR DESCRIPTION
This PR adds a top-level property, `theme`, which can be either `dark` or `light` where `light` is the default one. This determines the default colors of visual components, such as titles, axes, track outlines, ...

```js
{
   theme: "dark",
   title: "Basic Eaxmple: Visual Encoding",
   views: [ ... ],
   ...
}
```

![Screen Shot 2021-04-14 at 2 43 16 PM](https://user-images.githubusercontent.com/9922882/114763276-9fcdfc80-9d30-11eb-9fbe-366bf9621f49.png)

This is a beta feature.

This PR also adds an ability to change the padding of gosling.js' react component (#357):
```js
<GoslingComponent ... padding={30}/> // 30px around the output visualization
```

Towards #117 
Fix #357 

**To Do**
- [ ] We can change the color theme of Editor depending on the `theme` prop used in the code editor.
- [ ] Default mark fill/stroke colors can be determined by `theme`