### PR TITLE
feat: support defining custom themes

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -35,6 +35,21 @@
       ],
       "type": "string"
     },
+    "AxisStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "baselineColor": {
+          "type": "string"
+        },
+        "labelColor": {
+          "type": "string"
+        },
+        "tickColor": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "BEDDBData": {
       "additionalProperties": false,
       "properties": {
@@ -469,7 +484,7 @@
           "type": "boolean"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -830,7 +845,7 @@
           "type": "boolean"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "tracks": {
           "items": {
@@ -997,7 +1012,7 @@
           ]
         },
         "style": {
-          "$ref": "#/definitions/MarkStyle"
+          "$ref": "#/definitions/MarkStyleInGlyph"
         },
         "text": {
           "anyOf": [
@@ -1399,6 +1414,46 @@
     "MarkStyle": {
       "additionalProperties": false,
       "properties": {
+        "color": {
+          "type": "string"
+        },
+        "nominalColorRange": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "opacity": {
+          "type": "number"
+        },
+        "quantitativeSizeRange": {
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "size": {
+          "type": "number"
+        },
+        "stroke": {
+          "type": "string"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "MarkStyleInGlyph": {
+      "additionalProperties": false,
+      "properties": {
         "background": {
           "type": "string"
         },
@@ -1507,7 +1562,7 @@
           "type": "boolean"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "views": {
           "items": {
@@ -1784,7 +1839,7 @@
                 "$ref": "#/definitions/Channel"
               },
               "style": {
-                "$ref": "#/definitions/TrackStyle"
+                "$ref": "#/definitions/Style"
               },
               "text": {
                 "$ref": "#/definitions/Channel"
@@ -1896,7 +1951,7 @@
           "$ref": "#/definitions/Channel"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -2085,7 +2140,7 @@
           "$ref": "#/definitions/Channel"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -2270,7 +2325,7 @@
                       "$ref": "#/definitions/Channel"
                     },
                     "style": {
-                      "$ref": "#/definitions/TrackStyle"
+                      "$ref": "#/definitions/Style"
                     },
                     "text": {
                       "$ref": "#/definitions/Channel"
@@ -2382,7 +2437,7 @@
                 "$ref": "#/definitions/Channel"
               },
               "style": {
-                "$ref": "#/definitions/TrackStyle"
+                "$ref": "#/definitions/Style"
               },
               "subtitle": {
                 "type": "string"
@@ -2623,7 +2678,7 @@
           "type": "boolean"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -2773,7 +2828,7 @@
               "$ref": "#/definitions/Channel"
             },
             "style": {
-              "$ref": "#/definitions/TrackStyle"
+              "$ref": "#/definitions/Style"
             },
             "subtitle": {
               "type": "string"
@@ -2961,7 +3016,7 @@
                           "$ref": "#/definitions/Channel"
                         },
                         "style": {
-                          "$ref": "#/definitions/TrackStyle"
+                          "$ref": "#/definitions/Style"
                         },
                         "text": {
                           "$ref": "#/definitions/Channel"
@@ -3073,7 +3128,7 @@
                     "$ref": "#/definitions/Channel"
                   },
                   "style": {
-                    "$ref": "#/definitions/TrackStyle"
+                    "$ref": "#/definitions/Style"
                   },
                   "subtitle": {
                     "type": "string"
@@ -3320,7 +3375,7 @@
               "$ref": "#/definitions/Channel"
             },
             "style": {
-              "$ref": "#/definitions/TrackStyle"
+              "$ref": "#/definitions/Style"
             },
             "subtitle": {
               "type": "string"
@@ -3510,7 +3565,7 @@
                               "$ref": "#/definitions/Channel"
                             },
                             "style": {
-                              "$ref": "#/definitions/TrackStyle"
+                              "$ref": "#/definitions/Style"
                             },
                             "text": {
                               "$ref": "#/definitions/Channel"
@@ -3622,7 +3677,7 @@
                         "$ref": "#/definitions/Channel"
                       },
                       "style": {
-                        "$ref": "#/definitions/TrackStyle"
+                        "$ref": "#/definitions/Style"
                       },
                       "subtitle": {
                         "type": "string"
@@ -3798,7 +3853,7 @@
               "type": "boolean"
             },
             "style": {
-              "$ref": "#/definitions/TrackStyle"
+              "$ref": "#/definitions/Style"
             },
             "subtitle": {
               "type": "string"
@@ -3838,6 +3893,21 @@
           "type": "object"
         }
       ]
+    },
+    "RootStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "background": {
+          "type": "string"
+        },
+        "subtitleColor": {
+          "type": "string"
+        },
+        "titleColor": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     },
     "SingleTrack": {
       "additionalProperties": false,
@@ -3934,7 +4004,7 @@
           "$ref": "#/definitions/Channel"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -4183,7 +4253,7 @@
           "$ref": "#/definitions/Channel"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -4370,7 +4440,7 @@
                           "$ref": "#/definitions/Channel"
                         },
                         "style": {
-                          "$ref": "#/definitions/TrackStyle"
+                          "$ref": "#/definitions/Style"
                         },
                         "text": {
                           "$ref": "#/definitions/Channel"
@@ -4482,7 +4552,7 @@
                     "$ref": "#/definitions/Channel"
                   },
                   "style": {
-                    "$ref": "#/definitions/TrackStyle"
+                    "$ref": "#/definitions/Style"
                   },
                   "subtitle": {
                     "type": "string"
@@ -4698,128 +4768,7 @@
       ],
       "type": "object"
     },
-    "Theme": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ThemeType"
-        },
-        {
-          "$ref": "#/definitions/ThemeDeep"
-        }
-      ]
-    },
-    "ThemeDeep": {
-      "additionalProperties": false,
-      "properties": {
-        "axisColor": {
-          "type": "string"
-        },
-        "backgroundColor": {
-          "type": "string"
-        },
-        "base": {
-          "$ref": "#/definitions/ThemeType"
-        },
-        "brushColor": {
-          "type": "string"
-        },
-        "brushStrokeColor": {
-          "type": "string"
-        },
-        "brushStrokeWidth": {
-          "type": "number"
-        },
-        "lineSize": {
-          "type": "number"
-        },
-        "linkStrokeWidth": {
-          "type": "number"
-        },
-        "markColor": {
-          "type": "string"
-        },
-        "markOpacity": {
-          "type": "number"
-        },
-        "markStrokeColor": {
-          "type": "string"
-        },
-        "markStrokeWidth": {
-          "type": "number"
-        },
-        "nominalColors": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "nominalColorsExtended": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "pointSize": {
-          "type": "number"
-        },
-        "pointSizeRangeQuantitative": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "type": "array"
-        },
-        "ruleStrokeWidth": {
-          "type": "number"
-        },
-        "subtitleColor": {
-          "type": "string"
-        },
-        "titleColor": {
-          "type": "string"
-        },
-        "trackOutlineColor": {
-          "type": "string"
-        },
-        "trackOutlineWidth": {
-          "type": "number"
-        },
-        "useExtendedNominalColors": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "base"
-      ],
-      "type": "object"
-    },
-    "ThemeType": {
-      "enum": [
-        "light",
-        "dark"
-      ],
-      "type": "string"
-    },
-    "Track": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SingleTrack"
-        },
-        {
-          "$ref": "#/definitions/OverlaidTrack"
-        },
-        {
-          "$ref": "#/definitions/DataTrack"
-        }
-      ]
-    },
-    "TrackStyle": {
+    "Style": {
       "additionalProperties": false,
       "properties": {
         "align": {
@@ -4892,12 +4841,6 @@
         "outlineWidth": {
           "type": "number"
         },
-        "stroke": {
-          "type": "string"
-        },
-        "strokeWidth": {
-          "type": "number"
-        },
         "textAnchor": {
           "enum": [
             "start",
@@ -4924,6 +4867,166 @@
         },
         "verticalLink": {
           "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "Theme": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ThemeType"
+        },
+        {
+          "$ref": "#/definitions/ThemeDeep"
+        }
+      ]
+    },
+    "ThemeDeep": {
+      "additionalProperties": false,
+      "properties": {
+        "area": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "axis": {
+          "$ref": "#/definitions/AxisStyle"
+        },
+        "bar": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "base": {
+          "$ref": "#/definitions/ThemeType"
+        },
+        "brush": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "line": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "link": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "markCommon": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "point": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "rect": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "root": {
+          "$ref": "#/definitions/RootStyle"
+        },
+        "rule": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "text": {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "type": "string"
+            },
+            "nominalColorRange": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "opacity": {
+              "type": "number"
+            },
+            "quantitativeSizeRange": {
+              "items": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            "size": {
+              "type": "number"
+            },
+            "stroke": {
+              "type": "string"
+            },
+            "strokeWidth": {
+              "type": "number"
+            },
+            "textAnchor": {
+              "enum": [
+                "start",
+                "middle",
+                "end"
+              ],
+              "type": "string"
+            },
+            "textFontWeight": {
+              "enum": [
+                "bold",
+                "normal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "track": {
+          "$ref": "#/definitions/TrackStyle"
+        },
+        "triangle": {
+          "$ref": "#/definitions/MarkStyle"
+        }
+      },
+      "required": [
+        "base"
+      ],
+      "type": "object"
+    },
+    "ThemeType": {
+      "enum": [
+        "light",
+        "dark"
+      ],
+      "type": "string"
+    },
+    "Track": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SingleTrack"
+        },
+        {
+          "$ref": "#/definitions/OverlaidTrack"
+        },
+        {
+          "$ref": "#/definitions/DataTrack"
+        }
+      ]
+    },
+    "TrackStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "legendBackground": {
+          "type": "string"
+        },
+        "legendLabelColor": {
+          "type": "string"
+        },
+        "outline": {
+          "type": "string"
+        },
+        "outlineWidth": {
+          "type": "number"
+        },
+        "titleBackground": {
+          "type": "string"
+        },
+        "titleColor": {
+          "type": "string"
         }
       },
       "type": "object"

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1261,6 +1261,24 @@
       ],
       "type": "string"
     },
