### PR TITLE
feat: data transformation for string concat and replace

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -510,6 +510,12 @@
           "$ref": "#/definitions/FilterTransform"
         },
         {
+          "$ref": "#/definitions/StrConcatTransform"
+        },
+        {
+          "$ref": "#/definitions/StrReplaceTransform"
+        },
+        {
           "$ref": "#/definitions/LogTransform"
         },
         {
@@ -4620,6 +4626,75 @@
       },
       "required": [
         "tracks"
+      ],
+      "type": "object"
+    },
+    "StrConcatTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "newField": {
+          "type": "string"
+        },
+        "separator": {
+          "type": "string"
+        },
+        "type": {
+          "const": "concat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "fields",
+        "newField",
+        "separator"
+      ],
+      "type": "object"
+    },
+    "StrReplaceTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "newField": {
+          "type": "string"
+        },
+        "replace": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "from": {
+                "type": "string"
+              },
+              "to": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "from",
+              "to"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "replace",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "field",
+        "newField",
+        "replace"
       ],
       "type": "object"
     },

--- a/schema/history/0.7.7/gosling0.7.7.schema.json
+++ b/schema/history/0.7.7/gosling0.7.7.schema.json
@@ -510,6 +510,12 @@
           "$ref": "#/definitions/FilterTransform"
         },
         {
+          "$ref": "#/definitions/StrConcatTransform"
+        },
+        {
+          "$ref": "#/definitions/StrReplaceTransform"
+        },
+        {
           "$ref": "#/definitions/LogTransform"
         },
         {
@@ -4620,6 +4626,75 @@
       },
       "required": [
         "tracks"
+      ],
+      "type": "object"
+    },
+    "StrConcatTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "newField": {
+          "type": "string"
+        },
+        "separator": {
+          "type": "string"
+        },
+        "type": {
+          "const": "concat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "fields",
+        "newField",
+        "separator"
+      ],
+      "type": "object"
+    },
+    "StrReplaceTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "newField": {
+          "type": "string"
+        },
+        "replace": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "from": {
+                "type": "string"
+              },
+              "to": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "from",
+              "to"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "replace",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "field",
+        "newField",
+        "replace"
       ],
       "type": "object"
     },

--- a/schema/history/0.7.7/gosling0.7.7.schema.ts
+++ b/schema/history/0.7.7/gosling0.7.7.schema.ts
@@ -458,7 +458,13 @@ export interface MatrixData {
     url: string;
 }
 
-export type DataTransform = FilterTransform | LogTransform | DisplaceTransform | ExonSplitTransform;
+export type DataTransform =
+    | FilterTransform
+    | StrConcatTransform
+    | StrReplaceTransform
+    | LogTransform
+    | DisplaceTransform
+    | ExonSplitTransform;
 
 export type FilterTransform = OneOfFilter | RangeFilter | IncludeFilter;
 
