### PR TITLE
feat: support overriding and customizing theme

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -4624,6 +4624,107 @@
       "type": "object"
     },
     "Theme": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ThemeType"
+        },
+        {
+          "$ref": "#/definitions/ThemeDeep"
+        }
+      ]
+    },
+    "ThemeDeep": {
+      "additionalProperties": false,
+      "properties": {
+        "axisColor": {
+          "type": "string"
+        },
+        "backgroundColor": {
+          "type": "string"
+        },
+        "base": {
+          "$ref": "#/definitions/ThemeType"
+        },
+        "brushColor": {
+          "type": "string"
+        },
+        "brushStrokeColor": {
+          "type": "string"
+        },
+        "brushStrokeWidth": {
+          "type": "number"
+        },
+        "lineSize": {
+          "type": "number"
+        },
+        "linkStrokeWidth": {
+          "type": "number"
+        },
+        "markColor": {
+          "type": "string"
+        },
+        "markOpacity": {
+          "type": "number"
+        },
+        "markStrokeColor": {
+          "type": "string"
+        },
+        "markStrokeWidth": {
+          "type": "number"
+        },
+        "nominalColors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nominalColorsExtended": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "pointSize": {
+          "type": "number"
+        },
+        "pointSizeRangeQuantitative": {
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "ruleStrokeWidth": {
+          "type": "number"
+        },
+        "subtitleColor": {
+          "type": "string"
+        },
+        "titleColor": {
+          "type": "string"
+        },
+        "trackOutlineColor": {
+          "type": "string"
+        },
+        "trackOutlineWidth": {
+          "type": "number"
+        },
+        "useExtendedNominalColors": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "base"
+      ],
+      "type": "object"
+    },
+    "ThemeType": {
       "enum": [
         "light",
         "dark"

--- a/schema/history/0.7.7/gosling0.7.7.schema.json
+++ b/schema/history/0.7.7/gosling0.7.7.schema.json
@@ -4624,6 +4624,107 @@
       "type": "object"
     },
     "Theme": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ThemeType"
+        },
+        {
+          "$ref": "#/definitions/ThemeDeep"
+        }
+      ]
+    },
+    "ThemeDeep": {
+      "additionalProperties": false,
+      "properties": {
+        "axisColor": {
+          "type": "string"
+        },
+        "backgroundColor": {
+          "type": "string"
+        },
+        "base": {
+          "$ref": "#/definitions/ThemeType"
+        },
+        "brushColor": {
+          "type": "string"
+        },
+        "brushStrokeColor": {
+          "type": "string"
+        },
+        "brushStrokeWidth": {
+          "type": "number"
+        },
+        "lineSize": {
+          "type": "number"
+        },
+        "linkStrokeWidth": {
+          "type": "number"
+        },
+        "markColor": {
+          "type": "string"
+        },
+        "markOpacity": {
+          "type": "number"
+        },
+        "markStrokeColor": {
+          "type": "string"
+        },
+        "markStrokeWidth": {
+          "type": "number"
+        },
+        "nominalColors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nominalColorsExtended": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "pointSize": {
+          "type": "number"
+        },
+        "pointSizeRangeQuantitative": {
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "ruleStrokeWidth": {
+          "type": "number"
+        },
+        "subtitleColor": {
+          "type": "string"
+        },
+        "titleColor": {
+          "type": "string"
+        },
+        "trackOutlineColor": {
+          "type": "string"
+        },
+        "trackOutlineWidth": {
+          "type": "number"
+        },
+        "useExtendedNominalColors": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "base"
+      ],
+      "type": "object"
+    },
+    "ThemeType": {
       "enum": [
         "light",
         "dark"

--- a/schema/history/0.7.7/gosling0.7.7.schema.ts
+++ b/schema/history/0.7.7/gosling0.7.7.schema.ts
@@ -3,8 +3,6 @@ import { Chromosome } from './utils/chrom-size';
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
 
-export type Theme = 'light' | 'dark';
-
 export type RootSpecWithSingleView = SingleView & {
     title?: string;
     subtitle?: string;
@@ -17,6 +15,52 @@ export interface RootSpecWithMultipleViews extends MultipleViews {
     subtitle?: string;
     description?: string;
     theme?: Theme;
+}
+
+/* ----------------------------- THEME ----------------------------- */
+export type Theme = ThemeType | ThemeDeep;
+export type ThemeType = 'light' | 'dark';
+export enum Themes {
+    light = 'light',
+    dark = 'dark'
+}
+
+// TODO: combine with `TrackStyle`
+// TODO: encapsulate each level, e.g., track: { /* TrackLevelTheme */ }
+export interface ThemeDeep {
+    base: ThemeType;
+
+    /* Root level */
+    backgroundColor?: string; // background color of react component
+    titleColor?: string; // color of title
+    subtitleColor?: string; // color of subtitle
+
+    /* Track level */
+    trackOutlineColor?: string; // color of track outline
+    trackOutlineWidth?: number; // stroke width of track outline
+    axisColor?: string; // color of axis ticks and labels
+
+    /* Encoding level */
+    markColor?: string; // default color of marks
+    nominalColors?: string[]; // colors for nominal values
+    useExtendedNominalColors?: boolean;
+    nominalColorsExtended?: string[]; // colors for nominal values when too many categories
+    markStrokeColor?: string; // stroke color of marks
+    markStrokeWidth?: number; // stroke width of marks
+    markOpacity?: number; // opacity of marks
+    // TODO: quantitative colors
+
+    /* Mark-specific Encoding Level */
+    pointSize?: number; // size of points
+    pointSizeRangeQuantitative?: [number, number];
+    lineSize?: number; // line width
+    brushColor?: string; // fill color of brush
+    brushStrokeColor?: string; // stroke color of brush
+    brushStrokeWidth?: number; // stroke width of brush
+    ruleStrokeWidth?: number;
+    linkStrokeWidth?: number;
+
+    // ...
 }
 
 /* ----------------------------- VIEW ----------------------------- */

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -6,6 +6,7 @@ import * as gosling from '..';
 import { View as HgView } from './higlass.schema';
 import { traverseViewsInViewConfig } from '../core/utils/view-config';
 import { GET_CHROM_SIZES } from './utils/assembly';
+import { getTheme } from './utils/theme';
 
 /**
  * Register plugin tracks and data fetchers to HiGlass. This is necessary for the first time before using Gosling.
@@ -106,7 +107,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     style={{
                         position: 'relative',
                         padding,
-                        background: gs?.theme === 'dark' ? 'black' : 'white',
+                        background: getTheme(gs?.theme).backgroundColor,
                         width: size.width + padding * 2,
                         height: size.height + padding * 2,
                         textAlign: 'left'
@@ -117,7 +118,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                         style={{
                             position: 'relative',
                             display: 'block',
-                            background: gs?.theme === 'dark' ? 'black' : 'white',
+                            background: getTheme(gs?.theme).backgroundColor,
                             margin: 0,
                             padding: 0, // non-zero padding acts unexpectedly w/ HiGlassComponent
                             width: size.width,
@@ -139,7 +140,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                                 viewPaddingLeft: 0,
                                 viewPaddingRight: 0,
                                 sizeMode: 'bounded',
-                                theme: gs?.theme,
+                                // theme: gs?.theme, // TODO: do we need this?
                                 rangeSelectionOnAlt: true // this allows switching between `selection` and `zoom&pan` mode
                             }}
                             viewConfig={hs}

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -9,7 +9,7 @@ import { getGenomicChannelKeyFromTrack, getGenomicChannelFromTrack } from './uti
 import { viridisColorMap } from './utils/colors';
 import { IsDataDeep, IsChannelDeep, IsDataDeepTileset } from './gosling.schema.guards';
 import { DEFAULT_SUBTITLE_HEIGHT, DEFAULT_TITLE_HEIGHT } from './layout/defaults';
-import { getThemeColors } from './utils/theme';
+import { getTheme } from './utils/theme';
 
 /**
  * Convert a gosling track into a HiGlass view and add it into a higlass model.
@@ -60,7 +60,7 @@ export function goslingToHiGlass(
                 name: firstResolvedSpec.title,
                 labelPosition: firstResolvedSpec.title ? 'topLeft' : 'none',
                 fontSize: 12,
-                labelColor: getThemeColors(theme).main,
+                labelColor: getTheme(theme).axisColor,
                 labelShowResolution: false,
                 labelBackgroundColor: 'white',
                 labelTextOpacity: 1,
@@ -163,7 +163,7 @@ export function goslingToHiGlass(
                 bb.width,
                 DEFAULT_TITLE_HEIGHT,
                 firstResolvedSpec.title,
-                getThemeColors(theme).main,
+                getTheme(theme).titleColor,
                 18,
                 'bold'
             );
@@ -173,7 +173,7 @@ export function goslingToHiGlass(
                 bb.width,
                 DEFAULT_SUBTITLE_HEIGHT,
                 firstResolvedSpec.subtitle,
-                getThemeColors(theme).sub,
+                getTheme(theme).subtitleColor,
                 14,
                 'normal'
             );

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -3,8 +3,6 @@ import { Chromosome } from './utils/chrom-size';
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
 
-export type Theme = 'light' | 'dark';
-
 export type RootSpecWithSingleView = SingleView & {
     title?: string;
     subtitle?: string;
@@ -17,6 +15,52 @@ export interface RootSpecWithMultipleViews extends MultipleViews {
     subtitle?: string;
     description?: string;
     theme?: Theme;
+}
+
+/* ----------------------------- THEME ----------------------------- */
+export type Theme = ThemeType | ThemeDeep;
+export type ThemeType = 'light' | 'dark';
+export enum Themes {
+    light = 'light',
+    dark = 'dark'
+}
+
+// TODO: combine with `TrackStyle`
+// TODO: encapsulate each level, e.g., track: { /* TrackLevelTheme */ }
+export interface ThemeDeep {
+    base: ThemeType;
+
+    /* Root level */
+    backgroundColor?: string; // background color of react component
+    titleColor?: string; // color of title
+    subtitleColor?: string; // color of subtitle
+
+    /* Track level */
+    trackOutlineColor?: string; // color of track outline
+    trackOutlineWidth?: number; // stroke width of track outline
+    axisColor?: string; // color of axis ticks and labels
+
+    /* Encoding level */
+    markColor?: string; // default color of marks
+    nominalColors?: string[]; // colors for nominal values
+    useExtendedNominalColors?: boolean;
+    nominalColorsExtended?: string[]; // colors for nominal values when too many categories
+    markStrokeColor?: string; // stroke color of marks
+    markStrokeWidth?: number; // stroke width of marks
+    markOpacity?: number; // opacity of marks
+    // TODO: quantitative colors
+
+    /* Mark-specific Encoding Level */
+    pointSize?: number; // size of points
+    pointSizeRangeQuantitative?: [number, number];
+    lineSize?: number; // line width
+    brushColor?: string; // fill color of brush
+    brushStrokeColor?: string; // stroke color of brush
+    brushStrokeWidth?: number; // stroke width of brush
+    ruleStrokeWidth?: number;
+    linkStrokeWidth?: number;
+
+    // ...
 }
 
 /* ----------------------------- VIEW ----------------------------- */

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -6,7 +6,7 @@ import { getNumericDomain } from './utils/scales';
 import { RelativePosition } from './utils/bounding-box';
 import { validateSpec } from './utils/validate';
 import { GET_CHROM_SIZES } from './utils/assembly';
-import { getThemeColors } from './utils/theme';
+import { getTheme } from './utils/theme';
 
 export const HIGLASS_AXIS_SIZE = 30;
 const getViewTemplate = (assembly?: string) => {
@@ -140,11 +140,11 @@ export class HiGlassModel {
             uid: uuid.v4(),
             fromViewUid,
             options: {
-                projectionFillColor: style?.color ?? getThemeColors(theme).sub,
-                projectionStrokeColor: style?.stroke ?? getThemeColors(theme).main,
+                projectionFillColor: style?.color ?? getTheme(theme).brushColor,
+                projectionStrokeColor: style?.stroke ?? getTheme(theme).brushStrokeColor,
                 projectionFillOpacity: style?.opacity ?? 0.3,
                 projectionStrokeOpacity: style?.opacity ?? 0.3,
-                strokeWidth: style?.strokeWidth ?? 1,
+                strokeWidth: style?.strokeWidth ?? getTheme(theme).brushStrokeWidth,
                 startAngle: style?.startAngle,
                 endAngle: style?.endAngle,
                 innerRadius: style?.innerRadius,
@@ -266,8 +266,8 @@ export class HiGlassModel {
                 ...options,
                 assembly: this.getAssembly(),
                 stroke: 'transparent', // text outline
-                color: getThemeColors(options.theme).main,
-                tickColor: getThemeColors(options.theme).main,
+                color: getTheme(options.theme).axisColor,
+                tickColor: getTheme(options.theme).axisColor,
                 tickFormat: type === 'narrower' ? 'si' : 'plain',
                 tickPositions: type === 'regular' ? 'even' : 'ends',
                 reverseOrientation: position === 'bottom' || position === 'right' ? true : false

--- a/src/core/mark/outline.ts
+++ b/src/core/mark/outline.ts
@@ -2,7 +2,7 @@ import { GoslingTrackModel } from '../gosling-track-model';
 import { Theme } from '../gosling.schema';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
-import { getThemeColors } from '../utils/theme';
+import { getTheme } from '../utils/theme';
 
 export const TITLE_STYLE = {
     fontSize: '12px',
@@ -51,7 +51,7 @@ export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackMode
     g.lineStyle(
         tm.spec().style?.outlineWidth ?? 1,
         // TODO: outline not working
-        colorToHex(tm.spec().style?.outline ?? getThemeColors(theme).sub),
+        colorToHex(tm.spec().style?.outline ?? getTheme(theme).trackOutlineColor),
         1, // alpha
         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
@@ -63,7 +63,7 @@ export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackMode
 
     g.lineStyle(
         1,
-        colorToHex(getThemeColors(theme).main),
+        colorToHex(getTheme(theme).axisColor),
         1, // alpha
         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );

--- a/src/core/utils/theme.test.ts
+++ b/src/core/utils/theme.test.ts
@@ -1,0 +1,21 @@
+import { getTheme } from './theme';
+import { ThemeDeep } from '../gosling.schema';
+
+describe('Theme', () => {
+    it('Defualt Themes', () => {
+        expect(getTheme().base).toEqual('light');
+        expect(getTheme().titleColor).toEqual('black');
+    });
+    it('Predefined Themes', () => {
+        expect(getTheme('dark').base).toEqual('dark');
+        expect(getTheme('dark').titleColor).toEqual('white');
+    });
+    it('Overriding Themes', () => {
+        const custom: ThemeDeep = {
+            base: 'dark',
+            titleColor: 'yellow'
+        };
+        expect(getTheme('dark').titleColor).not.toEqual(getTheme(custom).titleColor);
+        expect(getTheme(custom).titleColor).toEqual('yellow');
+    });
+});

--- a/src/core/utils/theme.ts
+++ b/src/core/utils/theme.ts
@@ -1,8 +1,71 @@
-import { Theme } from '../gosling.schema';
+import { assign } from 'lodash';
+import { CHANNEL_DEFAULTS } from '../channel';
+import { Theme, ThemeDeep, Themes } from '../gosling.schema';
 
-export function getThemeColors(theme: Theme = 'light') {
-    return {
-        main: theme === 'light' ? 'black' : 'white',
-        sub: theme === 'dark' ? 'lightgray' : 'gray'
-    };
+export function getTheme(theme: Theme = 'light'): Required<ThemeDeep> {
+    if (theme === 'dark' || theme === 'light') {
+        return THEMES[theme];
+    } else {
+        return assign(JSON.parse(JSON.stringify(THEMES[theme.base])), JSON.parse(JSON.stringify(theme)));
+    }
 }
+
+/* ----------------------------- THEME PRESETS ----------------------------- */
+export const THEMES: { [key in Themes]: Required<ThemeDeep> } = {
+    light: {
+        base: 'light',
+
+        backgroundColor: 'white',
+        titleColor: 'black',
+        subtitleColor: 'gray',
+
+        trackOutlineColor: 'gray',
+        trackOutlineWidth: 1,
+        axisColor: 'black',
+
+        markColor: CHANNEL_DEFAULTS.NOMINAL_COLOR[0],
+        nominalColors: CHANNEL_DEFAULTS.NOMINAL_COLOR,
+        useExtendedNominalColors: false,
+        nominalColorsExtended: CHANNEL_DEFAULTS.NOMINAL_COLOR_EXTENDED,
+        markStrokeColor: 'black',
+        markStrokeWidth: 0,
+        markOpacity: 1,
+
+        pointSize: 3,
+        pointSizeRangeQuantitative: [2, 6],
+        lineSize: 1,
+        ruleStrokeWidth: 1,
+        linkStrokeWidth: 1,
+        brushColor: 'gray',
+        brushStrokeColor: 'black',
+        brushStrokeWidth: 1
+    },
+    dark: {
+        base: 'dark',
+
+        backgroundColor: 'black',
+        titleColor: 'white',
+        subtitleColor: 'lightgray',
+
+        trackOutlineColor: 'lightgray',
+        trackOutlineWidth: 1,
+        axisColor: 'white',
+
+        markColor: CHANNEL_DEFAULTS.NOMINAL_COLOR[0],
+        nominalColors: CHANNEL_DEFAULTS.NOMINAL_COLOR,
+        useExtendedNominalColors: false,
+        nominalColorsExtended: CHANNEL_DEFAULTS.NOMINAL_COLOR_EXTENDED,
+        markStrokeColor: 'white',
+        markStrokeWidth: 0,
+        markOpacity: 1,
+
+        pointSize: 3,
+        pointSizeRangeQuantitative: [2, 6],
+        lineSize: 1,
+        ruleStrokeWidth: 1,
+        linkStrokeWidth: 1,
+        brushColor: 'lightgray',
+        brushStrokeColor: 'white',
+        brushStrokeWidth: 1
+    }
+};

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -497,7 +497,12 @@ export const EX_SPEC_VISUAL_ENCODING_CIRCULAR: GoslingSpec = {
 };
 
 export const EX_SPEC_DARK_THEME: GoslingSpec = {
-    theme: 'dark',
+    theme: {
+        base: 'dark',
+        nominalColors: ['white', 'gray'],
+        markColor: 'gray',
+        markStrokeColor: 'black'
+    },
     title: 'Dark Theme (Beta)',
     subtitle: 'Gosling allows to easily change the color theme using a `theme` property',
     layout: 'circular',
@@ -505,7 +510,6 @@ export const EX_SPEC_DARK_THEME: GoslingSpec = {
     centerRadius: 0,
     static: true,
     xDomain: { chromosome: '1', interval: [1, 3000500] },
-    style: { outlineWidth: 0 },
     views: [
         {
             arrangement: 'horizontal',
@@ -682,5 +686,6 @@ export const EX_SPEC_DARK_THEME: GoslingSpec = {
                 }
             ]
         }
-    ]
+    ],
+    style: { outlineWidth: 0 }
 };

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -654,7 +654,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 }
 
                 // Construct separate gosling models for individual tiles
-                const gm = new GoslingTrackModel(resolved, tile.gos.tabularDataFiltered);
+                const gm = new GoslingTrackModel(resolved, tile.gos.tabularDataFiltered, this.options.theme);
 
                 // Add a track model to the tile object
                 tile.goslingModels.push(gm);


### PR DESCRIPTION
This allows to override a theme (currently, either `"dark"` or `"light"`) and customize styles (e.g., change the color palette for nominal values).

Towards #117 

![Screen Shot 2021-04-20 at 7 09 39 PM](https://user-images.githubusercontent.com/9922882/115474789-3bb5a780-a20c-11eb-889a-93d464031759.png)

**TODO**:
- [x] Better structure the properties in `theme` (e.g., group properties).
- [ ] Support special-purpose color pallettes (e.g., `strandColors` for gene annotation).
- [ ] Support diverse themes (e.g., UCSC, Wash U, IGV, ...), which is our long-term goal.