+    "LegendStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "background": {
+          "type": "string"
+        },
+        "backgroundOpacity": {
+          "type": "number"
+        },
+        "backgroundStroke": {
+          "type": "string"
+        },
+        "labelColor": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "LogBase": {
       "anyOf": [
         {
@@ -4899,6 +4917,9 @@
         "brush": {
           "$ref": "#/definitions/MarkStyle"
         },
+        "legend": {
+          "$ref": "#/definitions/LegendStyle"
+        },
         "line": {
           "$ref": "#/definitions/MarkStyle"
         },
@@ -5010,12 +5031,6 @@
     "TrackStyle": {
       "additionalProperties": false,
       "properties": {
-        "legendBackground": {
-          "type": "string"
-        },
-        "legendLabelColor": {
-          "type": "string"
-        },
         "outline": {
           "type": "string"
         },

--- a/schema/history/0.7.7/gosling0.7.7.schema.json
+++ b/schema/history/0.7.7/gosling0.7.7.schema.json
@@ -35,6 +35,21 @@
       ],
       "type": "string"
     },
+    "AxisStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "baselineColor": {
+          "type": "string"
+        },
+        "labelColor": {
+          "type": "string"
+        },
+        "tickColor": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "BEDDBData": {
       "additionalProperties": false,
       "properties": {
@@ -469,7 +484,7 @@
           "type": "boolean"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -830,7 +845,7 @@
           "type": "boolean"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "tracks": {
           "items": {
@@ -997,7 +1012,7 @@
           ]
         },
         "style": {
-          "$ref": "#/definitions/MarkStyle"
+          "$ref": "#/definitions/MarkStyleInGlyph"
         },
         "text": {
           "anyOf": [
@@ -1399,6 +1414,46 @@
     "MarkStyle": {
       "additionalProperties": false,
       "properties": {
+        "color": {
+          "type": "string"
+        },
+        "nominalColorRange": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "opacity": {
+          "type": "number"
+        },
+        "quantitativeSizeRange": {
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "size": {
+          "type": "number"
+        },
+        "stroke": {
+          "type": "string"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "MarkStyleInGlyph": {
+      "additionalProperties": false,
+      "properties": {
         "background": {
           "type": "string"
         },
@@ -1507,7 +1562,7 @@
           "type": "boolean"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "views": {
           "items": {
@@ -1784,7 +1839,7 @@
                 "$ref": "#/definitions/Channel"
               },
               "style": {
-                "$ref": "#/definitions/TrackStyle"
+                "$ref": "#/definitions/Style"
               },
               "text": {
                 "$ref": "#/definitions/Channel"
@@ -1896,7 +1951,7 @@
           "$ref": "#/definitions/Channel"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -2085,7 +2140,7 @@
           "$ref": "#/definitions/Channel"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -2270,7 +2325,7 @@
                       "$ref": "#/definitions/Channel"
                     },
                     "style": {
-                      "$ref": "#/definitions/TrackStyle"
+                      "$ref": "#/definitions/Style"
                     },
                     "text": {
                       "$ref": "#/definitions/Channel"
@@ -2382,7 +2437,7 @@
                 "$ref": "#/definitions/Channel"
               },
               "style": {
-                "$ref": "#/definitions/TrackStyle"
+                "$ref": "#/definitions/Style"
               },
               "subtitle": {
                 "type": "string"
@@ -2623,7 +2678,7 @@
           "type": "boolean"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -2773,7 +2828,7 @@
               "$ref": "#/definitions/Channel"
             },
             "style": {
-              "$ref": "#/definitions/TrackStyle"
+              "$ref": "#/definitions/Style"
             },
             "subtitle": {
               "type": "string"
@@ -2961,7 +3016,7 @@
                           "$ref": "#/definitions/Channel"
                         },
                         "style": {
-                          "$ref": "#/definitions/TrackStyle"
+                          "$ref": "#/definitions/Style"
                         },
                         "text": {
                           "$ref": "#/definitions/Channel"
@@ -3073,7 +3128,7 @@
                     "$ref": "#/definitions/Channel"
                   },
                   "style": {
-                    "$ref": "#/definitions/TrackStyle"
+                    "$ref": "#/definitions/Style"
                   },
                   "subtitle": {
                     "type": "string"
@@ -3320,7 +3375,7 @@
               "$ref": "#/definitions/Channel"
             },
             "style": {
-              "$ref": "#/definitions/TrackStyle"
+              "$ref": "#/definitions/Style"
             },
             "subtitle": {
               "type": "string"
@@ -3510,7 +3565,7 @@
                               "$ref": "#/definitions/Channel"
                             },
                             "style": {
-                              "$ref": "#/definitions/TrackStyle"
+                              "$ref": "#/definitions/Style"
                             },
                             "text": {
                               "$ref": "#/definitions/Channel"
@@ -3622,7 +3677,7 @@
                         "$ref": "#/definitions/Channel"
                       },
                       "style": {
-                        "$ref": "#/definitions/TrackStyle"
+                        "$ref": "#/definitions/Style"
                       },
                       "subtitle": {
                         "type": "string"
@@ -3798,7 +3853,7 @@
               "type": "boolean"
             },
             "style": {
-              "$ref": "#/definitions/TrackStyle"
+              "$ref": "#/definitions/Style"
             },
             "subtitle": {
               "type": "string"
@@ -3838,6 +3893,21 @@
           "type": "object"
         }
       ]
+    },
+    "RootStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "background": {
+          "type": "string"
+        },
+        "subtitleColor": {
+          "type": "string"
+        },
+        "titleColor": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     },
     "SingleTrack": {
       "additionalProperties": false,
@@ -3934,7 +4004,7 @@
           "$ref": "#/definitions/Channel"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -4183,7 +4253,7 @@
           "$ref": "#/definitions/Channel"
         },
         "style": {
-          "$ref": "#/definitions/TrackStyle"
+          "$ref": "#/definitions/Style"
         },
         "subtitle": {
           "type": "string"
@@ -4370,7 +4440,7 @@
                           "$ref": "#/definitions/Channel"
                         },
                         "style": {
-                          "$ref": "#/definitions/TrackStyle"
+                          "$ref": "#/definitions/Style"
                         },
                         "text": {
                           "$ref": "#/definitions/Channel"
@@ -4482,7 +4552,7 @@
                     "$ref": "#/definitions/Channel"
                   },
                   "style": {
-                    "$ref": "#/definitions/TrackStyle"
+                    "$ref": "#/definitions/Style"
                   },
                   "subtitle": {
                     "type": "string"
@@ -4698,128 +4768,7 @@
       ],
       "type": "object"
     },
-    "Theme": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ThemeType"
-        },
-        {
-          "$ref": "#/definitions/ThemeDeep"
-        }
-      ]
-    },
-    "ThemeDeep": {
-      "additionalProperties": false,
-      "properties": {
-        "axisColor": {
-          "type": "string"
-        },
-        "backgroundColor": {
-          "type": "string"
-        },
-        "base": {
-          "$ref": "#/definitions/ThemeType"
-        },
-        "brushColor": {
-          "type": "string"
-        },
-        "brushStrokeColor": {
-          "type": "string"
-        },
-        "brushStrokeWidth": {
-          "type": "number"
-        },
-        "lineSize": {
-          "type": "number"
-        },
-        "linkStrokeWidth": {
-          "type": "number"
-        },
-        "markColor": {
-          "type": "string"
-        },
-        "markOpacity": {
-          "type": "number"
-        },
-        "markStrokeColor": {
-          "type": "string"
-        },
-        "markStrokeWidth": {
-          "type": "number"
-        },
-        "nominalColors": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "nominalColorsExtended": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "pointSize": {
-          "type": "number"
-        },
-        "pointSizeRangeQuantitative": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "type": "array"
-        },
-        "ruleStrokeWidth": {
-          "type": "number"
-        },
-        "subtitleColor": {
-          "type": "string"
-        },
-        "titleColor": {
-          "type": "string"
-        },
-        "trackOutlineColor": {
-          "type": "string"
-        },
-        "trackOutlineWidth": {
-          "type": "number"
-        },
-        "useExtendedNominalColors": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "base"
-      ],
-      "type": "object"
-    },
-    "ThemeType": {
-      "enum": [
-        "light",
-        "dark"
-      ],
-      "type": "string"
-    },
-    "Track": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SingleTrack"
-        },
-        {
-          "$ref": "#/definitions/OverlaidTrack"
-        },
-        {
-          "$ref": "#/definitions/DataTrack"
-        }
-      ]
-    },
-    "TrackStyle": {
+    "Style": {
       "additionalProperties": false,
       "properties": {
         "align": {
@@ -4892,12 +4841,6 @@
         "outlineWidth": {
           "type": "number"
         },
-        "stroke": {
-          "type": "string"
-        },
-        "strokeWidth": {
-          "type": "number"
-        },
         "textAnchor": {
           "enum": [
             "start",
@@ -4924,6 +4867,166 @@
         },
         "verticalLink": {
           "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "Theme": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ThemeType"
+        },
+        {
+          "$ref": "#/definitions/ThemeDeep"
+        }
+      ]
+    },
+    "ThemeDeep": {
+      "additionalProperties": false,
+      "properties": {
+        "area": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "axis": {
+          "$ref": "#/definitions/AxisStyle"
+        },
+        "bar": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "base": {
+          "$ref": "#/definitions/ThemeType"
+        },
+        "brush": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "line": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "link": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "markCommon": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "point": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "rect": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "root": {
+          "$ref": "#/definitions/RootStyle"
+        },
+        "rule": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "text": {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "type": "string"
+            },
+            "nominalColorRange": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "opacity": {
+              "type": "number"
+            },
+            "quantitativeSizeRange": {
+              "items": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            "size": {
+              "type": "number"
+            },
+            "stroke": {
+              "type": "string"
+            },
+            "strokeWidth": {
+              "type": "number"
+            },
+            "textAnchor": {
+              "enum": [
+                "start",
+                "middle",
+                "end"
+              ],
+              "type": "string"
+            },
+            "textFontWeight": {
+              "enum": [
+                "bold",
+                "normal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "track": {
+          "$ref": "#/definitions/TrackStyle"
+        },
+        "triangle": {
+          "$ref": "#/definitions/MarkStyle"
+        }
+      },
+      "required": [
+        "base"
+      ],
+      "type": "object"
+    },
+    "ThemeType": {
+      "enum": [
+        "light",
+        "dark"
+      ],
+      "type": "string"
+    },
+    "Track": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SingleTrack"
+        },
+        {
+          "$ref": "#/definitions/OverlaidTrack"
+        },
+        {
+          "$ref": "#/definitions/DataTrack"
+        }
+      ]
+    },
+    "TrackStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "legendBackground": {
+          "type": "string"
+        },
+        "legendLabelColor": {
+          "type": "string"
+        },
+        "outline": {
+          "type": "string"
+        },
+        "outlineWidth": {
+          "type": "number"
+        },
+        "titleBackground": {
+          "type": "string"
+        },
+        "titleColor": {
+          "type": "string"
         }
       },
       "type": "object"

--- a/schema/history/0.7.7/gosling0.7.7.schema.json
+++ b/schema/history/0.7.7/gosling0.7.7.schema.json
@@ -1261,6 +1261,24 @@
       ],
       "type": "string"
     },