@@ -489,6 +495,20 @@ export interface LogTransform {
     field: string;
     base?: LogBase; // If not specified, 10 is used
     newField?: string; // If specified, store transformed values in a new field.
+}
+
+export interface StrConcatTransform {
+    type: 'concat';
+    fields: string[];
+    newField: string;
+    separator: string;
+}
+
+export interface StrReplaceTransform {
+    type: 'replace';
+    field: string;
+    newField: string;
+    replace: { from: string; to: string }[];
 }
 
 export interface DisplaceTransform {

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -458,7 +458,13 @@ export interface MatrixData {
     url: string;
 }
 
-export type DataTransform = FilterTransform | LogTransform | DisplaceTransform | ExonSplitTransform;
+export type DataTransform =
+    | FilterTransform
+    | StrConcatTransform
+    | StrReplaceTransform
+    | LogTransform
+    | DisplaceTransform
+    | ExonSplitTransform;
 
 export type FilterTransform = OneOfFilter | RangeFilter | IncludeFilter;
 
@@ -489,6 +495,20 @@ export interface LogTransform {
     field: string;
     base?: LogBase; // If not specified, 10 is used
     newField?: string; // If specified, store transformed values in a new field.
+}
+
+export interface StrConcatTransform {
+    type: 'concat';
+    fields: string[];
+    newField: string;
+    separator: string;
+}
+
+export interface StrReplaceTransform {
+    type: 'replace';
+    field: string;
+    newField: string;
+    replace: { from: string; to: string }[];
 }
 
 export interface DisplaceTransform {

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -1,5 +1,14 @@
 import { assign } from 'lodash';
-import { SingleTrack, Datum, FilterTransform, LogTransform, ExonSplitTransform, Assembly } from '../gosling.schema';
+import {
+    SingleTrack,
+    Datum,
+    FilterTransform,
+    LogTransform,
+    ExonSplitTransform,
+    Assembly,
+    StrConcatTransform,
+    StrReplaceTransform
+} from '../gosling.schema';
 import {
     getChannelKeysByAggregateFnc,
     getChannelKeysByType,
@@ -35,6 +44,36 @@ export function filterData(filter: FilterTransform, data: Datum[]): Datum[] {
             return not ? `${d[field]}`.includes(include) : !`${d[field]}`.includes(include);
         });
     }
+    return output;
+}
+
+/**
+ * Calculate new data, like log transformation.
+ */
+export function concatString(concat: StrConcatTransform, data: Datum[]): Datum[] {
+    const { fields, separator, newField } = concat;
+
+    let output: Datum[] = Array.from(data);
+    output = output.map(d => {
+        const strs = fields.map(f => d[f]);
+        d[newField] = strs.join(separator);
+        return d;
+    });
+    return output;
+}
+
+export function replaceString(_: StrReplaceTransform, data: Datum[]): Datum[] {
+    const { field, replace, newField } = _;
+
+    let output: Datum[] = Array.from(data);
+    output = output.map(d => {
+        d[newField] = d[field]; // copy original string
+        replace.forEach(r => {
+            const { from, to } = r;
+            d[newField] = d[newField].toString().replaceAll(from, to);
+        });
+        return d;
+    });
     return output;
 }
 

--- a/src/editor/example/cancer-variant.ts
+++ b/src/editor/example/cancer-variant.ts
@@ -1,27 +1,10 @@
 import { GoslingSpec } from '../..';
 
