### PR TITLE
feat: support y-axis

### DIFF
--- a/src/core/gosling-track-model.test.ts
+++ b/src/core/gosling-track-model.test.ts
@@ -130,6 +130,11 @@ describe('Gosling track model should be properly generated with data', () => {
         const rowDomain = IsChannelDeep(spec.row) ? (spec.row.domain as string[]) : [];
         const yDomain = IsChannelDeep(spec.y) ? (spec.y.domain as number[]) : [];
 
+        // model properties
+        expect(model.getChannelDomainArray('color')).toHaveLength(3);
+        expect(model.getChannelRangeArray('color')).not.toBeUndefined();
+        expect(model.isShowYAxis()).toBe(true);
+
         // domain
         expect(colorDomain).not.toBeUndefined();
         expect(colorDomain[0]).toBe(1);

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -28,7 +28,8 @@ import {
     IsShallowMark,
     IsStackedChannel,
     IsDomainArray,
-    PREDEFINED_COLOR_STR_MAP
+    PREDEFINED_COLOR_STR_MAP,
+    IsRangeArray
 } from './gosling.schema.guards';
 import { CHANNEL_DEFAULTS } from './channel';
 import { getTheme, Theme } from './utils/theme';
@@ -808,12 +809,33 @@ export class GoslingTrackModel {
     }
 
     /**
+     * Return whether to show y-axis.
+     */
+    public isShowYAxis(): boolean {
+        const spec = this.spec();
+        const yDomain = this.getChannelDomainArray('y');
+        const yRange = this.getChannelRangeArray('y');
+        return (
+            IsChannelDeep(spec.y) && spec.y.axis !== 'none' && spec.y.type === 'quantitative' && !!yDomain && !!yRange
+        );
+    }
+
+    /**
      * Return the domain of a visual channel.
      * `undefined` if we do not have domain in array.
      */
     public getChannelDomainArray(channelKey: keyof typeof ChannelTypes): string[] | number[] | undefined {
         const c = this.spec()[channelKey];
         return IsChannelDeep(c) && IsDomainArray(c.domain) ? c.domain : undefined;
+    }
+
+    /**
+     * Return the range of a visual channel.
+     * `undefined` if we do not have domain in array.
+     */
+    public getChannelRangeArray(channelKey: keyof typeof ChannelTypes): string[] | number[] | undefined {
+        const c = this.spec()[channelKey];
+        return IsChannelDeep(c) && IsRangeArray(c.range) ? c.range : undefined;
     }
 
     /**

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -30,7 +30,8 @@ import {
     SingleView,
     FlatTracks,
     OverlaidTracks,
-    StackedTracks
+    StackedTracks,
+    Range
 } from './gosling.schema';
 import { SUPPORTED_CHANNELS } from './mark';
 import { isArray } from 'lodash';
@@ -168,6 +169,13 @@ export function IsIncludeFilter(_: FilterTransform): _ is IncludeFilter {
  */
 export function IsDomainArray(domain?: Domain): domain is string[] | number[] {
     return isArray(domain);
+}
+
+/**
+ * Check whether range is in array shape.
+ */
+export function IsRangeArray(range?: Range): range is string[] | number[] {
+    return isArray(range);
 }
 
 // TODO: perhaps, combine this with `isStackedChannel`

--- a/src/core/mark/axis.test.ts
+++ b/src/core/mark/axis.test.ts
@@ -1,0 +1,78 @@
+import * as PIXI from 'pixi.js';
+import { GoslingTrackModel } from '../gosling-track-model';
+import { SingleTrack } from '../gosling.schema';
+import { drawLinearYAxis } from './axis';
+
+describe('Y Axis', () => {
+    const g = new PIXI.Graphics();
+    it('Linear', () => {
+        const t: SingleTrack = {
+            data: { type: 'csv', url: '' },
+            mark: 'line',
+            x: { field: 'x', type: 'genomic' },
+            y: { field: 'y', type: 'quantitative' },
+            width: 100,
+            height: 100
+        };
+        const d = [
+            { x: 1, y: 2 },
+            { x: 11, y: 22 },
+            { x: 111, y: 222 }
+        ];
+        const model = new GoslingTrackModel(t, d);
+        drawLinearYAxis(
+            {
+                libraries: {
+                    PIXI: {
+                        Text: PIXI.Text
+                    }
+                }
+            },
+            {
+                dimensions: [100, 400],
+                position: [0, 0],
+                pBorder: g
+            },
+            null,
+            model
+        );
+    });
+
+    it('Circular', () => {
+        const t: SingleTrack = {
+            layout: 'circular',
+            startAngle: 0,
+            endAngle: 240,
+            innerRadius: 10,
+            outerRadius: 40,
+            data: { type: 'csv', url: '' },
+            mark: 'line',
+            x: { field: 'x', type: 'genomic' },
+            y: { field: 'y', type: 'quantitative', axis: 'right' },
+            width: 100,
+            height: 100
+        };
+        const d = [
+            { x: 1, y: 2 },
+            { x: 11, y: 22 },
+            { x: 111, y: 222 }
+        ];
+        const model = new GoslingTrackModel(t, d);
+        drawLinearYAxis(
+            {
+                libraries: {
+                    PIXI: {
+                        Text: PIXI.Text
+                    }
+                }
+            },
+            {
+                dimensions: [100, 400],
+                position: [0, 0],
+                pBorder: g
+            },
+            null,
+            model
+        );
+    });
+});

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -1,0 +1,158 @@
+import { GoslingTrackModel } from '../gosling-track-model';
+import { IsChannelDeep } from '../gosling.schema.guards';
+import colorToHex from '../utils/color-to-hex';
+import { getTheme, Theme } from '../utils/theme';
+import { scaleLinear } from 'd3-scale';
+
+/**
+ * Axis text styles
+ */
+export const getAxisTextStyle = (fill = 'black') => {
+    return {
+        fontSize: '10px',
+        fontFamily: 'Arial',
+        fontWeight: 'normal',
+        fill,
+        background: 'white',
+        lineJoin: 'round'
+        // stroke: '#ffffff',
+        // strokeThickness: 2
+    };
+};
+
+/**
+ * Draw linear scale Y axis
+ */
+export function drawYAxis(HGC: any, trackInfo: any, tile: any, gos: GoslingTrackModel, theme: Theme = 'light') {
+    const yDomain = gos.getChannelDomainArray('y');
+    const yRange = gos.getChannelRangeArray('y');
+
+    if (!gos.isShowYAxis() || !yDomain || !yRange) {
+        // We do not need to draw a y-axis
+        return;
+    }
+
+    /* track size */
+    const [tw, th] = trackInfo.dimensions;
+    const [tx, ty] = trackInfo.position;
+
+    /* row separation */
+    const rowCategories: string[] = (gos.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
+    const rowHeight = th / rowCategories.length;
+
+    if (rowHeight <= 20) {
+        // Height is too narrow to draw axis
+        return;
+    }
+
+    /* Axis components */
+    const yChannel = gos.spec().y;
+    const isLeft = IsChannelDeep(yChannel) && yChannel.axis === 'right' ? false : true; // Right only if explicitly specified
+    const yScale = scaleLinear()
+        .domain(yDomain as number[])
+        .range(yRange as number[]);
+
+    /* render */
+    const graphics = trackInfo.pBorder;
+
+    rowCategories.forEach((category, i) => {
+        if (i !== 0) {
+            // Let's draw only one y-axis since the scale is shared anyway.
+            return;
+        }
+
+        const rowPosition = gos.encodedValue('row', category);
+        const dx = isLeft ? tx : tx + tw;
+        const dy = ty + rowPosition;
+
+        /* Axis Baseline */
+        graphics.lineStyle(
+            1,
+            colorToHex(getTheme(theme).axis.baselineColor),
+            1, // alpha
+            0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+        );
+        graphics.moveTo(dx, dy);
+        graphics.lineTo(dx, dy + rowHeight);
+
+        /* Ticks */
+        const EXTENT_TICK_SIZE = 8;
+        const TICK_SIZE = 6;
+        const tickCount = Math.max(Math.ceil(rowHeight / 40), 1);
+        let ticks = yScale.ticks(tickCount).filter(v => yDomain[0] <= v && v <= yDomain[1]);
+
+        if (ticks.length === 1) {
+            // Sometimes, ticks() gives a single value, so use a larger tickCount.
+            ticks = yScale.ticks(tickCount + 1).filter(v => yDomain[0] <= v && v <= yDomain[1]);
+        }
+
+        graphics.lineStyle(
+            1,
+            colorToHex(getTheme(theme).axis.tickColor),
+            1, // alpha
+            0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+        );
+        let tickEnd = isLeft ? dx + TICK_SIZE : dx - TICK_SIZE;
+        ticks.forEach(t => {
+            const y = yScale(t);
+            graphics.moveTo(dx, dy + rowHeight - y);
+            graphics.lineTo(tickEnd, dy + rowHeight - y);
+        });
+
+        // Two ticks on the bottom and top
+        tickEnd = isLeft ? dx + EXTENT_TICK_SIZE : dx - EXTENT_TICK_SIZE;
+        graphics.moveTo(dx, dy);
+        graphics.lineTo(tickEnd, dy);
+        graphics.moveTo(dx, dy + rowHeight);
+        graphics.lineTo(tickEnd, dy + rowHeight);
+
+        /* Labels */
+        ticks.forEach(t => {
+            const y = yScale(t);
+            tickEnd = isLeft ? dx + TICK_SIZE * 2 : dx - TICK_SIZE * 2;
+
+            const textGraphic = new HGC.libraries.PIXI.Text(t, getAxisTextStyle(getTheme(theme).legend.labelColor));
+            textGraphic.anchor.x = isLeft ? 0 : 1;
+            textGraphic.anchor.y = y === 0 ? 0.9 : 0.5;
+            textGraphic.position.x = tickEnd;
+            textGraphic.position.y = dy + rowHeight - y;
+
+            graphics.addChild(textGraphic);
+        });
+    });
+
+    // const paddingX = 4;
+    // const paddingY = 2;
+
+    // rowCategories.forEach(category => {
+    //     const rowPosition = gos.encodedValue('row', category);
+
+    //     const textGraphic = new HGC.libraries.PIXI.Text(
+    //         category,
+    //         getLegendTextStyle(getTheme(theme).legend.labelColor)
+    //     );
+    //     textGraphic.anchor.x = 0;
+    //     textGraphic.anchor.y = 0;
+    //     textGraphic.position.x = trackInfo.position[0] + paddingX;
+    //     textGraphic.position.y = trackInfo.position[1] + rowPosition + paddingY;
+
+    //     graphics.addChild(textGraphic);
+
+    //     const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(getTheme(theme).legend.labelColor));
+    //     const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
+
+    //     graphics.beginFill(colorToHex(getTheme(theme).legend.background), getTheme(theme).legend.backgroundOpacity);
+    //     graphics.lineStyle(
+    //         1,
+    //         colorToHex(getTheme(theme).legend.backgroundStroke),
+    //         0, // alpha
+    //         0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+    //     );
+    //     graphics.drawRect(
+    //         trackInfo.position[0] + 1,
+    //         trackInfo.position[1] + rowPosition + 1,
+    //         textMetrics.width + paddingX * 2,
+    //         textMetrics.height + paddingY * 2
+    //     );
+    // });
+}

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -3,6 +3,7 @@ import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
 import { getTheme, Theme } from '../utils/theme';
 import { scaleLinear } from 'd3-scale';
+import { cartesianToPolar, valueToRadian } from '../utils/polar';
 
 /**
  * Axis text styles
@@ -23,9 +24,16 @@ export const getAxisTextStyle = (fill = 'black') => {
 /**
  * Draw linear scale Y axis
  */
-export function drawYAxis(HGC: any, trackInfo: any, tile: any, gos: GoslingTrackModel, theme: Theme = 'light') {
+export function drawLinearYAxis(HGC: any, trackInfo: any, tile: any, gos: GoslingTrackModel, theme: Theme = 'light') {
+    const spec = gos.spec();
+    const CIRCULAR = spec.layout === 'circular';
     const yDomain = gos.getChannelDomainArray('y');
     const yRange = gos.getChannelRangeArray('y');
+
+    if (CIRCULAR) {
+        // Wrong function, this is for linear tracks
+        return;
+    }
 
     if (!gos.isShowYAxis() || !yDomain || !yRange) {
         // We do not need to draw a y-axis
@@ -47,7 +55,7 @@ export function drawYAxis(HGC: any, trackInfo: any, tile: any, gos: GoslingTrack
 
     /* Axis components */
     const yChannel = gos.spec().y;
-    const isLeft = IsChannelDeep(yChannel) && yChannel.axis === 'right' ? false : true; // Right only if explicitly specified
+    const isLeft = IsChannelDeep(yChannel) && yChannel.axis === 'right' ? false : true; // Right position only if explicitly specified
     const yScale = scaleLinear()
         .domain(yDomain as number[])
         .range(yRange as number[]);
@@ -120,39 +128,165 @@ export function drawYAxis(HGC: any, trackInfo: any, tile: any, gos: GoslingTrack
             graphics.addChild(textGraphic);
         });
     });
+}
 
-    // const paddingX = 4;
-    // const paddingY = 2;
+/**
+ * Draw linear scale Y axis
+ */
+export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: GoslingTrackModel, theme: Theme = 'light') {
+    const spec = gos.spec();
+    const CIRCULAR = spec.layout === 'circular';
+    const yDomain = gos.getChannelDomainArray('y');
+    const yRange = gos.getChannelRangeArray('y');
 
-    // rowCategories.forEach(category => {
-    //     const rowPosition = gos.encodedValue('row', category);
+    if (!CIRCULAR) {
+        // Wrong function, this is for circular tracks
+        return;
+    }
 
-    //     const textGraphic = new HGC.libraries.PIXI.Text(
-    //         category,
-    //         getLegendTextStyle(getTheme(theme).legend.labelColor)
-    //     );
-    //     textGraphic.anchor.x = 0;
-    //     textGraphic.anchor.y = 0;
-    //     textGraphic.position.x = trackInfo.position[0] + paddingX;
-    //     textGraphic.position.y = trackInfo.position[1] + rowPosition + paddingY;
+    if (!gos.isShowYAxis() || !yDomain || !yRange) {
+        // We do not need to draw a y-axis
+        return;
+    }
 
-    //     graphics.addChild(textGraphic);
+    /* track size */
+    const [tw, th] = [spec.width, spec.height];
+    // const [tx, ty] = trackInfo.position;
 
-    //     const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(getTheme(theme).legend.labelColor));
-    //     const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
+    /* circular parameters */
+    const trackInnerRadius = spec.innerRadius ?? 220;
+    const trackOuterRadius = spec.outerRadius ?? 300;
+    const trackRingSize = trackOuterRadius - trackInnerRadius;
+    const startAngle = spec.startAngle ?? 0;
+    const endAngle = spec.endAngle ?? 360;
+    const cx = tw / 2.0;
+    const cy = th / 2.0;
 
-    //     graphics.beginFill(colorToHex(getTheme(theme).legend.background), getTheme(theme).legend.backgroundOpacity);
-    //     graphics.lineStyle(
-    //         1,
-    //         colorToHex(getTheme(theme).legend.backgroundStroke),
-    //         0, // alpha
-    //         0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
-    //     );
-    //     graphics.drawRect(
-    //         trackInfo.position[0] + 1,
-    //         trackInfo.position[1] + rowPosition + 1,
-    //         textMetrics.width + paddingX * 2,
-    //         textMetrics.height + paddingY * 2
-    //     );
-    // });
+    /* row separation */
+    const rowCategories: string[] = (gos.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
+    const rowHeight = th / rowCategories.length;
+
+    if (rowHeight <= 20) {
+        // Height is too narrow to draw axis
+        return;
+    }
+
+    /* Axis components */
+    // const yChannel = gos.spec().y;
+    // const isLeft = IsChannelDeep(yChannel) && yChannel.axis === 'right' ? false : true; // Right position only if explicitly specified
+    const yScale = scaleLinear()
+        .domain(yDomain as number[])
+        .range(yRange as number[]);
+
+    /* render */
+    const graphics = tile.graphics; // We do not use `pBorder` as in linear layouts.
+
+    rowCategories.forEach((category, i) => {
+        if (i !== 0) {
+            // Let's draw only one y-axis since the scale is shared anyway.
+            return;
+        }
+
+        const rowPosition = gos.encodedValue('row', category);
+        const innerR = trackOuterRadius - ((rowPosition + rowHeight) / th) * trackRingSize;
+        const outerR = trackOuterRadius - (rowPosition / th) * trackRingSize;
+        const innerPos = cartesianToPolar(0, tw, innerR, cx, cy, startAngle, endAngle);
+        const outerPos = cartesianToPolar(0, tw, outerR, cx, cy, startAngle, endAngle);
+
+        /* Axis Baseline */
+        graphics.lineStyle(
+            1,
+            colorToHex(getTheme(theme).axis.baselineColor),
+            1, // alpha
+            0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+        );
+        graphics.moveTo(innerPos.x, innerPos.y);
+        graphics.lineTo(outerPos.x, outerPos.y);
+
+        /* Ticks */
+        // const EXTENT_TICK_SIZE = 8;
+        const TICK_SIZE = 2;
+        const tickCount = Math.max(Math.ceil(rowHeight / 40 / 2), 1);
+        let ticks = yScale.ticks(tickCount).filter(v => yDomain[0] <= v && v <= yDomain[1]);
+
+        if (ticks.length === 1) {
+            // Sometimes, ticks() gives a single value, so use a larger tickCount.
+            ticks = yScale.ticks(tickCount + 1).filter(v => yDomain[0] <= v && v <= yDomain[1]);
+        }
+
+        graphics.lineStyle(
+            1,
+            colorToHex(getTheme(theme).axis.tickColor),
+            1, // alpha
+            0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+        );
+        ticks.forEach(t => {
+            const y = yScale(t);
+            const midR = trackOuterRadius - ((rowPosition + y) / th) * trackRingSize;
+            const pos = cartesianToPolar(0, tw, midR, cx, cy, startAngle, endAngle);
+            const startRad = valueToRadian(0, tw, startAngle, endAngle);
+            const endRad = valueToRadian(TICK_SIZE, tw, startAngle, endAngle); // TODO:
+            graphics.moveTo(pos.x, pos.y);
+            graphics.arc(cx, cy, midR, startRad, endRad, true);
+            graphics.arc(cx, cy, midR + 1, endRad, startRad, false);
+            graphics.closePath();
+        });
+
+        // Two ticks on the bottom and top
+        let startRad = valueToRadian(0, tw, startAngle, endAngle);
+        let endRad = valueToRadian(TICK_SIZE, tw, startAngle, endAngle);
+        graphics.moveTo(innerPos.x, innerPos.y);
+        graphics.arc(cx, cy, trackInnerRadius, startRad, endRad, true);
+        graphics.arc(cx, cy, trackInnerRadius + 1, endRad, startRad, false);
+        graphics.closePath();
+
+        startRad = valueToRadian(0, tw, startAngle, endAngle);
+        endRad = valueToRadian(TICK_SIZE, tw, startAngle, endAngle); // TODO:
+        graphics.moveTo(outerPos.x, outerPos.y);
+        graphics.arc(cx, cy, trackOuterRadius, startRad, endRad, true);
+        graphics.arc(cx, cy, trackOuterRadius + 1, endRad, startRad, false);
+        graphics.closePath();
+
+        /* Labels */
+        ticks.forEach(t => {
+            const y = yScale(t);
+            const midR = trackOuterRadius - ((rowPosition + y) / th) * trackRingSize;
+            const pos = cartesianToPolar(TICK_SIZE * 2, tw, midR, cx, cy, startAngle, endAngle);
+
+            const textGraphic = new HGC.libraries.PIXI.Text(t, getAxisTextStyle(getTheme(theme).legend.labelColor));
+            textGraphic.anchor.x = 1;
+            textGraphic.anchor.y = 0.5;
+            textGraphic.position.x = pos.x;
+            textGraphic.position.y = pos.y;
+
+            textGraphic.resolution = 4;
+            const txtStyle = new HGC.libraries.PIXI.TextStyle(getAxisTextStyle());
+            const metric = HGC.libraries.PIXI.TextMetrics.measureText(textGraphic.text, txtStyle);
+
+            // scale the width of text label so that its width is the same when converted into circular form
+            const textw = ((metric.width / (2 * midR * Math.PI)) * tw * 360) / (endAngle - startAngle);
+            let [minX, maxX] = [TICK_SIZE * 2, TICK_SIZE * 2 + textw];
+
+            // make sure not to place the label on the origin
+            if (minX < 0) {
+                const gap = -minX;
+                minX = 0;
+                maxX += gap;
+            } else if (maxX > tw) {
+                const gap = maxX - tw;
+                maxX = tw;
+                minX -= gap;
+            }
+
+            const ropePoints: number[] = [];
+            for (let i = maxX; i >= minX; i -= textw / 10.0) {
+                const p = cartesianToPolar(i, tw, midR, tw / 2.0, th / 2.0, startAngle, endAngle);
+                ropePoints.push(new HGC.libraries.PIXI.Point(p.x, p.y));
+            }
+
+            textGraphic.updateText();
+            const rope = new HGC.libraries.PIXI.SimpleRope(textGraphic.texture, ropePoints);
+            graphics.addChild(rope);
+        });
+    });
 }

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -66,12 +66,12 @@ export function drawLinearYAxis(HGC: any, trackInfo: any, tile: any, gos: Goslin
     /* render */
     const graphics = trackInfo.pBorder;
 
-    rowCategories.forEach((category, i) => {
-        if (rowCategories.length > 1 ? i !== 1 : i !== 0) {
-            // Let's draw only one y-axis since the scale is shared anyway.
-            // Draw the second y-axis if exist, so that track title is not occluded by the y-axis.
-            return;
-        }
+    rowCategories.forEach(category => {
+        // if (rowCategories.length > 1 ? i !== 1 : i !== 0) {
+        //     // Let's draw only one y-axis since the scale is shared anyway.
+        //     // Draw the second y-axis if exist, so that track title is not occluded by the y-axis.
+        //     return;
+        // }
 
         const rowPosition = gos.encodedValue('row', category);
         const dx = isLeft ? tx : tx + tw;
@@ -182,12 +182,12 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
     /* render */
     const graphics = tile.graphics; // We do not use `pBorder` as in linear layouts.
 
-    rowCategories.forEach((category, i) => {
-        if (rowCategories.length > 1 ? i !== 1 : i !== 0) {
-            // Let's draw only one y-axis since the scale is shared anyway.
-            // Draw the second y-axis if exist, so that track title is not occluded by the y-axis.
-            return;
-        }
+    rowCategories.forEach(category => {
+        // if (rowCategories.length > 1 ? i !== 1 : i !== 0) {
+        //     // Let's draw only one y-axis since the scale is shared anyway.
+        //     // Draw the second y-axis if exist, so that track title is not occluded by the y-axis.
+        //     return;
+        // }
 
         const rowPosition = gos.encodedValue('row', category);
 
@@ -232,7 +232,7 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
             const y = yScale(t);
 
             // The current position, i.e., radius, of this tick
-            const currentR = trackOuterRadius - ((rowPosition + y) / th) * trackRingSize;
+            const currentR = trackOuterRadius - ((rowPosition + rowHeight - y) / th) * trackRingSize;
 
             // Ticks are drawn in anti-clockwise direction
             const scaledStartX = isLeft ? 0 : tw - SCALED_TICK_SIZE(currentR);
@@ -283,7 +283,7 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
             const y = yScale(t);
 
             // The current position, i.e., radius, of this label
-            const currentR = trackOuterRadius - ((rowPosition + y) / th) * trackRingSize;
+            const currentR = trackOuterRadius - ((rowPosition + rowHeight - y) / th) * trackRingSize;
 
             // The position of a tick in the polar system
             const pos = cartesianToPolar(SCALED_TICK_SIZE(currentR) * 2, tw, currentR, cx, cy, startAngle, endAngle);

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -67,8 +67,9 @@ export function drawLinearYAxis(HGC: any, trackInfo: any, tile: any, gos: Goslin
     const graphics = trackInfo.pBorder;
 
     rowCategories.forEach((category, i) => {
-        if (i !== 0) {
+        if (rowCategories.length > 1 ? i !== 1 : i !== 0) {
             // Let's draw only one y-axis since the scale is shared anyway.
+            // Draw the second y-axis if exist, so that track title is not occluded by the y-axis.
             return;
         }
 
@@ -182,8 +183,9 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
     const graphics = tile.graphics; // We do not use `pBorder` as in linear layouts.
 
     rowCategories.forEach((category, i) => {
-        if (i !== 0) {
+        if (rowCategories.length > 1 ? i !== 1 : i !== 0) {
             // Let's draw only one y-axis since the scale is shared anyway.
+            // Draw the second y-axis if exist, so that track title is not occluded by the y-axis.
             return;
         }
 

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -5,6 +5,9 @@ import { getTheme, Theme } from '../utils/theme';
 import { scaleLinear } from 'd3-scale';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 
+const EXTENT_TICK_SIZE = 8;
+const TICK_SIZE = 6;
+
 /**
  * Axis text styles
  */
@@ -31,7 +34,7 @@ export function drawLinearYAxis(HGC: any, trackInfo: any, tile: any, gos: Goslin
     const yRange = gos.getChannelRangeArray('y');
 
     if (CIRCULAR) {
-        // Wrong function, this is for linear tracks
+        // Wrong function call, this is for linear tracks!
         return;
     }
 
@@ -84,8 +87,6 @@ export function drawLinearYAxis(HGC: any, trackInfo: any, tile: any, gos: Goslin
         graphics.lineTo(dx, dy + rowHeight);
 
         /* Ticks */
-        const EXTENT_TICK_SIZE = 8;
-        const TICK_SIZE = 6;
         const tickCount = Math.max(Math.ceil(rowHeight / 40), 1);
         let ticks = yScale.ticks(tickCount).filter(v => yDomain[0] <= v && v <= yDomain[1]);
 
@@ -140,7 +141,7 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
     const yRange = gos.getChannelRangeArray('y');
 
     if (!CIRCULAR) {
-        // Wrong function, this is for circular tracks
+        // Wrong function call, this is for circular tracks.
         return;
     }
 
@@ -151,7 +152,6 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
 
     /* track size */
     const [tw, th] = [spec.width, spec.height];
-    // const [tx, ty] = trackInfo.position;
 
     /* circular parameters */
     const trackInnerRadius = spec.innerRadius ?? 220;
@@ -166,14 +166,14 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
     const rowCategories: string[] = (gos.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
     const rowHeight = th / rowCategories.length;
 
-    if (rowHeight <= 20) {
+    if ((rowHeight / th) * trackRingSize <= 20) {
         // Height is too narrow to draw axis
         return;
     }
 
     /* Axis components */
-    // const yChannel = gos.spec().y;
-    // const isLeft = IsChannelDeep(yChannel) && yChannel.axis === 'right' ? false : true; // Right position only if explicitly specified
+    const yChannel = gos.spec().y;
+    const isLeft = IsChannelDeep(yChannel) && yChannel.axis === 'right' ? false : true; // Right position only if explicitly specified
     const yScale = scaleLinear()
         .domain(yDomain as number[])
         .range(yRange as number[]);
@@ -188,12 +188,13 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
         }
 
         const rowPosition = gos.encodedValue('row', category);
-        const innerR = trackOuterRadius - ((rowPosition + rowHeight) / th) * trackRingSize;
-        const outerR = trackOuterRadius - (rowPosition / th) * trackRingSize;
-        const innerPos = cartesianToPolar(0, tw, innerR, cx, cy, startAngle, endAngle);
-        const outerPos = cartesianToPolar(0, tw, outerR, cx, cy, startAngle, endAngle);
 
         /* Axis Baseline */
+        const innerR = trackOuterRadius - ((rowPosition + rowHeight) / th) * trackRingSize;
+        const outerR = trackOuterRadius - (rowPosition / th) * trackRingSize;
+        const innerPos = cartesianToPolar(isLeft ? 0 : tw, tw, innerR, cx, cy, startAngle, endAngle);
+        const outerPos = cartesianToPolar(isLeft ? 0 : tw, tw, outerR, cx, cy, startAngle, endAngle);
+
         graphics.lineStyle(
             1,
             colorToHex(getTheme(theme).axis.baselineColor),
@@ -204,16 +205,21 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
         graphics.lineTo(outerPos.x, outerPos.y);
 
         /* Ticks */
-        // const EXTENT_TICK_SIZE = 8;
-        const TICK_SIZE = 2;
-        const tickCount = Math.max(Math.ceil(rowHeight / 40 / 2), 1);
+        // Since we use the polar system, we use numbers 'scaled' for the polar system.
+        const SCALED_TICK_SIZE = (r: number) => (TICK_SIZE * tw) / 2 / Math.PI / r;
+        const SCALED_EXTENT_TICK_SIZE = (r: number) => (EXTENT_TICK_SIZE * tw) / 2 / Math.PI / r;
+
+        // Determine ticks to display
+        const axisHeight = (rowHeight / th) * trackRingSize;
+        const tickCount = Math.max(Math.ceil(axisHeight / 40), 1);
         let ticks = yScale.ticks(tickCount).filter(v => yDomain[0] <= v && v <= yDomain[1]);
 
         if (ticks.length === 1) {
-            // Sometimes, ticks() gives a single value, so use a larger tickCount.
+            // Sometimes, ticks() gives a single tick (e.g., only baseline), so let's use a larger tickCount.
             ticks = yScale.ticks(tickCount + 1).filter(v => yDomain[0] <= v && v <= yDomain[1]);
         }
 
+        // Render ticks
         graphics.lineStyle(
             1,
             colorToHex(getTheme(theme).axis.tickColor),
@@ -222,39 +228,67 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
         );
         ticks.forEach(t => {
             const y = yScale(t);
-            const midR = trackOuterRadius - ((rowPosition + y) / th) * trackRingSize;
-            const pos = cartesianToPolar(0, tw, midR, cx, cy, startAngle, endAngle);
-            const startRad = valueToRadian(0, tw, startAngle, endAngle);
-            const endRad = valueToRadian(TICK_SIZE, tw, startAngle, endAngle); // TODO:
+
+            // The current position, i.e., radius, of this tick
+            const currentR = trackOuterRadius - ((rowPosition + y) / th) * trackRingSize;
+
+            // Ticks are drawn in anti-clockwise direction
+            const scaledStartX = isLeft ? 0 : tw - SCALED_TICK_SIZE(currentR);
+            const scaledEndX = isLeft ? SCALED_TICK_SIZE(currentR) : tw;
+
+            // The position of a tick in the polar system
+            const pos = cartesianToPolar(scaledStartX, tw, currentR, cx, cy, startAngle, endAngle);
+            const startRad = valueToRadian(scaledStartX, tw, startAngle, endAngle);
+            const endRad = valueToRadian(scaledEndX, tw, startAngle, endAngle);
+
+            // Render a tick
             graphics.moveTo(pos.x, pos.y);
-            graphics.arc(cx, cy, midR, startRad, endRad, true);
-            graphics.arc(cx, cy, midR + 1, endRad, startRad, false);
+            graphics.arc(cx, cy, currentR, startRad, endRad, true);
+            graphics.arc(cx, cy, currentR, endRad, startRad, false);
             graphics.closePath();
         });
 
         // Two ticks on the bottom and top
-        let startRad = valueToRadian(0, tw, startAngle, endAngle);
-        let endRad = valueToRadian(TICK_SIZE, tw, startAngle, endAngle);
-        graphics.moveTo(innerPos.x, innerPos.y);
-        graphics.arc(cx, cy, trackInnerRadius, startRad, endRad, true);
-        graphics.arc(cx, cy, trackInnerRadius + 1, endRad, startRad, false);
-        graphics.closePath();
+        {
+            // The inner tick
+            const scaledStartX = isLeft ? 0 : tw - SCALED_EXTENT_TICK_SIZE(trackInnerRadius);
+            const scaledEndX = isLeft ? SCALED_EXTENT_TICK_SIZE(trackInnerRadius) : tw;
 
-        startRad = valueToRadian(0, tw, startAngle, endAngle);
-        endRad = valueToRadian(TICK_SIZE, tw, startAngle, endAngle); // TODO:
-        graphics.moveTo(outerPos.x, outerPos.y);
-        graphics.arc(cx, cy, trackOuterRadius, startRad, endRad, true);
-        graphics.arc(cx, cy, trackOuterRadius + 1, endRad, startRad, false);
-        graphics.closePath();
+            const startRad = valueToRadian(scaledStartX, tw, startAngle, endAngle);
+            const endRad = valueToRadian(scaledEndX, tw, startAngle, endAngle);
+
+            graphics.moveTo(innerPos.x, innerPos.y);
+            graphics.arc(cx, cy, trackInnerRadius, startRad, endRad, true);
+            graphics.arc(cx, cy, trackInnerRadius, endRad, startRad, false);
+            graphics.closePath();
+        }
+        {
+            // The outer tick
+            const scaledStartX = isLeft ? 0 : tw - SCALED_EXTENT_TICK_SIZE(trackOuterRadius);
+            const scaledEndX = isLeft ? SCALED_EXTENT_TICK_SIZE(trackOuterRadius) : tw;
+
+            const startRad = valueToRadian(scaledStartX, tw, startAngle, endAngle);
+            const endRad = valueToRadian(scaledEndX, tw, startAngle, endAngle);
+
+            graphics.moveTo(outerPos.x, outerPos.y);
+            graphics.arc(cx, cy, trackOuterRadius, startRad, endRad, true);
+            graphics.arc(cx, cy, trackOuterRadius, endRad, startRad, false);
+            graphics.closePath();
+        }
 
         /* Labels */
         ticks.forEach(t => {
             const y = yScale(t);
-            const midR = trackOuterRadius - ((rowPosition + y) / th) * trackRingSize;
-            const pos = cartesianToPolar(TICK_SIZE * 2, tw, midR, cx, cy, startAngle, endAngle);
 
+            // The current position, i.e., radius, of this label
+            const currentR = trackOuterRadius - ((rowPosition + y) / th) * trackRingSize;
+
+            // The position of a tick in the polar system
+            const pos = cartesianToPolar(SCALED_TICK_SIZE(currentR) * 2, tw, currentR, cx, cy, startAngle, endAngle);
+
+            // ! Maybe combine this part with `axis-plugin-track.ts`
             const textGraphic = new HGC.libraries.PIXI.Text(t, getAxisTextStyle(getTheme(theme).legend.labelColor));
-            textGraphic.anchor.x = 1;
+            textGraphic.anchor.x = isLeft ? 1 : 0;
             textGraphic.anchor.y = 0.5;
             textGraphic.position.x = pos.x;
             textGraphic.position.y = pos.y;
@@ -263,27 +297,21 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
             const txtStyle = new HGC.libraries.PIXI.TextStyle(getAxisTextStyle());
             const metric = HGC.libraries.PIXI.TextMetrics.measureText(textGraphic.text, txtStyle);
 
-            // scale the width of text label so that its width is the same when converted into circular form
-            const textw = ((metric.width / (2 * midR * Math.PI)) * tw * 360) / (endAngle - startAngle);
-            let [minX, maxX] = [TICK_SIZE * 2, TICK_SIZE * 2 + textw];
+            // Scale the width of text label so that its width is the same when converted into circular form
+            const txtWidth = ((metric.width / (2 * currentR * Math.PI)) * tw * 360) / (endAngle - startAngle);
+            const scaledStartX = isLeft
+                ? SCALED_TICK_SIZE(currentR) * 2
+                : tw - SCALED_TICK_SIZE(currentR) * 2 - txtWidth;
+            const scaledEndX = isLeft ? SCALED_TICK_SIZE(currentR) * 2 + txtWidth : tw - SCALED_TICK_SIZE(currentR) * 2;
 
-            // make sure not to place the label on the origin
-            if (minX < 0) {
-                const gap = -minX;
-                minX = 0;
-                maxX += gap;
-            } else if (maxX > tw) {
-                const gap = maxX - tw;
-                maxX = tw;
-                minX -= gap;
-            }
-
+            // Determine the points of a rope element for a lebel
             const ropePoints: number[] = [];
-            for (let i = maxX; i >= minX; i -= textw / 10.0) {
-                const p = cartesianToPolar(i, tw, midR, tw / 2.0, th / 2.0, startAngle, endAngle);
+            for (let i = scaledEndX; i >= scaledStartX; i -= txtWidth / 10.0) {
+                const p = cartesianToPolar(i, tw, currentR, cx, cy, startAngle, endAngle);
                 ropePoints.push(new HGC.libraries.PIXI.Point(p.x, p.y));
             }
 
+            // Render a label
             textGraphic.updateText();
             const rope = new HGC.libraries.PIXI.SimpleRope(textGraphic.texture, ropePoints);
             graphics.addChild(rope);

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -11,7 +11,8 @@ import { drawRule } from './rule';
 import { drawLink } from './link';
 import { drawGrid } from './grid';
 import { drawChartOutlines } from './outline';
-import { drawColorLegend, drawYLegend } from './legend';
+import { drawColorLegend, drawRowLegend } from './legend';
+import { drawYAxis } from './axis';
 import { drawCircularGrid } from './grid-circular';
 import { drawCircularOutlines } from './outline-circular';
 import { drawBackground } from './background';
@@ -46,7 +47,14 @@ export const RESOLUTION = 4;
 /**
  * Draw a track based on the track specification in a Gosling grammar.
  */
-export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrackModel, theme: Theme = 'light') {
+export function drawMark(
+    HGC: any,
+    trackInfo: any,
+    tile: any,
+    model: GoslingTrackModel,
+    theme: Theme = 'light',
+    isLast: boolean
+) {
     if (!HGC || !trackInfo || !tile) {
         // We did not receive parameters correctly.
         return;
@@ -121,7 +129,11 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
     if (CIRCULAR) {
         // ...
     } else {
-        drawYLegend(HGC, trackInfo, tile, model, theme);
+        drawRowLegend(HGC, trackInfo, tile, model, theme);
+        if (isLast) {
+            // Need to render Y-Axis only once
+            drawYAxis(HGC, trackInfo, tile, model, theme);
+        }
     }
     drawColorLegend(HGC, trackInfo, tile, model, theme);
 }

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -12,7 +12,7 @@ import { drawLink } from './link';
 import { drawGrid } from './grid';
 import { drawChartOutlines } from './outline';
 import { drawColorLegend, drawRowLegend } from './legend';
-import { drawYAxis } from './axis';
+import { drawCircularYAxis, drawLinearYAxis } from './axis';
 import { drawCircularGrid } from './grid-circular';
 import { drawCircularOutlines } from './outline-circular';
 import { drawBackground } from './background';
@@ -47,14 +47,7 @@ export const RESOLUTION = 4;
 /**
  * Draw a track based on the track specification in a Gosling grammar.
  */
-export function drawMark(
-    HGC: any,
-    trackInfo: any,
-    tile: any,
-    model: GoslingTrackModel,
-    theme: Theme = 'light',
-    isLast: boolean
-) {
+export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrackModel, theme: Theme = 'light') {
     if (!HGC || !trackInfo || !tile) {
         // We did not receive parameters correctly.
         return;
@@ -127,13 +120,10 @@ export function drawMark(
 
     /* embellishment after rendering plots */
     if (CIRCULAR) {
-        // ...
+        drawCircularYAxis(HGC, trackInfo, tile, model, theme);
     } else {
+        drawLinearYAxis(HGC, trackInfo, tile, model, theme);
         drawRowLegend(HGC, trackInfo, tile, model, theme);
-        if (isLast) {
-            // Need to render Y-Axis only once
-            drawYAxis(HGC, trackInfo, tile, model, theme);
-        }
     }
     drawColorLegend(HGC, trackInfo, tile, model, theme);
 }

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -152,7 +152,7 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
     });
 }
 
-export function drawYLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel, theme: Theme = 'light') {
+export function drawRowLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel, theme: Theme = 'light') {
     /* track spec */
     const spec = tm.spec();
     if (

--- a/src/editor/example/corces.ts
+++ b/src/editor/example/corces.ts
@@ -84,7 +84,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                 field: 'position',
                 type: 'genomic'
             },
-            y: { field: 'peak', type: 'quantitative' },
+            y: { field: 'peak', type: 'quantitative', axis: 'right' },
             style: { outline: '#20102F' },
             width: 400,
             height: 40,

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -135,8 +135,7 @@ export const examples: ReadonlyArray<{
         name: 'Dark Theme (Beta)',
         id: 'DARK_THEME',
         spec: EX_SPEC_DARK_THEME,
-        underDevelopment: true,
-        forceShow: true
+        underDevelopment: true
     },
     {
         name: 'Custom Theme (Beta)',

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -135,7 +135,8 @@ export const examples: ReadonlyArray<{
         name: 'Dark Theme (Beta)',
         id: 'DARK_THEME',
         spec: EX_SPEC_DARK_THEME,
-        underDevelopment: true
+        underDevelopment: true,
+        forceShow: true
     },
     {
         name: 'Custom Theme (Beta)',

--- a/src/editor/example/matrix-hffc6.ts
+++ b/src/editor/example/matrix-hffc6.ts
@@ -141,7 +141,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                             mark: 'bar',
                             x: { field: 'start', type: 'genomic', axis: 'none' },
                             xe: { field: 'end', type: 'genomic', axis: 'none' },
-                            y: { field: 'peak', type: 'quantitative' },
+                            y: { field: 'peak', type: 'quantitative', axis: 'right' },
                             color: { value: 'darkgreen' },
                             width: 570,
                             height: 40
@@ -158,7 +158,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                             mark: 'bar',
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
-                            y: { field: 'peak', type: 'quantitative' },
+                            y: { field: 'peak', type: 'quantitative', axis: 'right' },
                             color: { value: '#E79F00' },
                             width: 570,
                             height: 40
@@ -177,7 +177,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                     mark: 'bar',
                                     x: { field: 'start', type: 'genomic' },
                                     xe: { field: 'end', type: 'genomic' },
-                                    y: { field: 'peak', type: 'quantitative' },
+                                    y: { field: 'peak', type: 'quantitative', axis: 'right' },
                                     color: { value: '#0072B2' }
                                 },
                                 {
@@ -264,7 +264,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                             mark: 'bar',
                             x: { field: 'start', type: 'genomic', axis: 'none' },
                             xe: { field: 'end', type: 'genomic' },
-                            y: { field: 'value', type: 'quantitative' },
+                            y: { field: 'value', type: 'quantitative', axis: 'right' },
                             color: {
                                 field: 'category',
                                 type: 'nominal',
@@ -330,7 +330,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                             mark: 'bar',
                             x: { field: 'start', type: 'genomic', axis: 'none' },
                             xe: { field: 'end', type: 'genomic', axis: 'none' },
-                            y: { field: 'peak', type: 'quantitative' },
+                            y: { field: 'peak', type: 'quantitative', axis: 'right' },
                             color: { value: 'darkgreen' },
                             width: 570,
                             height: 40
@@ -347,7 +347,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                             mark: 'bar',
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
-                            y: { field: 'peak', type: 'quantitative' },
+                            y: { field: 'peak', type: 'quantitative', axis: 'right' },
                             color: { value: '#E79F00' },
                             width: 570,
                             height: 40
@@ -366,7 +366,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                     mark: 'bar',
                                     x: { field: 'start', type: 'genomic' },
                                     xe: { field: 'end', type: 'genomic' },
-                                    y: { field: 'peak', type: 'quantitative' },
+                                    y: { field: 'peak', type: 'quantitative', axis: 'right' },
                                     color: { value: '#0072B2' }
                                 },
                                 {
@@ -453,7 +453,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                             mark: 'bar',
                             x: { field: 'start', type: 'genomic', axis: 'none' },
                             xe: { field: 'end', type: 'genomic' },
-                            y: { field: 'value', type: 'quantitative' },
+                            y: { field: 'value', type: 'quantitative', axis: 'right' },
                             color: {
                                 field: 'category',
                                 type: 'nominal',

--- a/src/editor/example/pathogenic.ts
+++ b/src/editor/example/pathogenic.ts
@@ -114,7 +114,7 @@ export const EX_SPEC_PATHOGENIC: GoslingSpec = {
                     mark: 'bar',
                     x: { field: 'start', type: 'genomic' },
                     xe: { field: 'end', type: 'genomic' },
-                    y: { field: 'count', type: 'quantitative' },
+                    y: { field: 'count', type: 'quantitative', axis: 'none' },
                     color: {
                         field: 'significance',
                         type: 'nominal',

--- a/src/editor/example/semantic-zoom.ts
+++ b/src/editor/example/semantic-zoom.ts
@@ -17,7 +17,7 @@ const ScalableSequenceTrack: OverlaidTracks = {
     tracks: [
         {
             mark: 'bar',
-            y: { field: 'count', type: 'quantitative' }
+            y: { field: 'count', type: 'quantitative', axis: 'none' }
         },
         {
             dataTransform: [{ type: 'filter', field: 'count', oneOf: [0], not: true }],

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -497,14 +497,14 @@ export const EX_SPEC_VISUAL_ENCODING_CIRCULAR: GoslingSpec = {
 };
 
 export const EX_SPEC_DARK_THEME: GoslingSpec = {
-    theme: {
-        base: 'dark',
-        markCommon: {
-            color: 'gray',
-            nominalColorRange: ['white', 'gray'],
-            stroke: 'black'
-        }
-    },
+    // theme: {
+    //     base: 'dark',
+    //     markCommon: {
+    //         color: 'gray',
+    //         nominalColorRange: ['white', 'gray'],
+    //         stroke: 'black'
+    //     }
+    // },
     title: 'Dark Theme (Beta)',
     subtitle: 'Gosling allows to easily change the color theme using a `theme` property',
     layout: 'circular',

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -2,7 +2,6 @@ import { GoslingSpec } from '../../core/gosling.schema';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
-    // theme: 'dark', // beta support
     title: 'Visual Encoding',
     subtitle: 'Gosling provides diverse visual encoding methods',
     layout: 'linear',
@@ -497,14 +496,14 @@ export const EX_SPEC_VISUAL_ENCODING_CIRCULAR: GoslingSpec = {
 };
 
 export const EX_SPEC_DARK_THEME: GoslingSpec = {
-    // theme: {
-    //     base: 'dark',
-    //     markCommon: {
-    //         color: 'gray',
-    //         nominalColorRange: ['white', 'gray'],
-    //         stroke: 'black'
-    //     }
-    // },
+    theme: {
+        base: 'dark',
+        markCommon: {
+            color: 'gray',
+            nominalColorRange: ['white', 'gray'],
+            stroke: 'black'
+        }
+    },
     title: 'Dark Theme (Beta)',
     subtitle: 'Gosling allows to easily change the color theme using a `theme` property',
     layout: 'circular',
@@ -530,7 +529,7 @@ export const EX_SPEC_DARK_THEME: GoslingSpec = {
                             },
                             mark: 'bar',
                             x: { field: 'position', type: 'genomic', axis: 'top' },
-                            y: { field: 'peak', type: 'quantitative' },
+                            y: { field: 'peak', type: 'quantitative', axis: 'left' },
                             color: { field: 'sample', type: 'nominal', legend: true },
                             width: 550,
                             height: 230

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -116,7 +116,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             }
 
             // A single tile contains one or multiple gosling visualizations that are overlaid
-            tile.goslingModels.forEach((tm: GoslingTrackModel, index: number) => {
+            tile.goslingModels.forEach((tm: GoslingTrackModel) => {
                 // check visibility condition
                 const trackWidth = this.dimensions[1];
                 const zoomLevel = this._xScale.invert(trackWidth) - this._xScale.invert(0);
@@ -124,7 +124,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                     return;
                 }
 
-                drawMark(HGC, this, tile, tm, this.options.theme, index === tile.goslingModels.length - 1);
+                drawMark(HGC, this, tile, tm, this.options.theme);
             });
         }
 

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -115,7 +115,8 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 return;
             }
 
-            tile.goslingModels.forEach((tm: GoslingTrackModel) => {
+            // A single tile contains one or multiple gosling visualizations that are overlaid
+            tile.goslingModels.forEach((tm: GoslingTrackModel, index: number) => {
                 // check visibility condition
                 const trackWidth = this.dimensions[1];
                 const zoomLevel = this._xScale.invert(trackWidth) - this._xScale.invert(0);
@@ -123,7 +124,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                     return;
                 }
 
-                drawMark(HGC, this, tile, tm, this.options.theme);
+                drawMark(HGC, this, tile, tm, this.options.theme, index === tile.goslingModels.length - 1);
             });
         }
 


### PR DESCRIPTION
## Update Details
- Show linear scale y-axis on the left or right depending on the `y` channel's `"axis"` property (default `"left"`).
- Show the axis only when the assigned axis height is more than `20px`.
- When a `row` channel is mapped to a nominal field, a single track contains multiple (shared) y-scales. In this case, only the first (top-most) y-axis is shown to prevent making a track too bush (refer to screenshots below).

Fixes #78, Fixes #92

## Open Issues
- How to better display a y-axis, a track title, color/row legends at once w/o visual occlusion? We currently show such visual components inside a track, making the track busy.

<img width="640" alt="Screen Shot 2021-04-28 at 9 55 39 AM" src="https://user-images.githubusercontent.com/9922882/116415975-f0048e80-a807-11eb-889d-22f7cf4e17f5.png">

## Screenshots
![Screen Shot 2021-04-27 at 5 49 56 PM](https://user-images.githubusercontent.com/9922882/116317258-1c28fc80-a781-11eb-8067-86577915b5f7.png)

<img width="575" alt="Screen Shot 2021-04-27 at 9 44 45 PM" src="https://user-images.githubusercontent.com/9922882/116333649-d0d31600-a7a1-11eb-995a-b96c31f02f14.png">

<img width="624" alt="Screen Shot 2021-04-27 at 9 43 19 PM" src="https://user-images.githubusercontent.com/9922882/116333582-b0a35700-a7a1-11eb-87f7-e5b9af09eb03.png">

<img width="649" alt="Screen Shot 2021-04-27 at 9 42 33 PM" src="https://user-images.githubusercontent.com/9922882/116333583-b0a35700-a7a1-11eb-8720-a537f3026ac7.png">