+    "LegendStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "background": {
+          "type": "string"
+        },
+        "backgroundOpacity": {
+          "type": "number"
+        },
+        "backgroundStroke": {
+          "type": "string"
+        },
+        "labelColor": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "LogBase": {
       "anyOf": [
         {
@@ -4899,6 +4917,9 @@
         "brush": {
           "$ref": "#/definitions/MarkStyle"
         },
+        "legend": {
+          "$ref": "#/definitions/LegendStyle"
+        },
         "line": {
           "$ref": "#/definitions/MarkStyle"
         },
@@ -5010,12 +5031,6 @@
     "TrackStyle": {
       "additionalProperties": false,
       "properties": {
-        "legendBackground": {
-          "type": "string"
-        },
-        "legendLabelColor": {
-          "type": "string"
-        },
         "outline": {
           "type": "string"
         },

--- a/schema/history/0.7.7/gosling0.7.7.schema.ts
+++ b/schema/history/0.7.7/gosling0.7.7.schema.ts
@@ -1,4 +1,5 @@
 import { Chromosome } from './utils/chrom-size';
+import { Theme } from './utils/theme'
 
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
@@ -15,52 +16,6 @@ export interface RootSpecWithMultipleViews extends MultipleViews {
     subtitle?: string;
     description?: string;
     theme?: Theme;
-}
-
-/* ----------------------------- THEME ----------------------------- */
-export type Theme = ThemeType | ThemeDeep;
-export type ThemeType = 'light' | 'dark';
-export enum Themes {
-    light = 'light',
-    dark = 'dark'
-}
-
-// TODO: combine with `TrackStyle`
-// TODO: encapsulate each level, e.g., track: { /* TrackLevelTheme */ }
-export interface ThemeDeep {
-    base: ThemeType;
-
-    /* Root level */
-    backgroundColor?: string; // background color of react component
-    titleColor?: string; // color of title
-    subtitleColor?: string; // color of subtitle
-
-    /* Track level */
-    trackOutlineColor?: string; // color of track outline
-    trackOutlineWidth?: number; // stroke width of track outline
-    axisColor?: string; // color of axis ticks and labels
-
-    /* Encoding level */
-    markColor?: string; // default color of marks
-    nominalColors?: string[]; // colors for nominal values
-    useExtendedNominalColors?: boolean;
-    nominalColorsExtended?: string[]; // colors for nominal values when too many categories
-    markStrokeColor?: string; // stroke color of marks
-    markStrokeWidth?: number; // stroke width of marks
-    markOpacity?: number; // opacity of marks
-    // TODO: quantitative colors
-
-    /* Mark-specific Encoding Level */
-    pointSize?: number; // size of points
-    pointSizeRangeQuantitative?: [number, number];
-    lineSize?: number; // line width
-    brushColor?: string; // fill color of brush
-    brushStrokeColor?: string; // stroke color of brush
-    brushStrokeWidth?: number; // stroke width of brush
-    ruleStrokeWidth?: number;
-    linkStrokeWidth?: number;
-
-    // ...
 }
 
 /* ----------------------------- VIEW ----------------------------- */
@@ -113,7 +68,7 @@ export interface CommonViewDef {
     centerRadius?: number; // [0, 1] (default: 0.3)
 
     // Overriden by children
-    style?: TrackStyle;
+    style?: Style;
 }
 
 /* ----------------------------- TRACK ----------------------------- */
@@ -236,16 +191,19 @@ export type OverlaidTrack = Partial<SingleTrack> &
         overlay: Partial<Omit<SingleTrack, 'height' | 'width' | 'layout' | 'title' | 'subtitle'>>[];
     };
 
-export interface TrackStyle {
+export interface Style {
+    // Top-level Styles
     background?: string;
     backgroundOpacity?: number;
-    dashed?: [number, number];
-    linePattern?: { type: 'triangleLeft' | 'triangleRight'; size: number };
-    curve?: 'top' | 'bottom' | 'left' | 'right';
-    align?: 'left' | 'right';
-    dy?: number;
     outline?: string;
     outlineWidth?: number;
+
+    // Mark-level styles
+    dashed?: [number, number];
+    linePattern?: { type: 'triangleLeft' | 'triangleRight'; size: number };
+    curve?: 'top' | 'bottom' | 'left' | 'right'; // for genomic range rules
+    align?: 'left' | 'right'; // currently, only supported for triangles
+    dy?: number; // currently, only used for text marks
     verticalLink?: boolean; // Should bands be connected from the top to bottom?
     circularLink?: boolean; // !! Deprecated: draw arc instead of bazier curve?
     inlineLegend?: boolean; // show legend in a single horizontal line?
@@ -255,9 +213,6 @@ export interface TrackStyle {
     textStrokeWidth?: number;
     textFontWeight?: 'bold' | 'normal';
     textAnchor?: 'start' | 'middle' | 'end';
-    //
-    stroke?: string; // deprecated
-    strokeWidth?: number; // deprecated
 }
 
 /* ----------------------------- SEMANTIC ZOOM ----------------------------- */
@@ -579,10 +534,10 @@ export interface GlyphElement {
     opacity?: ChannelBind | ChannelValue | 'none';
     text?: ChannelBind | ChannelValue | 'none';
     background?: ChannelBind | ChannelValue | 'none';
-    style?: MarkStyle;
+    style?: MarkStyleInGlyph;
 }
 
-export interface MarkStyle {
+export interface MarkStyleInGlyph {
     dashed?: string;
     dy?: number;
     stroke?: string;

--- a/schema/history/0.7.7/gosling0.7.7.schema.ts
+++ b/schema/history/0.7.7/gosling0.7.7.schema.ts
@@ -1,5 +1,5 @@
 import { Chromosome } from './utils/chrom-size';
-import { Theme } from './utils/theme'
+import { Theme } from './utils/theme';
 
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -107,7 +107,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     style={{
                         position: 'relative',
                         padding,
-                        background: getTheme(gs?.theme).backgroundColor,
+                        background: getTheme(gs?.theme).root.background,
                         width: size.width + padding * 2,
                         height: size.height + padding * 2,
                         textAlign: 'left'
@@ -118,7 +118,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                         style={{
                             position: 'relative',
                             display: 'block',
-                            background: getTheme(gs?.theme).backgroundColor,
+                            background: getTheme(gs?.theme).root.background,
                             margin: 0,
                             padding: 0, // non-zero padding acts unexpectedly w/ HiGlassComponent
                             width: size.width,

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -2,14 +2,14 @@ import uuid from 'uuid';
 import { Track as HiGlassTrack } from './higlass.schema';
 import { HiGlassModel, HIGLASS_AXIS_SIZE } from './higlass-model';
 import { parseServerAndTilesetUidFromUrl } from './utils';
-import { Track, Domain, DataTransform, Theme } from './gosling.schema';
+import { Track, Domain, DataTransform } from './gosling.schema';
 import { BoundingBox, RelativePosition } from './utils/bounding-box';
 import { resolveSuperposedTracks } from './utils/overlay';
 import { getGenomicChannelKeyFromTrack, getGenomicChannelFromTrack } from './utils/validate';
 import { viridisColorMap } from './utils/colors';
 import { IsDataDeep, IsChannelDeep, IsDataDeepTileset } from './gosling.schema.guards';
 import { DEFAULT_SUBTITLE_HEIGHT, DEFAULT_TITLE_HEIGHT } from './layout/defaults';
-import { getTheme } from './utils/theme';
+import { getTheme, Theme } from './utils/theme';
 
 /**
  * Convert a gosling track into a HiGlass view and add it into a higlass model.
@@ -58,11 +58,11 @@ export function goslingToHiGlass(
                 mousePositionColor: '#B8BCC1',
                 /* Track title */
                 name: firstResolvedSpec.title,
-                labelPosition: firstResolvedSpec.title ? 'topLeft' : 'none',
                 fontSize: 12,
-                labelColor: getTheme(theme).axisColor,
+                labelPosition: firstResolvedSpec.title ? 'topLeft' : 'none',
                 labelShowResolution: false,
-                labelBackgroundColor: 'white',
+                labelColor: getTheme(theme).track.titleColor,
+                labelBackgroundColor: getTheme(theme).track.titleBackground,
                 labelTextOpacity: 1,
                 labelLeftMargin: 1,
                 labelTopMargin: 1,
@@ -163,7 +163,7 @@ export function goslingToHiGlass(
                 bb.width,
                 DEFAULT_TITLE_HEIGHT,
                 firstResolvedSpec.title,
-                getTheme(theme).titleColor,
+                getTheme(theme).root.titleColor,
                 18,
                 'bold'
             );
@@ -173,7 +173,7 @@ export function goslingToHiGlass(
                 bb.width,
                 DEFAULT_SUBTITLE_HEIGHT,
                 firstResolvedSpec.subtitle,
-                getTheme(theme).subtitleColor,
+                getTheme(theme).root.subtitleColor,
                 14,
                 'normal'
             );

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -1,12 +1,4 @@
-import {
-    ChannelDeep,
-    PREDEFINED_COLORS,
-    ChannelTypes,
-    ChannelValue,
-    SingleTrack,
-    Channel,
-    Theme
-} from './gosling.schema';
+import { ChannelDeep, PREDEFINED_COLORS, ChannelTypes, ChannelValue, SingleTrack, Channel } from './gosling.schema';
 import { validateTrack, getGenomicChannelFromTrack, getGenomicChannelKeyFromTrack } from './utils/validate';
 import {
     ScaleLinear,
@@ -39,7 +31,7 @@ import {
     PREDEFINED_COLOR_STR_MAP
 } from './gosling.schema.guards';
 import { CHANNEL_DEFAULTS } from './channel';
-import { getTheme } from './utils/theme';
+import { getTheme, Theme } from './utils/theme';
 
 export type ScaleType =
     | ScaleLinear<any, any>

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -559,7 +559,7 @@ export class GoslingTrackModel {
                             break;
                         case 'size':
                             // TODO: make as an object
-                            if (spec.mark === 'line') value = getTheme(this.theme).lineSize;
+                            if (spec.mark === 'line') value = getTheme(this.theme).line.size;
                             else if (spec.mark === 'bar') value = undefined;
                             else if (spec.mark === 'rect') value = undefined;
                             else if (spec.mark === 'triangleRight') value = undefined;
@@ -573,24 +573,24 @@ export class GoslingTrackModel {
                                 IsChannelDeep(spec.xe)
                             )
                                 value = undefined;
-                            else value = getTheme(this.theme).pointSize;
+                            else value = getTheme(this.theme).point.size;
                             break;
                         case 'color':
-                            value = getTheme(this.theme).markColor;
+                            value = getTheme(this.theme).markCommon.color;
                             break;
                         case 'row':
                             value = 0;
                             break;
                         case 'stroke':
-                            value = getTheme(this.theme).markStrokeColor;
+                            value = getTheme(this.theme).markCommon.stroke;
                             break;
                         case 'strokeWidth':
-                            if (spec.mark === 'rule') value = getTheme(this.theme).ruleStrokeWidth;
-                            else if (spec.mark === 'link') value = getTheme(this.theme).linkStrokeWidth;
-                            else value = getTheme(this.theme).markStrokeWidth;
+                            if (spec.mark === 'rule') value = getTheme(this.theme).rule.strokeWidth;
+                            else if (spec.mark === 'link') value = getTheme(this.theme).link.strokeWidth;
+                            else value = getTheme(this.theme).markCommon.strokeWidth;
                             break;
                         case 'opacity':
-                            value = getTheme(this.theme).markOpacity;
+                            value = getTheme(this.theme).markCommon.opacity;
                             break;
                         case 'text':
                             value = '';
@@ -629,7 +629,7 @@ export class GoslingTrackModel {
                                 range = CHANNEL_DEFAULTS.QUANTITATIVE_COLOR as PREDEFINED_COLORS;
                                 break;
                             case 'size':
-                                range = getTheme(this.theme).pointSizeRangeQuantitative;
+                                range = getTheme(this.theme).markCommon.quantitativeSizeRange;
                                 break;
                             case 'strokeWidth':
                                 range = [1, 3];
@@ -662,12 +662,7 @@ export class GoslingTrackModel {
                                 break;
                             case 'color':
                             case 'stroke':
-                                range =
-                                    Array.isArray(channel.domain) &&
-                                    channel.domain.length > getTheme(this.theme).nominalColors.length &&
-                                    getTheme(this.theme).useExtendedNominalColors
-                                        ? getTheme(this.theme).nominalColorsExtended
-                                        : getTheme(this.theme).nominalColors;
+                                range = getTheme(this.theme).markCommon.nominalColorRange;
                                 break;
                             case 'row':
                                 range = [0, spec.height];

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -7,7 +7,7 @@ import {
     DomainInterval,
     DomainChrInterval,
     DomainGene,
-    TrackStyle,
+    Style,
     MarkType,
     MarkDeep,
     Track,
@@ -97,7 +97,7 @@ export function IsDomainGene(domain: Domain): domain is DomainGene {
     return 'gene' in domain;
 }
 
-export function IsTrackStyle(track: TrackStyle | undefined): track is TrackStyle {
+export function IsTrackStyle(track: Style | undefined): track is Style {
     return track !== undefined;
 }
 

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -1,4 +1,5 @@
 import { Chromosome } from './utils/chrom-size';
+import { Theme } from './utils/theme';
 
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
@@ -15,52 +16,6 @@ export interface RootSpecWithMultipleViews extends MultipleViews {
     subtitle?: string;
     description?: string;
     theme?: Theme;
-}
-
-/* ----------------------------- THEME ----------------------------- */
-export type Theme = ThemeType | ThemeDeep;
-export type ThemeType = 'light' | 'dark';
-export enum Themes {
-    light = 'light',
-    dark = 'dark'
-}
-
-// TODO: combine with `TrackStyle`
-// TODO: encapsulate each level, e.g., track: { /* TrackLevelTheme */ }
-export interface ThemeDeep {
-    base: ThemeType;
-
-    /* Root level */
-    backgroundColor?: string; // background color of react component
-    titleColor?: string; // color of title
-    subtitleColor?: string; // color of subtitle
-
-    /* Track level */
-    trackOutlineColor?: string; // color of track outline
-    trackOutlineWidth?: number; // stroke width of track outline
-    axisColor?: string; // color of axis ticks and labels
-
-    /* Encoding level */
-    markColor?: string; // default color of marks
-    nominalColors?: string[]; // colors for nominal values
-    useExtendedNominalColors?: boolean;
-    nominalColorsExtended?: string[]; // colors for nominal values when too many categories
-    markStrokeColor?: string; // stroke color of marks
-    markStrokeWidth?: number; // stroke width of marks
-    markOpacity?: number; // opacity of marks
-    // TODO: quantitative colors
-
-    /* Mark-specific Encoding Level */
-    pointSize?: number; // size of points
-    pointSizeRangeQuantitative?: [number, number];
-    lineSize?: number; // line width
-    brushColor?: string; // fill color of brush
-    brushStrokeColor?: string; // stroke color of brush
-    brushStrokeWidth?: number; // stroke width of brush
-    ruleStrokeWidth?: number;
-    linkStrokeWidth?: number;
-
-    // ...
 }
 
 /* ----------------------------- VIEW ----------------------------- */
@@ -113,7 +68,7 @@ export interface CommonViewDef {
     centerRadius?: number; // [0, 1] (default: 0.3)
 
     // Overriden by children
-    style?: TrackStyle;
+    style?: Style;
 }
 
 /* ----------------------------- TRACK ----------------------------- */
@@ -236,16 +191,19 @@ export type OverlaidTrack = Partial<SingleTrack> &
         overlay: Partial<Omit<SingleTrack, 'height' | 'width' | 'layout' | 'title' | 'subtitle'>>[];
     };
 
-export interface TrackStyle {
+export interface Style {
+    // Top-level Styles
     background?: string;
     backgroundOpacity?: number;
-    dashed?: [number, number];
-    linePattern?: { type: 'triangleLeft' | 'triangleRight'; size: number };
-    curve?: 'top' | 'bottom' | 'left' | 'right';
-    align?: 'left' | 'right';
-    dy?: number;
     outline?: string;
     outlineWidth?: number;
+
+    // Mark-level styles
+    dashed?: [number, number];
+    linePattern?: { type: 'triangleLeft' | 'triangleRight'; size: number };
+    curve?: 'top' | 'bottom' | 'left' | 'right'; // for genomic range rules
+    align?: 'left' | 'right'; // currently, only supported for triangles
+    dy?: number; // currently, only used for text marks
     verticalLink?: boolean; // Should bands be connected from the top to bottom?
     circularLink?: boolean; // !! Deprecated: draw arc instead of bazier curve?
     inlineLegend?: boolean; // show legend in a single horizontal line?
@@ -255,9 +213,6 @@ export interface TrackStyle {
     textStrokeWidth?: number;
     textFontWeight?: 'bold' | 'normal';
     textAnchor?: 'start' | 'middle' | 'end';
-    //
-    stroke?: string; // deprecated
-    strokeWidth?: number; // deprecated
 }
 
 /* ----------------------------- SEMANTIC ZOOM ----------------------------- */
@@ -579,10 +534,10 @@ export interface GlyphElement {
     opacity?: ChannelBind | ChannelValue | 'none';
     text?: ChannelBind | ChannelValue | 'none';
     background?: ChannelBind | ChannelValue | 'none';
-    style?: MarkStyle;
+    style?: MarkStyleInGlyph;
 }
 
-export interface MarkStyle {
+export interface MarkStyleInGlyph {
     dashed?: string;
     dy?: number;
     stroke?: string;

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -140,11 +140,11 @@ export class HiGlassModel {
             uid: uuid.v4(),
             fromViewUid,
             options: {
-                projectionFillColor: style?.color ?? getTheme(theme).brushColor,
-                projectionStrokeColor: style?.stroke ?? getTheme(theme).brushStrokeColor,
+                projectionFillColor: style?.color ?? getTheme(theme).brush.color,
+                projectionStrokeColor: style?.stroke ?? getTheme(theme).brush.stroke,
                 projectionFillOpacity: style?.opacity ?? 0.3,
                 projectionStrokeOpacity: style?.opacity ?? 0.3,
-                strokeWidth: style?.strokeWidth ?? getTheme(theme).brushStrokeWidth,
+                strokeWidth: style?.strokeWidth ?? getTheme(theme).brush.strokeWidth,
                 startAngle: style?.startAngle,
                 endAngle: style?.endAngle,
                 innerRadius: style?.innerRadius,
@@ -266,8 +266,8 @@ export class HiGlassModel {
                 ...options,
                 assembly: this.getAssembly(),
                 stroke: 'transparent', // text outline
-                color: getTheme(options.theme).axisColor,
-                tickColor: getTheme(options.theme).axisColor,
+                color: getTheme(options.theme).axis.labelColor,
+                tickColor: getTheme(options.theme).axis.tickColor,
                 tickFormat: type === 'narrower' ? 'si' : 'plain',
                 tickPositions: type === 'regular' ? 'even' : 'ends',
                 reverseOrientation: position === 'bottom' || position === 'right' ? true : false

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -142,8 +142,8 @@ export class HiGlassModel {
             options: {
                 projectionFillColor: style?.color ?? getTheme(theme).brush.color,
                 projectionStrokeColor: style?.stroke ?? getTheme(theme).brush.stroke,
-                projectionFillOpacity: style?.opacity ?? 0.3,
-                projectionStrokeOpacity: style?.opacity ?? 0.3,
+                projectionFillOpacity: style?.opacity ?? getTheme(theme).brush.opacity,
+                projectionStrokeOpacity: style?.opacity ?? getTheme(theme).brush.opacity,
                 strokeWidth: style?.strokeWidth ?? getTheme(theme).brush.strokeWidth,
                 startAngle: style?.startAngle,
                 endAngle: style?.endAngle,

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -1,12 +1,12 @@
 import uuid from 'uuid';
 import { HiGlassSpec, Track } from './higlass.schema';
 import HiGlassSchema from './higlass.schema.json';
-import { Assembly, AxisPosition, Domain, Orientation, Theme } from './gosling.schema';
+import { Assembly, AxisPosition, Domain, Orientation } from './gosling.schema';
 import { getNumericDomain } from './utils/scales';
 import { RelativePosition } from './utils/bounding-box';
 import { validateSpec } from './utils/validate';
 import { GET_CHROM_SIZES } from './utils/assembly';
-import { getTheme } from './utils/theme';
+import { getTheme, Theme } from './utils/theme';
 
 export const HIGLASS_AXIS_SIZE = 30;
 const getViewTemplate = (assembly?: string) => {

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -4,7 +4,7 @@ import { drawLine } from './line';
 import { drawBar } from './bar';
 import { drawArea } from './area';
 import { drawRect } from './rect';
-import { ChannelTypes, Theme } from '../gosling.schema';
+import { ChannelTypes } from '../gosling.schema';
 import { drawTriangle } from './triangle';
 import { drawText } from './text';
 import { drawRule } from './rule';
@@ -15,6 +15,7 @@ import { drawColorLegend, drawYLegend } from './legend';
 import { drawCircularGrid } from './grid-circular';
 import { drawCircularOutlines } from './outline-circular';
 import { drawBackground } from './background';
+import { Theme } from '../utils/theme';
 
 /**
  * Visual channels currently supported for visual encoding.
@@ -120,7 +121,7 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
     if (CIRCULAR) {
         // ...
     } else {
-        drawYLegend(HGC, trackInfo, tile, model);
+        drawYLegend(HGC, trackInfo, tile, model, theme);
     }
-    drawColorLegend(HGC, trackInfo, tile, model);
+    drawColorLegend(HGC, trackInfo, tile, model, theme);
 }

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -59,7 +59,7 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
                 const color = tm.encodedValue('color', category);
                 const textGraphic = new HGC.libraries.PIXI.Text(
                     category,
-                    getLegendTextStyle(getTheme(theme).track.legendLabelColor)
+                    getLegendTextStyle(getTheme(theme).legend.labelColor)
                 );
                 textGraphic.anchor.x = 1;
                 textGraphic.anchor.y = 0;
@@ -69,7 +69,7 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
                 graphics.addChild(textGraphic);
 
                 const textStyleObj = new HGC.libraries.PIXI.TextStyle(
-                    getLegendTextStyle(getTheme(theme).track.legendLabelColor)
+                    getLegendTextStyle(getTheme(theme).legend.labelColor)
                 );
                 const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
@@ -98,7 +98,7 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
 
             const textGraphic = new HGC.libraries.PIXI.Text(
                 category,
-                getLegendTextStyle(getTheme(theme).track.legendLabelColor)
+                getLegendTextStyle(getTheme(theme).legend.labelColor)
             );
             textGraphic.anchor.x = 1;
             textGraphic.anchor.y = 0;
@@ -108,7 +108,7 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
             graphics.addChild(textGraphic);
 
             const textStyleObj = new HGC.libraries.PIXI.TextStyle(
-                getLegendTextStyle(getTheme(theme).track.legendLabelColor)
+                getLegendTextStyle(getTheme(theme).legend.labelColor)
             );
             const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
@@ -126,21 +126,27 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
         });
     }
 
-    graphics.beginFill(colorToHex(getTheme(theme).track.legendBackground), 0.7);
+    graphics.beginFill(colorToHex(getTheme(theme).legend.background), getTheme(theme).legend.backgroundOpacity);
     graphics.lineStyle(
         1,
-        colorToHex('#DBDBDB'),
-        0.7, // alpha
+        colorToHex(getTheme(theme).legend.backgroundStroke),
+        1, // alpha
         0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
     graphics.drawRect(
-        trackInfo.position[0] + trackInfo.dimensions[0] - maxWidth,
+        trackInfo.position[0] + trackInfo.dimensions[0] - maxWidth - 1,
         trackInfo.position[1] + 1,
         maxWidth,
         cumY - paddingY
     );
 
     recipe.forEach(r => {
+        graphics.lineStyle(
+            1,
+            colorToHex('black'),
+            0, // alpha
+            0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+        );
         graphics.beginFill(colorToHex(r.color), 1);
         graphics.drawCircle(r.x, r.y, 4);
     });
@@ -181,7 +187,7 @@ export function drawYLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrac
 
         const textGraphic = new HGC.libraries.PIXI.Text(
             category,
-            getLegendTextStyle(getTheme(theme).track.legendLabelColor)
+            getLegendTextStyle(getTheme(theme).legend.labelColor)
         );
         textGraphic.anchor.x = 0;
         textGraphic.anchor.y = 0;
@@ -190,15 +196,13 @@ export function drawYLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrac
 
         graphics.addChild(textGraphic);
 
-        const textStyleObj = new HGC.libraries.PIXI.TextStyle(
-            getLegendTextStyle(getTheme(theme).track.legendLabelColor)
-        );
+        const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(getTheme(theme).legend.labelColor));
         const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
-        graphics.beginFill(colorToHex(getTheme(theme).track.legendBackground), 0.7);
+        graphics.beginFill(colorToHex(getTheme(theme).legend.background), getTheme(theme).legend.backgroundOpacity);
         graphics.lineStyle(
             1,
-            colorToHex('#DBDBDB'),
+            colorToHex(getTheme(theme).legend.backgroundStroke),
             0, // alpha
             0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
         );

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -1,20 +1,23 @@
 import { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
+import { getTheme, Theme } from '../utils/theme';
 
-export const LEGEND_LABEL_STYLE = {
-    fontSize: '12px',
-    fontFamily: 'Arial',
-    fontWeight: 'normal',
-    fill: 'black',
-    background: 'white',
-    lineJoin: 'round'
-    // Other possible options:
-    // stroke: '#ffffff',
-    // strokeThickness: 2
+export const getLegendTextStyle = (fill = 'black') => {
+    return {
+        fontSize: '12px',
+        fontFamily: 'Arial',
+        fontWeight: 'normal',
+        fill,
+        background: 'white',
+        lineJoin: 'round'
+        // Other possible options:
+        // stroke: '#ffffff',
+        // strokeThickness: 2
+    };
 };
 
-export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel) {
+export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel, theme: Theme = 'light') {
     /* track spec */
     const spec = tm.spec();
     if (!IsChannelDeep(spec.color) || spec.color.type !== 'nominal' || !spec.color.legend) {
@@ -54,7 +57,10 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
                 }
 
                 const color = tm.encodedValue('color', category);
-                const textGraphic = new HGC.libraries.PIXI.Text(category, { ...LEGEND_LABEL_STYLE });
+                const textGraphic = new HGC.libraries.PIXI.Text(
+                    category,
+                    getLegendTextStyle(getTheme(theme).track.legendLabelColor)
+                );
                 textGraphic.anchor.x = 1;
                 textGraphic.anchor.y = 0;
                 textGraphic.position.x = trackInfo.position[0] + trackInfo.dimensions[0] - maxWidth - paddingX;
@@ -62,7 +68,9 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
 
                 graphics.addChild(textGraphic);
 
-                const textStyleObj = new HGC.libraries.PIXI.TextStyle(LEGEND_LABEL_STYLE);
+                const textStyleObj = new HGC.libraries.PIXI.TextStyle(
+                    getLegendTextStyle(getTheme(theme).track.legendLabelColor)
+                );
                 const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
                 if (cumY < textMetrics.height + paddingY * 3) {
@@ -88,7 +96,10 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
 
             const color = tm.encodedValue('color', category);
 
-            const textGraphic = new HGC.libraries.PIXI.Text(category, { ...LEGEND_LABEL_STYLE });
+            const textGraphic = new HGC.libraries.PIXI.Text(
+                category,
+                getLegendTextStyle(getTheme(theme).track.legendLabelColor)
+            );
             textGraphic.anchor.x = 1;
             textGraphic.anchor.y = 0;
             textGraphic.position.x = trackInfo.position[0] + trackInfo.dimensions[0] - paddingX;
@@ -96,7 +107,9 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
 
             graphics.addChild(textGraphic);
 
-            const textStyleObj = new HGC.libraries.PIXI.TextStyle(LEGEND_LABEL_STYLE);
+            const textStyleObj = new HGC.libraries.PIXI.TextStyle(
+                getLegendTextStyle(getTheme(theme).track.legendLabelColor)
+            );
             const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
             if (maxWidth < textMetrics.width + paddingX * 3) {
@@ -113,7 +126,7 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
         });
     }
 
-    graphics.beginFill(colorToHex('white'), 0.7);
+    graphics.beginFill(colorToHex(getTheme(theme).track.legendBackground), 0.7);
     graphics.lineStyle(
         1,
         colorToHex('#DBDBDB'),
@@ -133,7 +146,7 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
     });
 }
 
-export function drawYLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel) {
+export function drawYLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel, theme: Theme = 'light') {
     /* track spec */
     const spec = tm.spec();
     if (
@@ -166,7 +179,10 @@ export function drawYLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrac
     rowCategories.forEach(category => {
         const rowPosition = tm.encodedValue('row', category);
 
-        const textGraphic = new HGC.libraries.PIXI.Text(category, { ...LEGEND_LABEL_STYLE });
+        const textGraphic = new HGC.libraries.PIXI.Text(
+            category,
+            getLegendTextStyle(getTheme(theme).track.legendLabelColor)
+        );
         textGraphic.anchor.x = 0;
         textGraphic.anchor.y = 0;
         textGraphic.position.x = trackInfo.position[0] + paddingX;
@@ -174,10 +190,12 @@ export function drawYLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrac
 
         graphics.addChild(textGraphic);
 
-        const textStyleObj = new HGC.libraries.PIXI.TextStyle(LEGEND_LABEL_STYLE);
+        const textStyleObj = new HGC.libraries.PIXI.TextStyle(
+            getLegendTextStyle(getTheme(theme).track.legendLabelColor)
+        );
         const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
-        graphics.beginFill(colorToHex('white'), 0.7);
+        graphics.beginFill(colorToHex(getTheme(theme).track.legendBackground), 0.7);
         graphics.lineStyle(
             1,
             colorToHex('#DBDBDB'),

--- a/src/core/mark/outline.ts
+++ b/src/core/mark/outline.ts
@@ -1,8 +1,7 @@
 import { GoslingTrackModel } from '../gosling-track-model';
-import { Theme } from '../gosling.schema';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
-import { getTheme } from '../utils/theme';
+import { Theme, getTheme } from '../utils/theme';
 
 export const TITLE_STYLE = {
     fontSize: '12px',
@@ -51,7 +50,7 @@ export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackMode
     g.lineStyle(
         tm.spec().style?.outlineWidth ?? 1,
         // TODO: outline not working
-        colorToHex(tm.spec().style?.outline ?? getTheme(theme).trackOutlineColor),
+        colorToHex(tm.spec().style?.outline ?? getTheme(theme).track.outline),
         1, // alpha
         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
@@ -63,7 +62,7 @@ export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackMode
 
     g.lineStyle(
         1,
-        colorToHex(getTheme(theme).axisColor),
+        colorToHex(getTheme(theme).axis.baselineColor),
         1, // alpha
         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );

--- a/src/core/utils/style.ts
+++ b/src/core/utils/style.ts
@@ -1,7 +1,7 @@
 import { assign } from 'lodash';
-import { TrackStyle } from '../gosling.schema';
+import { Style } from '../gosling.schema';
 
-export function getStyleOverridden(parent: TrackStyle | undefined, child: TrackStyle | undefined) {
+export function getStyleOverridden(parent: Style | undefined, child: Style | undefined) {
     // Deep overriding instead of replacing.
     const base = parent ? JSON.parse(JSON.stringify(parent)) : {};
     return child ? assign(base, child) : base;

--- a/src/core/utils/theme.test.ts
+++ b/src/core/utils/theme.test.ts
@@ -1,21 +1,20 @@
-import { getTheme } from './theme';
-import { ThemeDeep } from '../gosling.schema';
+import { ThemeDeep, getTheme } from './theme';
 
 describe('Theme', () => {
     it('Defualt Themes', () => {
         expect(getTheme().base).toEqual('light');
-        expect(getTheme().titleColor).toEqual('black');
+        expect(getTheme().root.titleColor).toEqual('black');
     });
     it('Predefined Themes', () => {
         expect(getTheme('dark').base).toEqual('dark');
-        expect(getTheme('dark').titleColor).toEqual('white');
+        expect(getTheme('dark').root.titleColor).toEqual('white');
     });
     it('Overriding Themes', () => {
         const custom: ThemeDeep = {
             base: 'dark',
-            titleColor: 'yellow'
+            root: { titleColor: 'yellow' }
         };
-        expect(getTheme('dark').titleColor).not.toEqual(getTheme(custom).titleColor);
-        expect(getTheme(custom).titleColor).toEqual('yellow');
+        expect(getTheme('dark').root.titleColor).not.toEqual(getTheme(custom).root.titleColor);
+        expect(getTheme(custom).root.titleColor).toEqual('yellow');
     });
 });

--- a/src/core/utils/theme.ts
+++ b/src/core/utils/theme.ts
@@ -1,8 +1,100 @@
 import { assign } from 'lodash';
 import { CHANNEL_DEFAULTS } from '../channel';
-import { Theme, ThemeDeep, Themes } from '../gosling.schema';
 
-export function getTheme(theme: Theme = 'light'): Required<ThemeDeep> {
+/* ----------------------------- THEME ----------------------------- */
+export type Theme = ThemeType | ThemeDeep;
+export type ThemeType = 'light' | 'dark';
+export enum Themes {
+    light = 'light',
+    dark = 'dark'
+}
+
+export interface ThemeDeep {
+    base: ThemeType;
+
+    root?: RootStyle;
+    track?: TrackStyle;
+    axis?: AxisStyle;
+
+    // Mark-Specific Styles
+    markCommon?: MarkStyle;
+    point?: MarkStyle;
+    rect?: MarkStyle;
+    triangle?: MarkStyle;
+    area?: MarkStyle;
+    line?: MarkStyle;
+    bar?: MarkStyle;
+    rule?: MarkStyle;
+    link?: MarkStyle;
+    brush?: MarkStyle;
+    text?: MarkStyle & {
+        textFontWeight?: 'bold' | 'normal';
+        textAnchor?: 'start' | 'middle' | 'end';
+    };
+}
+
+// TODO: Better way to implement deep `Required` type instead of having two separate interfaces, i.e., CompleteThemeDeep and ThemeDeep
+export interface CompleteThemeDeep {
+    base: Required<ThemeType>;
+
+    root: Required<RootStyle>;
+    track: Required<TrackStyle>;
+    axis: Required<AxisStyle>;
+
+    // Mark-Specific
+    markCommon: Required<MarkStyle>;
+    point: Required<MarkStyle>;
+    rect: Required<MarkStyle>;
+    triangle: Required<MarkStyle>;
+    area: Required<MarkStyle>;
+    line: Required<MarkStyle>;
+    bar: Required<MarkStyle>;
+    rule: Required<MarkStyle>;
+    link: Required<MarkStyle>;
+    brush: Required<MarkStyle>;
+    text: Required<MarkStyle> &
+        Required<{
+            textFontWeight?: 'bold' | 'normal';
+            textAnchor?: 'start' | 'middle' | 'end';
+        }>;
+}
+
+export interface RootStyle {
+    background?: string;
+    titleColor?: string;
+    subtitleColor?: string;
+}
+
+export interface TrackStyle {
+    titleColor?: string;
+    titleBackground?: string;
+    outline?: string;
+    outlineWidth?: number;
+    legendLabelColor?: string;
+    legendBackground?: string;
+    // ...
+}
+
+export interface AxisStyle {
+    tickColor?: string;
+    labelColor?: string;
+    baselineColor?: string;
+    // ...
+}
+
+export interface MarkStyle {
+    color?: string;
+    size?: number;
+    stroke?: string;
+    strokeWidth?: number;
+    opacity?: number;
+
+    nominalColorRange?: string[];
+    quantitativeSizeRange?: [number, number];
+    // ...
+}
+
+export function getTheme(theme: Theme = 'light'): Required<CompleteThemeDeep> {
     if (theme === 'dark' || theme === 'light') {
         return THEMES[theme];
     } else {
@@ -10,62 +102,150 @@ export function getTheme(theme: Theme = 'light'): Required<ThemeDeep> {
     }
 }
 
+const LightThemeMarkCommonStyle: Required<MarkStyle> = {
+    color: CHANNEL_DEFAULTS.NOMINAL_COLOR[0],
+    size: 1,
+    stroke: 'black',
+    strokeWidth: 0,
+    opacity: 1,
+    nominalColorRange: CHANNEL_DEFAULTS.NOMINAL_COLOR,
+    quantitativeSizeRange: [2, 6]
+};
+
+const DarkThemeMarkCommonStyle: Required<MarkStyle> = { ...LightThemeMarkCommonStyle, stroke: 'white' };
+
 /* ----------------------------- THEME PRESETS ----------------------------- */
-export const THEMES: { [key in Themes]: Required<ThemeDeep> } = {
+export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
     light: {
         base: 'light',
 
-        backgroundColor: 'white',
-        titleColor: 'black',
-        subtitleColor: 'gray',
+        root: {
+            background: 'white',
+            titleColor: 'black',
+            subtitleColor: 'gray'
+        },
 
-        trackOutlineColor: 'gray',
-        trackOutlineWidth: 1,
-        axisColor: 'black',
+        track: {
+            titleColor: 'black',
+            titleBackground: 'white',
+            outline: 'gray',
+            outlineWidth: 1,
+            legendBackground: 'white',
+            legendLabelColor: 'black'
+        },
 
-        markColor: CHANNEL_DEFAULTS.NOMINAL_COLOR[0],
-        nominalColors: CHANNEL_DEFAULTS.NOMINAL_COLOR,
-        useExtendedNominalColors: false,
-        nominalColorsExtended: CHANNEL_DEFAULTS.NOMINAL_COLOR_EXTENDED,
-        markStrokeColor: 'black',
-        markStrokeWidth: 0,
-        markOpacity: 1,
+        axis: {
+            tickColor: 'black',
+            labelColor: 'black',
+            baselineColor: 'black'
+        },
 
-        pointSize: 3,
-        pointSizeRangeQuantitative: [2, 6],
-        lineSize: 1,
-        ruleStrokeWidth: 1,
-        linkStrokeWidth: 1,
-        brushColor: 'gray',
-        brushStrokeColor: 'black',
-        brushStrokeWidth: 1
+        markCommon: {
+            ...LightThemeMarkCommonStyle
+        },
+        point: {
+            ...LightThemeMarkCommonStyle,
+            size: 3
+        },
+        rect: {
+            ...LightThemeMarkCommonStyle
+        },
+        triangle: {
+            ...LightThemeMarkCommonStyle
+        },
+        area: {
+            ...LightThemeMarkCommonStyle
+        },
+        line: {
+            ...LightThemeMarkCommonStyle
+        },
+        bar: {
+            ...LightThemeMarkCommonStyle
+        },
+        rule: {
+            ...LightThemeMarkCommonStyle,
+            strokeWidth: 1
+        },
+        link: {
+            ...LightThemeMarkCommonStyle,
+            strokeWidth: 1
+        },
+        text: {
+            ...LightThemeMarkCommonStyle,
+            textAnchor: 'middle',
+            textFontWeight: 'normal'
+        },
+        brush: {
+            ...LightThemeMarkCommonStyle,
+            color: 'gray',
+            stroke: 'black',
+            strokeWidth: 1
+        }
     },
     dark: {
         base: 'dark',
 
-        backgroundColor: 'black',
-        titleColor: 'white',
-        subtitleColor: 'lightgray',
+        root: {
+            background: 'black',
+            titleColor: 'white',
+            subtitleColor: 'lightgray'
+        },
 
-        trackOutlineColor: 'lightgray',
-        trackOutlineWidth: 1,
-        axisColor: 'white',
+        track: {
+            titleColor: 'white',
+            titleBackground: 'black',
+            outline: 'lightgray',
+            outlineWidth: 1,
+            legendBackground: 'black',
+            legendLabelColor: 'white'
+        },
 
-        markColor: CHANNEL_DEFAULTS.NOMINAL_COLOR[0],
-        nominalColors: CHANNEL_DEFAULTS.NOMINAL_COLOR,
-        useExtendedNominalColors: false,
-        nominalColorsExtended: CHANNEL_DEFAULTS.NOMINAL_COLOR_EXTENDED,
-        markStrokeColor: 'white',
-        markStrokeWidth: 0,
-        markOpacity: 1,
+        axis: {
+            tickColor: 'white',
+            labelColor: 'white',
+            baselineColor: 'white'
+        },
 
-        pointSize: 3,
-        pointSizeRangeQuantitative: [2, 6],
-        lineSize: 1,
-        ruleStrokeWidth: 1,
-        linkStrokeWidth: 1,
-        brushColor: 'lightgray',
-        brushStrokeColor: 'white',
-        brushStrokeWidth: 1
+        markCommon: {
+            ...DarkThemeMarkCommonStyle
+        },
+        point: {
+            ...DarkThemeMarkCommonStyle,
+            size: 3
+        },
+        rect: {
+            ...DarkThemeMarkCommonStyle
+        },
+        triangle: {
+            ...DarkThemeMarkCommonStyle
+        },
+        area: {
+            ...DarkThemeMarkCommonStyle
+        },
+        line: {
+            ...DarkThemeMarkCommonStyle
+        },
+        bar: {
+            ...DarkThemeMarkCommonStyle
+        },
+        rule: {
+            ...DarkThemeMarkCommonStyle,
+            strokeWidth: 1
+        },
+        link: {
+            ...DarkThemeMarkCommonStyle,
+            strokeWidth: 1
+        },
+        text: {
+            ...DarkThemeMarkCommonStyle,
+            textAnchor: 'middle',
+            textFontWeight: 'normal'
+        },
+        brush: {
+            ...DarkThemeMarkCommonStyle,
+            color: 'lightgray',
+            stroke: 'white',
+            strokeWidth: 1
+        }
     }
 };

--- a/src/core/utils/theme.ts
+++ b/src/core/utils/theme.ts
@@ -14,6 +14,7 @@ export interface ThemeDeep {
 
     root?: RootStyle;
     track?: TrackStyle;
+    legend?: LegendStyle;
     axis?: AxisStyle;
 
     // Mark-Specific Styles
@@ -39,6 +40,7 @@ export interface CompleteThemeDeep {
 
     root: Required<RootStyle>;
     track: Required<TrackStyle>;
+    legend: Required<LegendStyle>;
     axis: Required<AxisStyle>;
 
     // Mark-Specific
@@ -70,8 +72,14 @@ export interface TrackStyle {
     titleBackground?: string;
     outline?: string;
     outlineWidth?: number;
-    legendLabelColor?: string;
-    legendBackground?: string;
+    // ...
+}
+
+export interface LegendStyle {
+    labelColor?: string;
+    background?: string;
+    backgroundOpacity?: number;
+    backgroundStroke?: string;
     // ...
 }
 
@@ -98,7 +106,14 @@ export function getTheme(theme: Theme = 'light'): Required<CompleteThemeDeep> {
     if (theme === 'dark' || theme === 'light') {
         return THEMES[theme];
     } else {
-        return assign(JSON.parse(JSON.stringify(THEMES[theme.base])), JSON.parse(JSON.stringify(theme)));
+        // Iterate all keys to override from base
+        const base = JSON.parse(JSON.stringify(THEMES[theme.base]));
+        Object.keys(base).forEach(k => {
+            if ((theme as any)[k]) {
+                base[k] = assign(JSON.parse(JSON.stringify(base[k])), JSON.parse(JSON.stringify((theme as any)[k])));
+            }
+        });
+        return base;
     }
 }
 
@@ -129,9 +144,14 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
             titleColor: 'black',
             titleBackground: 'white',
             outline: 'gray',
-            outlineWidth: 1,
-            legendBackground: 'white',
-            legendLabelColor: 'black'
+            outlineWidth: 1
+        },
+
+        legend: {
+            background: 'white',
+            backgroundOpacity: 0.7,
+            labelColor: 'black',
+            backgroundStroke: '#DBDBDB'
         },
 
         axis: {
@@ -178,6 +198,7 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
         brush: {
             ...LightThemeMarkCommonStyle,
             color: 'gray',
+            opacity: 0.3,
             stroke: 'black',
             strokeWidth: 1
         }
@@ -195,9 +216,14 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
             titleColor: 'white',
             titleBackground: 'black',
             outline: 'lightgray',
-            outlineWidth: 1,
-            legendBackground: 'black',
-            legendLabelColor: 'white'
+            outlineWidth: 1
+        },
+
+        legend: {
+            background: 'black',
+            backgroundOpacity: 0.7,
+            labelColor: 'white',
+            backgroundStroke: '#DBDBDB'
         },
 
         axis: {
@@ -244,6 +270,7 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
         brush: {
             ...DarkThemeMarkCommonStyle,
             color: 'lightgray',
+            opacity: 0.3,
             stroke: 'white',
             strokeWidth: 1
         }

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -16,6 +16,7 @@ import { EX_SPEC_GIVE } from './give';
 import { EX_SPEC_CORCES_ET_AL } from './corces';
 import { EX_SPEC_PATHOGENIC } from './pathogenic';
 import { EX_SPEC_CYTOBANDS } from './ideograms';
+import { EX_SPEC_CUSTOM_THEME } from './theme';
 import { EX_SPEC_FUJI_PLOT } from './fuji';
 
 export const examples: ReadonlyArray<{
@@ -128,13 +129,18 @@ export const examples: ReadonlyArray<{
     {
         name: 'Breast Cancer Variant (Staaf et al. 2019)',
         id: 'CANCER_VARIANT',
-        spec: EX_SPEC_CANCER_VARIANT,
-        underDevelopment: true
+        spec: EX_SPEC_CANCER_VARIANT
     },
     {
         name: 'Dark Theme (Beta)',
         id: 'DARK_THEME',
         spec: EX_SPEC_DARK_THEME,
+        underDevelopment: true
+    },
+    {
+        name: 'Custom Theme (Beta)',
+        id: 'CUSTOM_THEME',
+        spec: EX_SPEC_CUSTOM_THEME,
         underDevelopment: true
     }
 ].filter(d => !d.hidden);

--- a/src/editor/example/theme.ts
+++ b/src/editor/example/theme.ts
@@ -1,0 +1,266 @@
+import { GoslingSpec } from '../../core/gosling.schema';
+import { GOSLING_PUBLIC_DATA } from './gosling-data';
+
+export const EX_SPEC_CUSTOM_THEME: GoslingSpec = {
+    theme: {
+        base: 'light',
+        track: {
+            outline: 'black'
+        },
+        markCommon: {
+            color: 'black'
+        },
+        brush: {
+            color: 'red',
+            opacity: 1,
+            strokeWidth: 1,
+            stroke: 'red'
+        },
+        legend: {
+            background: '#2E4863',
+            backgroundOpacity: 1,
+            labelColor: 'white'
+        }
+    },
+    title: 'Custom Theme',
+    subtitle: 'Customize the style of Gosling visualizations',
+    layout: 'linear',
+    arrangement: 'vertical',
+    views: [
+        {
+            layout: 'linear',
+            xDomain: { chromosome: '3' },
+            centerRadius: 0.8,
+            tracks: [
+                {
+                    alignment: 'overlay',
+                    title: 'chr3',
+                    data: {
+                        url:
+                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/cytogenetic_band.csv',
+                        type: 'csv',
+                        chromosomeField: 'Chr.',
+                        genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop'],
+                        quantitativeFields: ['Band', 'Density']
+                    },
+                    tracks: [
+                        {
+                            mark: 'text',
+                            dataTransform: [
+                                {
+                                    type: 'filter',
+                                    field: 'Stain',
+                                    oneOf: ['acen-1', 'acen-2'],
+                                    not: true
+                                }
+                            ],
+                            text: { field: 'Band', type: 'nominal' },
+                            color: { value: 'black' },
+                            visibility: [
+                                {
+                                    operation: 'less-than',
+                                    measure: 'width',
+                                    threshold: '|xe-x|',
+                                    transitionPadding: 10,
+                                    target: 'mark'
+                                }
+                            ]
+                        },
+                        {
+                            mark: 'rect',
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-1', 'acen-2'], not: true }],
+                            color: {
+                                field: 'Density',
+                                type: 'nominal',
+                                domain: ['', '25', '50', '75', '100'],
+                                range: ['#E3E3E3', '#D9D9D9', '#979797', '#636363', 'black']
+                            },
+                            size: { value: 20 }
+                        },
+                        {
+                            mark: 'rect',
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['gvar'] }],
+                            color: { value: 'black' },
+                            size: { value: 20 }
+                        },
+                        {
+                            mark: 'triangleRight',
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-1'] }],
+                            color: { value: '#963232' },
+                            size: { value: 20 }
+                        },
+                        {
+                            mark: 'triangleLeft',
+                            dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-2'] }],
+                            color: { value: '#963232' },
+                            size: { value: 20 }
+                        },
+                        {
+                            mark: 'brush',
+                            x: { linkingId: 'detail' },
+                            strokeWidth: { value: 0 }
+                        }
+                    ],
+                    x: { field: 'Basepair_start', type: 'genomic', axis: 'none' },
+                    xe: { field: 'Basepair_stop', type: 'genomic' },
+                    stroke: { value: 'black' },
+                    strokeWidth: { value: 1 },
+                    width: 600,
+                    height: 25
+                }
+            ]
+        },
+        {
+            xDomain: { chromosome: '3', interval: [52168000, 52890000] },
+            linkingId: 'detail',
+            mark: 'bar',
+            x: {
+                field: 'position',
+                type: 'genomic'
+            },
+            y: { field: 'peak', type: 'quantitative' },
+            width: 400,
+            height: 40,
+            tracks: [
+                {
+                    data: {
+                        url:
+                            'https://s3.amazonaws.com/gosling-lang.org/data/ExcitatoryNeurons-insertions_bin100_RIPnorm.bw',
+                        type: 'bigwig',
+                        column: 'position',
+                        value: 'peak'
+                    },
+                    title: 'Excitatory neurons'
+                },
+                {
+                    data: {
+                        url:
+                            'https://s3.amazonaws.com/gosling-lang.org/data/InhibitoryNeurons-insertions_bin100_RIPnorm.bw',
+                        type: 'bigwig',
+                        column: 'position',
+                        value: 'peak'
+                    },
+                    title: 'Inhibitory neurons'
+                },
+                {
+                    data: {
+                        url:
+                            'https://s3.amazonaws.com/gosling-lang.org/data/DopaNeurons_Cluster10_AllFrags_projSUNI2_insertions_bin100_RIPnorm.bw',
+                        type: 'bigwig',
+                        column: 'position',
+                        value: 'peak'
+                    },
+                    title: 'Dopaminergic neurons'
+                },
+                {
+                    alignment: 'overlay',
+                    title: 'Genes',
+                    data: {
+                        url: GOSLING_PUBLIC_DATA.geneAnnotation,
+                        type: 'beddb',
+                        genomicFields: [
+                            { index: 1, name: 'start' },
+                            { index: 2, name: 'end' }
+                        ],
+                        valueFields: [
+                            { index: 5, name: 'strand', type: 'nominal' },
+                            { index: 3, name: 'name', type: 'nominal' }
+                        ],
+                        exonIntervalFields: [
+                            { index: 12, name: 'start' },
+                            { index: 13, name: 'end' }
+                        ]
+                    },
+                    style: { outline: '#20102F' },
+                    tracks: [
+                        {
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['+'] }
+                            ],
+                            mark: 'text',
+                            text: { field: 'name', type: 'nominal' },
+                            x: {
+                                field: 'start',
+                                type: 'genomic'
+                            },
+                            xe: { field: 'end', type: 'genomic' },
+                            style: { textFontSize: 8, dy: -12 }
+                        },
+                        {
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['-'] }
+                            ],
+                            mark: 'text',
+                            text: { field: 'name', type: 'nominal' },
+                            x: { field: 'start', type: 'genomic' },
+                            xe: { field: 'end', type: 'genomic' },
+                            style: { textFontSize: 8, dy: 10 }
+                        },
+                        {
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['+'] }
+                            ],
+                            mark: 'rect',
+                            x: { field: 'end', type: 'genomic' },
+                            size: { value: 7 }
+                        },
+                        {
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['-'] }
+                            ],
+                            mark: 'rect',
+                            x: { field: 'start', type: 'genomic' },
+                            size: { value: 7 }
+                        },
+                        {
+                            dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
+                            mark: 'rect',
+                            x: { field: 'start', type: 'genomic' },
+                            xe: { field: 'end', type: 'genomic' },
+                            size: { value: 14 }
+                        },
+                        {
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['-'] }
+                            ],
+                            mark: 'rule',
+                            x: { field: 'start', type: 'genomic' },
+                            xe: { field: 'end', type: 'genomic' },
+                            strokeWidth: { value: 1 },
+                            style: { linePattern: { size: 3, type: 'triangleLeft' } }
+                        },
+                        {
+                            dataTransform: [
+                                { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                { type: 'filter', field: 'strand', oneOf: ['+'] }
+                            ],
+                            mark: 'rule',
+                            x: { field: 'start', type: 'genomic' },
+                            xe: { field: 'end', type: 'genomic' },
+                            strokeWidth: { value: 1 },
+                            style: { linePattern: { size: 3, type: 'triangleRight' } }
+                        }
+                    ],
+                    row: { field: 'strand', type: 'nominal', domain: ['+', '-'] },
+                    color: { field: 'strand', type: 'nominal', domain: ['+', '-'], range: ['#006300', '#0C0C78'] },
+                    visibility: [
+                        {
+                            operation: 'less-than',
+                            measure: 'width',
+                            threshold: '|xe-x|',
+                            transitionPadding: 10,
+                            target: 'mark'
+                        }
+                    ],
+                    width: 600,
+                    height: 80
+                }
+            ]
+        }
+    ]
+};

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -499,9 +499,11 @@ export const EX_SPEC_VISUAL_ENCODING_CIRCULAR: GoslingSpec = {
 export const EX_SPEC_DARK_THEME: GoslingSpec = {
     theme: {
         base: 'dark',
-        nominalColors: ['white', 'gray'],
-        markColor: 'gray',
-        markStrokeColor: 'black'
+        markCommon: {
+            color: 'gray',
+            nominalColorRange: ['white', 'gray'],
+            stroke: 'black'
+        }
     },
     title: 'Dark Theme (Beta)',
     subtitle: 'Gosling allows to easily change the color theme using a `theme` property',


### PR DESCRIPTION
(This PR is not yet finalized.)

This PR will allow a way to customize themes. Currently, it provides two basic themes, `light` and `dark` (as started to support via #359), and users can customize them. The supported styles are defined in [src/core/utils/theme.ts](src/core/utils/theme.ts), which include changing the color of titles, axis components (e.g., labels, baseline, ticks), track outlines/background, and legends, and changing the visual properties of marks (e.g., default colors/size of marks).

![Screen Shot 2021-04-26 at 9 51 13 PM](https://user-images.githubusercontent.com/9922882/116172887-8f773380-a6d9-11eb-9246-0417cb623c8e.png)

Towards #117

**To Do & Open Questions**
- [ ] Define a custom theme separately from the main Gosling.js spec? (e.g., `<GoslingComponent spec={s} theme={t}/>`).
- [ ] Need to create a separate GitHub repository to provide predefined themes and typescript types, `gosling-themes` (In a separate PR).
- [ ] All mark-specific properties should be reflected in the visualization.
- [ ] Allow using predefined string values for specific-purpose colors (e.g., `range: "strandColors"` for + and - strands and `range: "ATGC" for four different colors for the bases, ..., "chromosomeColors"). These will be defined in themes and will be changed when a theme is switched (e.g., dark blue colors for "strandColors" and black for "ATGC" for a "UCSC" theme).
   -  For "igv.js", "ATGC" can be ["#00C800", "#FF0000", "#D17105", "#0000C8"] and "gene" can be "#000096", referring to https://igv.org/web/release/2.8.1/examples/cram-vcf.html.
- [x] Should override a child property if `undefined`
