### PR TITLE
feat: allow defining track styles in the upper level

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -468,6 +468,9 @@
         "static": {
           "type": "boolean"
         },
+        "style": {
+          "$ref": "#/definitions/TrackStyle"
+        },
         "subtitle": {
           "type": "string"
         },
@@ -751,6 +754,9 @@
         },
         "static": {
           "type": "boolean"
+        },
+        "style": {
+          "$ref": "#/definitions/TrackStyle"
         },
         "tracks": {
           "items": {
@@ -1425,6 +1431,9 @@
         },
         "static": {
           "type": "boolean"
+        },
+        "style": {
+          "$ref": "#/definitions/TrackStyle"
         },
         "views": {
           "items": {
@@ -2538,6 +2547,9 @@
         },
         "static": {
           "type": "boolean"
+        },
+        "style": {
+          "$ref": "#/definitions/TrackStyle"
         },
         "subtitle": {
           "type": "string"
@@ -3710,6 +3722,9 @@
             },
             "static": {
               "type": "boolean"
+            },
+            "style": {
+              "$ref": "#/definitions/TrackStyle"
             },
             "subtitle": {
               "type": "string"

--- a/schema/history/0.7.6/gosling0.7.6.schema.json
+++ b/schema/history/0.7.6/gosling0.7.6.schema.json
@@ -468,6 +468,9 @@
         "static": {
           "type": "boolean"
         },
+        "style": {
+          "$ref": "#/definitions/TrackStyle"
+        },
         "subtitle": {
           "type": "string"
         },
@@ -751,6 +754,9 @@
         },
         "static": {
           "type": "boolean"
+        },
+        "style": {
+          "$ref": "#/definitions/TrackStyle"
         },
         "tracks": {
           "items": {
@@ -1425,6 +1431,9 @@
         },
         "static": {
           "type": "boolean"
+        },
+        "style": {
+          "$ref": "#/definitions/TrackStyle"
         },
         "views": {
           "items": {
@@ -2538,6 +2547,9 @@
         },
         "static": {
           "type": "boolean"
+        },
+        "style": {
+          "$ref": "#/definitions/TrackStyle"
         },
         "subtitle": {
           "type": "string"
@@ -3710,6 +3722,9 @@
             },
             "static": {
               "type": "boolean"
+            },
+            "style": {
+              "$ref": "#/definitions/TrackStyle"
             },
             "subtitle": {
               "type": "string"

--- a/schema/history/0.7.6/gosling0.7.6.schema.ts
+++ b/schema/history/0.7.6/gosling0.7.6.schema.ts
@@ -67,6 +67,9 @@ export interface CommonViewDef {
      * Proportion of the radius of the center white space.
      */
     centerRadius?: number; // [0, 1] (default: 0.3)
+
+    // Overriden by children
+    style?: TrackStyle;
 }
 
 /* ----------------------------- TRACK ----------------------------- */
@@ -160,9 +163,6 @@ export interface SingleTrack extends CommonTrackDef {
 
     // Visibility
     visibility?: VisibilityCondition[];
-
-    // Styling
-    style?: TrackStyle;
 
     // Experimental
     stackY?: boolean; // Will be deprecated.

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -67,6 +67,9 @@ export interface CommonViewDef {
      * Proportion of the radius of the center white space.
      */
     centerRadius?: number; // [0, 1] (default: 0.3)
+
+    // Overriden by children
+    style?: TrackStyle;
 }
 
 /* ----------------------------- TRACK ----------------------------- */
@@ -160,9 +163,6 @@ export interface SingleTrack extends CommonTrackDef {
 
     // Visibility
     visibility?: VisibilityCondition[];
-
-    // Styling
-    style?: TrackStyle;
 
     // Experimental
     stackY?: boolean; // Will be deprecated.

--- a/src/core/utils/spec-preprocess.test.ts
+++ b/src/core/utils/spec-preprocess.test.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec, Track } from '../gosling.schema';
+import { GoslingSpec, SingleView, Track } from '../gosling.schema';
 import { getBoundingBox, getRelativeTrackInfo } from './bounding-box';
 import { traverseToFixSpecDownstream, overrideTemplates, convertToFlatTracks } from './spec-preprocess';
 
@@ -15,6 +15,27 @@ describe('Fix Spec Downstream', () => {
         const size = getBoundingBox(info);
         expect(!isNaN(+size.width) && isFinite(size.width)).toEqual(true);
         expect(!isNaN(+size.height) && isFinite(size.height)).toEqual(true);
+    });
+
+    it('style', () => {
+        {
+            const spec: GoslingSpec = {
+                style: { outline: 'red' },
+                views: [{ tracks: [{ overlay: [], width: 0, height: 0 }] }]
+            };
+            traverseToFixSpecDownstream(spec);
+            expect((spec.views[0] as SingleView).style?.outline).toEqual('red');
+            expect((spec.views[0] as SingleView).tracks[0].style?.outline).toEqual('red');
+        }
+        {
+            const spec: GoslingSpec = {
+                style: { outline: 'red' },
+                views: [{ tracks: [{ overlay: [], width: 0, height: 0, style: { outline: 'green' } }] }]
+            };
+            traverseToFixSpecDownstream(spec);
+            expect((spec.views[0] as SingleView).style?.outline).toEqual('red');
+            expect((spec.views[0] as SingleView).tracks[0].style?.outline).toEqual('green');
+        }
     });
 
     it('static', () => {

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -26,6 +26,7 @@ import {
     DEFAULT_VIEW_SPACING
 } from '../layout/defaults';
 import { spreadTracksByData } from './overlay';
+import { getStyleOverridden } from '../utils/style';
 
 /**
  * Traverse individual tracks and call the callback function to read and/or update the track definition.
@@ -132,6 +133,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
         if (spec.spacing === undefined && !('tracks' in spec)) spec.spacing = parentDef.spacing;
         if ('views' in spec && 'arrangement' in parentDef && spec.arrangement === undefined)
             spec.arrangement = parentDef.arrangement;
+        spec.style = getStyleOverridden(parentDef.style, spec.style); // override styles deeply
     } else {
         // This means we are at the rool level, so assign default values if missing
         if (spec.assembly === undefined) spec.assembly = 'hg38';
@@ -209,6 +211,14 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
             if (!track.layout) track.layout = spec.layout;
             if (!track.orientation) track.orientation = spec.orientation;
             if (track.static === undefined) track.static = spec.static !== undefined ? spec.static : false;
+
+            // Override styles
+            track.style = getStyleOverridden(spec.style, track.style);
+            if (IsOverlaidTrack(track)) {
+                track.overlay.forEach(o => {
+                    o.style = getStyleOverridden(track.style, o.style);
+                });
+            }
 
             /**
              * Orientation is only supported in 1D linear layouts

--- a/src/core/utils/style.ts
+++ b/src/core/utils/style.ts
@@ -1,0 +1,8 @@
+import { assign } from 'lodash';
+import { TrackStyle } from '../gosling.schema';
+
+export function getStyleOverridden(parent: TrackStyle | undefined, child: TrackStyle | undefined) {
+    // Deep overriding instead of replacing.
+    const base = parent ? JSON.parse(JSON.stringify(parent)) : {};
+    return child ? assign(base, child) : base;
+}

--- a/src/editor/example/circular-overview-linear-detail-views.ts
+++ b/src/editor/example/circular-overview-linear-detail-views.ts
@@ -125,8 +125,7 @@ export const EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL: GoslingSpec = {
                             stroke: { value: 'black' },
                             strokeWidth: { value: 0.3 },
                             style: {
-                                background: 'blue',
-                                backgroundOpacity: 0.1
+                                background: 'blue'
                             },
                             width: 245,
                             height: 150
@@ -159,15 +158,15 @@ export const EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL: GoslingSpec = {
                             stroke: { value: 'black' },
                             strokeWidth: { value: 0.3 },
                             style: {
-                                background: 'red',
-                                backgroundOpacity: 0.1
+                                background: 'red'
                             },
                             width: 245,
                             height: 150
                         }
                     ]
                 }
-            ]
+            ],
+            style: { backgroundOpacity: 0.1 }
         }
     ]
 };

--- a/src/editor/example/corces.ts
+++ b/src/editor/example/corces.ts
@@ -186,6 +186,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                             { index: 13, name: 'end' }
                         ]
                     },
+                    style: { outline: '#20102F' },
                     tracks: [
                         {
                             dataTransform: [
@@ -256,7 +257,6 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                             target: 'mark'
                         }
                     ],
-                    style: { outline: '#20102F' },
                     width: 400,
                     height: 80
                 },
@@ -359,7 +359,6 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                     color: { value: 'none' },
                     stroke: { value: '#F97E2A' },
                     opacity: { value: 0.1 },
-                    style: { outline: '#20102F' },
                     width: 400,
                     height: 60
                 },
@@ -380,7 +379,6 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                     color: { value: 'none' },
                     stroke: { value: '#50ADF9' },
                     opacity: { value: 0.1 },
-                    style: { outline: '#20102F' },
                     overlayOnPreviousTrack: true,
                     width: 400,
                     height: 60
@@ -403,7 +401,6 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                     color: { value: 'none' },
                     stroke: { value: '#7B0EDC' },
                     opacity: { value: 0.1 },
-                    style: { outline: '#20102F' },
                     overlayOnPreviousTrack: true,
                     width: 400,
                     height: 60

--- a/src/editor/example/give.ts
+++ b/src/editor/example/give.ts
@@ -69,7 +69,6 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     ],
                     row: { field: 'strand', type: 'nominal', domain: ['+', '-'] },
                     color: { value: '#4050B4' },
-                    style: { outlineWidth: 0 },
                     width: 700,
                     height: 50
                 },
@@ -88,7 +87,6 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     color: { value: '#8A96D5' },
                     stroke: { value: '#3C4DB4' },
                     strokeWidth: { value: 0.5 },
-                    style: { outlineWidth: 0 },
                     width: 700,
                     height: 40
                 },
@@ -107,7 +105,6 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     color: { value: '#8A96D5' },
                     stroke: { value: '#3C4DB4' },
                     strokeWidth: { value: 0.5 },
-                    style: { outlineWidth: 0 },
                     width: 700,
                     height: 40
                 },
@@ -126,7 +123,6 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     color: { value: '#8A96D5' },
                     stroke: { value: '#3C4DB4' },
                     strokeWidth: { value: 0.5 },
-                    style: { outlineWidth: 0 },
                     width: 700,
                     height: 40
                 },
@@ -169,9 +165,6 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     size: { value: 14 },
                     stroke: { value: 'black' },
                     strokeWidth: { value: 0.5 },
-                    style: {
-                        outlineWidth: 0
-                    },
                     width: 700,
                     height: 40
                 },
@@ -223,9 +216,6 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     },
                     opacity: { value: 0.5 },
                     size: { value: 14 },
-                    style: {
-                        outlineWidth: 0
-                    },
                     overlayOnPreviousTrack: true,
                     width: 700,
                     height: 40
@@ -274,9 +264,6 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     size: { value: 14 },
                     stroke: { value: 'black' },
                     strokeWidth: { value: 0.5 },
-                    style: {
-                        outlineWidth: 0
-                    },
                     width: 700,
                     height: 40
                 },
@@ -328,9 +315,6 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     },
                     opacity: { value: 0.5 },
                     size: { value: 14 },
-                    style: {
-                        outlineWidth: 0
-                    },
                     overlayOnPreviousTrack: true,
                     width: 700,
                     height: 40
@@ -350,7 +334,6 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     color: { value: '#8A96D5' },
                     stroke: { value: '#3C4DB4' },
                     strokeWidth: { value: 0.5 },
-                    style: { outlineWidth: 0 },
                     width: 700,
                     height: 40
                 },
@@ -369,7 +352,6 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     color: { value: '#8A96D5' },
                     stroke: { value: '#3C4DB4' },
                     strokeWidth: { value: 0.5 },
-                    style: { outlineWidth: 0 },
                     width: 700,
                     height: 40
                 },
@@ -388,7 +370,6 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     color: { value: '#8A96D5' },
                     stroke: { value: '#3C4DB4' },
                     strokeWidth: { value: 0.5 },
-                    style: { outlineWidth: 0 },
                     width: 700,
                     height: 40
                 },
@@ -452,11 +433,11 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     ],
                     row: { field: 'strand', type: 'nominal', domain: ['+', '-'] },
                     color: { value: '#4050B4' },
-                    style: { outlineWidth: 0 },
                     width: 700,
                     height: 50
                 }
             ]
         }
-    ]
+    ],
+    style: { outlineWidth: 0 }
 };

--- a/src/editor/example/mark-displacement.ts
+++ b/src/editor/example/mark-displacement.ts
@@ -70,7 +70,7 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                     stroke: { value: 'black' },
                     strokeWidth: { value: 1 },
                     opacity: { value: 0.8 },
-                    style: { outlineWidth: 0, inlineLegend: true },
+                    style: { inlineLegend: true },
                     width: 700,
                     height: 60
                 },
@@ -103,7 +103,7 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                     stroke: { value: 'lightgrey' },
                     strokeWidth: { value: 0.5 },
                     opacity: { value: 0.8 },
-                    style: { verticalLink: true, outlineWidth: 0 },
+                    style: { verticalLink: true },
                     width: 700,
                     height: 60
                 },
@@ -127,8 +127,7 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                             strokeWidth: { value: 0.5 },
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
-                            opacity: { value: 0.8 },
-                            style: { outlineWidth: 0 }
+                            opacity: { value: 0.8 }
                         },
                         {
                             data: {
@@ -222,10 +221,7 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                 field: 'end',
                                 type: 'genomic'
                             },
-                            style: {
-                                dy: -15,
-                                outlineWidth: 0
-                            }
+                            style: { dy: -15 }
                         },
                         {
                             data: {
@@ -271,7 +267,7 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                 type: 'genomic'
                             },
                             size: { value: 15 },
-                            style: { align: 'right', outlineWidth: 0 }
+                            style: { align: 'right' }
                         },
                         {
                             data: {
@@ -370,8 +366,7 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                 type: 'genomic'
                             },
                             style: {
-                                linePattern: { type: 'triangleRight', size: 5 },
-                                outlineWidth: 0
+                                linePattern: { type: 'triangleRight', size: 5 }
                             }
                         },
                         {
@@ -424,14 +419,10 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                                 type: 'genomic'
                             },
                             style: {
-                                linePattern: { type: 'triangleLeft', size: 5 },
-                                outlineWidth: 0
+                                linePattern: { type: 'triangleLeft', size: 5 }
                             }
                         }
                     ],
-                    style: {
-                        outlineWidth: 0
-                    },
                     width: 700,
                     height: 100
                 }
@@ -474,5 +465,6 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                 }
             ]
         }
-    ]
+    ],
+    style: { outlineWidth: 0 }
 };

--- a/src/editor/example/matrix-hffc6.ts
+++ b/src/editor/example/matrix-hffc6.ts
@@ -27,7 +27,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                 //         xe: { field: 'end', type: 'genomic', axis: 'none' },
                 //         y: { field: 'peak', type: 'quantitative' },
                 //         color: { value: 'darkgreen' },
-                //         style: { outline: 'white' },
+                //
                 //         height: 570,
                 //         width: 40
                 //     }]
@@ -47,7 +47,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                 //         xe: { field: 'end', type: 'genomic', axis: 'none' },
                 //         y: { field: 'peak', type: 'quantitative' },
                 //         color: { value: '#E79F00' },
-                //         style: { outline: 'white' },
+                //
                 //         height: 570,
                 //         width: 40
                 //     }]
@@ -98,7 +98,6 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                     color: { value: '#029F73' }
                                 }
                             ],
-                            style: { outline: 'white' },
                             height: 570,
                             width: 40
                         }
@@ -144,7 +143,6 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                             xe: { field: 'end', type: 'genomic', axis: 'none' },
                             y: { field: 'peak', type: 'quantitative' },
                             color: { value: 'darkgreen' },
-                            style: { outline: 'white' },
                             width: 570,
                             height: 40
                         },
@@ -162,7 +160,6 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                             xe: { field: 'end', type: 'genomic' },
                             y: { field: 'peak', type: 'quantitative' },
                             color: { value: '#E79F00' },
-                            style: { outline: 'white' },
                             width: 570,
                             height: 40
                         },
@@ -229,7 +226,6 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                     color: { value: '#029F73' }
                                 }
                             ],
-                            style: { outline: 'white' },
                             width: 570,
                             height: 40
                         }
@@ -291,7 +287,6 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                 ]
                             },
                             // strokeWidth: {value: 0.5},
-                            style: { outline: 'white' },
                             width: 570,
                             height: 40
                         }
@@ -337,7 +332,6 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                             xe: { field: 'end', type: 'genomic', axis: 'none' },
                             y: { field: 'peak', type: 'quantitative' },
                             color: { value: 'darkgreen' },
-                            style: { outline: 'white' },
                             width: 570,
                             height: 40
                         },
@@ -355,7 +349,6 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                             xe: { field: 'end', type: 'genomic' },
                             y: { field: 'peak', type: 'quantitative' },
                             color: { value: '#E79F00' },
-                            style: { outline: 'white' },
                             width: 570,
                             height: 40
                         },
@@ -422,7 +415,6 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                     color: { value: '#029F73' }
                                 }
                             ],
-                            style: { outline: 'white' },
                             width: 570,
                             height: 40
                         }
@@ -484,7 +476,6 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                 ]
                             },
                             // strokeWidth: {value: 0.5},
-                            style: { outline: 'white' },
                             width: 570,
                             height: 40
                         }
@@ -492,5 +483,6 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                 }
             ]
         }
-    ]
+    ],
+    style: { outlineWidth: 0 }
 };

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -505,6 +505,7 @@ export const EX_SPEC_DARK_THEME: GoslingSpec = {
     centerRadius: 0,
     static: true,
     xDomain: { chromosome: '1', interval: [1, 3000500] },
+    style: { outlineWidth: 0 },
     views: [
         {
             arrangement: 'horizontal',
@@ -585,8 +586,7 @@ export const EX_SPEC_DARK_THEME: GoslingSpec = {
                                     ],
                                     mark: 'triangleRight',
                                     x: { field: 'end', type: 'genomic' },
-                                    size: { value: 15 },
-                                    style: { outlineWidth: 0 }
+                                    size: { value: 15 }
                                 },
                                 {
                                     dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
@@ -594,7 +594,7 @@ export const EX_SPEC_DARK_THEME: GoslingSpec = {
                                     text: { field: 'name', type: 'nominal' },
                                     x: { field: 'start', type: 'genomic' },
                                     xe: { field: 'end', type: 'genomic' },
-                                    style: { dy: -15, outlineWidth: 0 }
+                                    style: { dy: -15 }
                                 },
                                 {
                                     dataTransform: [
@@ -604,15 +604,14 @@ export const EX_SPEC_DARK_THEME: GoslingSpec = {
                                     mark: 'triangleLeft',
                                     x: { field: 'start', type: 'genomic' },
                                     size: { value: 15 },
-                                    style: { align: 'right', outlineWidth: 0 }
+                                    style: { align: 'right' }
                                 },
                                 {
                                     dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
                                     mark: 'rect',
                                     x: { field: 'start', type: 'genomic' },
                                     size: { value: 15 },
-                                    xe: { field: 'end', type: 'genomic' },
-                                    style: { outlineWidth: 0 }
+                                    xe: { field: 'end', type: 'genomic' }
                                 },
                                 {
                                     dataTransform: [
@@ -654,7 +653,6 @@ export const EX_SPEC_DARK_THEME: GoslingSpec = {
                                 }
                             ],
                             opacity: { value: 0.8 },
-                            style: { outlineWidth: 0 },
                             width: 350,
                             height: 100
                         },


### PR DESCRIPTION
One can now define a common track style once in the root level specification:

```js
{
   style: {outline: 'black'}, // black outline will be used for child tracks unless it is defined by children
   view: [...]
}
```

Fix #362 