-export const view = (sample: string) => {
+export function view(sample: string): GoslingSpec {
     return {
         layout: 'circular',
         spacing: 1,
         tracks: [
-            {
-                title: sample,
-                data: {
-                    url: `https://s3.amazonaws.com/gosling-lang.org/data/cancer/substitution.${sample}.csv`,
-                    type: 'csv',
-                    chromosomeField: 'Chrom',
-                    genomicFields: ['Pos'],
-                    quantitativeFields: ['GP', 'SP', 'DP']
-                },
-                mark: 'point',
-                x: { field: 'Pos', type: 'genomic' },
-                y: { field: 'DP', type: 'quantitative' },
-                color: { field: 'Ref', type: 'nominal' },
-                // "stroke": {"field": "svclass", "type": "nominal"},
-                width: 500,
-                height: 60
-            },
             {
                 data: {
                     url:
@@ -42,7 +25,63 @@ export const view = (sample: string) => {
                 xe: { field: 'chromEnd', type: 'genomic' },
                 opacity: { value: 0.5 },
                 width: 500,
-                height: 20
+                height: 40
+            },
+            {
+                title: sample,
+                data: {
+                    url: `https://s3.amazonaws.com/gosling-lang.org/data/cancer/substitution.${sample}.csv`,
+                    type: 'csv',
+                    chromosomeField: 'Chrom',
+                    genomicFields: ['Pos'],
+                    quantitativeFields: ['GP', 'SP', 'DP', 'PosDiff']
+                },
+                dataTransform: [
+                    { type: 'concat', fields: ['Ref', 'Alt'], separator: ' > ', newField: 'sub' },
+                    {
+                        type: 'replace',
+                        field: 'sub',
+                        newField: 'sub',
+                        replace: [
+                            { from: 'G > A', to: 'C > T' },
+                            { from: 'G > T', to: 'C > A' },
+                            { from: 'G > C', to: 'C > G' },
+                            { from: 'A > G', to: 'T > C' },
+                            { from: 'A > T', to: 'T > A' },
+                            { from: 'A > C', to: 'T > G' }
+                        ]
+                    }
+                ],
+                mark: 'point',
+                x: { field: 'Pos', type: 'genomic' },
+                y: { field: 'PosDiff', type: 'quantitative', flip: true },
+                size: { field: 'PosDiff', type: 'quantitative' },
+                color: {
+                    field: 'sub',
+                    type: 'nominal',
+                    legend: true,
+                    domain: ['C > A', 'C > G', 'C > T', 'T > A', 'T > C', 'T > G'],
+                    range: ['#0072B2', 'black', '#D45E00', 'gray', '#029F73', '#CB7AA7']
+                },
+                opacity: { value: 0.3 },
+                style: { outlineWidth: 1, outline: 'lightgray' },
+                // "stroke": {"field": "svclass", "type": "nominal"},
+                width: 500,
+                height: 80
+            },
+            {
+                data: {
+                    url: `https://s3.amazonaws.com/gosling-lang.org/data/cancer/indel.${sample}.csv`,
+                    type: 'csv',
+                    chromosomeField: 'Chrom',
+                    genomicFields: ['Pos']
+                },
+                mark: 'rect',
+                x: { field: 'Pos', type: 'genomic' },
+                color: { field: 'Type', type: 'nominal', domain: ['Ins', 'Del'], range: ['green', 'red'] },
+                row: { field: 'Type', type: 'nominal', domain: ['Ins', 'Del'] },
+                width: 500,
+                height: 40
             },
             {
                 data: {
@@ -59,18 +98,18 @@ export const view = (sample: string) => {
                 color: { field: 'svclass', type: 'nominal' },
                 stroke: { field: 'svclass', type: 'nominal' },
                 width: 500,
-                height: 130
+                height: 80
             }
         ]
     };
-};
+}
 
 export const EX_SPEC_CANCER_VARIANT: GoslingSpec = {
     title: 'Breast Cancer Variant (Staaf et al. 2019)',
-    subtitle: 'Genetic characteristics of RAD51C- and PALB2-altered TNBCs (under development)',
+    subtitle: 'Genetic characteristics of RAD51C- and PALB2-altered TNBCs',
     layout: 'linear',
     arrangement: 'vertical',
-    // "centerRadius": 0.5,
+    centerRadius: 0.1,
     assembly: 'hg19',
     views: [
         {

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -9,7 +9,7 @@ import { Tooltip } from '../gosling-tooltip';
 import { sampleSize, uniqBy } from 'lodash';
 import { scaleLinear } from 'd3-scale';
 import colorToHex from '../core/utils/color-to-hex';
-import { calculateData, filterData, splitExon } from '../core/utils/data-transform';
+import { calculateData, concatString, filterData, replaceString, splitExon } from '../core/utils/data-transform';
 
 // For using libraries, refer to https://github.com/higlass/higlass/blob/f82c0a4f7b2ab1c145091166b0457638934b15f3/app/scripts/configs/available-for-plugins.js
 function GoslingTrack(HGC: any, ...args: any[]): any {
@@ -509,6 +509,12 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                         switch (t.type) {
                             case 'filter':
                                 tile.gos.tabularDataFiltered = filterData(t, tile.gos.tabularDataFiltered);
+                                break;
+                            case 'concat':
+                                tile.gos.tabularDataFiltered = concatString(t, tile.gos.tabularDataFiltered);
+                                break;
+                            case 'replace':
+                                tile.gos.tabularDataFiltered = replaceString(t, tile.gos.tabularDataFiltered);
                                 break;
                             case 'log':
                                 tile.gos.tabularDataFiltered = calculateData(t, tile.gos.tabularDataFiltered);


### PR DESCRIPTION
This adds an example using the real SV data from a paper ([Staaf et al. 2019](https://www.nature.com/articles/s41591-019-0582-4)).

For re-implementing this example, this PR adds two general transformation functions, (1) string concatenation and (2) replacement:

```js
dataTransform: [
    { type: 'concat', fields: ['Ref', 'Alt'], separator: ' > ', newField: 'sub' },
    {
        type: 'replace',
        field: 'sub',
        newField: 'sub',
        replace: [
            { from: 'G > A', to: 'C > T' },
            { from: 'G > T', to: 'C > A' },
            { from: 'G > C', to: 'C > G' },
            { from: 'A > G', to: 'T > C' },
            { from: 'A > T', to: 'T > A' },
            { from: 'A > C', to: 'T > G' }
        ]
    }
],
```

![Screen Shot 2021-04-21 at 5 29 17 PM](https://user-images.githubusercontent.com/9922882/115623411-26ea1a00-a2c7-11eb-9dcb-b3f4453ac51e.png)

Fix #342 