### PR TITLE
feat: show quantitative color legends

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1275,6 +1275,9 @@
         },
         "labelColor": {
           "type": "string"
+        },
+        "tickColor": {
+          "type": "string"
         }
       },
       "type": "object"

--- a/schema/history/0.7.7/gosling0.7.7.schema.json
+++ b/schema/history/0.7.7/gosling0.7.7.schema.json
@@ -1275,6 +1275,9 @@
         },
         "labelColor": {
           "type": "string"
+        },
+        "tickColor": {
+          "type": "string"
         }
       },
       "type": "object"

--- a/src/core/mark/legend.test.ts
+++ b/src/core/mark/legend.test.ts
@@ -1,0 +1,82 @@
+import * as PIXI from 'pixi.js';
+import { GoslingTrackModel } from '../gosling-track-model';
+import { SingleTrack } from '../gosling.schema';
+import { drawColorLegend } from './legend';
+
+describe('Color Legend', () => {
+    const g = new PIXI.Graphics();
+    it('Nominal', () => {
+        const t: SingleTrack = {
+            data: { type: 'csv', url: '' },
+            mark: 'line',
+            x: { field: 'x', type: 'genomic' },
+            color: { field: 'v', type: 'quantitative', legend: true },
+            width: 100,
+            height: 100
+        };
+        const d = [
+            { x: 1, y: 2 },
+            { x: 11, y: 22 },
+            { x: 111, y: 222 }
+        ];
+        const model = new GoslingTrackModel(t, d);
+        drawColorLegend(
+            {
+                libraries: {
+                    PIXI: {
+                        Text: PIXI.Text,
+                        TextStyle: PIXI.TextStyle,
+                        TextMetrics: PIXI.TextMetrics
+                    }
+                }
+            },
+            {
+                dimensions: [100, 400],
+                position: [0, 0],
+                pBorder: g
+            },
+            null,
+            model
+        );
+    });
+
+    it('Quantitative', () => {
+        const t: SingleTrack = {
+            layout: 'circular',
+            startAngle: 0,
+            endAngle: 240,
+            innerRadius: 10,
+            outerRadius: 40,
+            data: { type: 'csv', url: '' },
+            mark: 'point',
+            x: { field: 'x', type: 'genomic' },
+            color: { field: 'v', type: 'nominal', legend: true },
+            width: 100,
+            height: 100
+        };
+        const d = [
+            { x: 1, v: '2' },
+            { x: 11, v: '22' },
+            { x: 111, v: '222' }
+        ];
+        const model = new GoslingTrackModel(t, d);
+        drawColorLegend(
+            {
+                libraries: {
+                    PIXI: {
+                        Text: PIXI.Text,
+                        TextStyle: PIXI.TextStyle,
+                        TextMetrics: PIXI.TextMetrics
+                    }
+                }
+            },
+            {
+                dimensions: [100, 400],
+                position: [0, 0],
+                pBorder: g
+            },
+            null,
+            model
+        );
+    });
+});

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -121,9 +121,10 @@ export function drawColorLegendQuantitative(
             .ticks(tickCount + 1)
             .filter(v => colorDomain[0] <= v && v <= colorDomain[1]);
     }
+    const TICK_STROKE_SIZE = 1;
     graphics.lineStyle(
-        1,
-        colorToHex(getTheme(theme).axis.tickColor),
+        TICK_STROKE_SIZE,
+        colorToHex(getTheme(theme).legend.tickColor),
         1, // alpha
         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
@@ -132,11 +133,11 @@ export function drawColorLegendQuantitative(
     ticks.forEach(value => {
         let y = legendY + colorBarDim.top + colorBarDim.height - ((value - startValue) / extent) * colorBarDim.height;
 
-        // Prevent ticks from going outside of the color bar by the stroke size of ticks
+        // Prevent ticks from exceeding outside of a color bar by the stroke size of ticks
         if (y === legendY + colorBarDim.top) {
-            y += 1;
+            y += TICK_STROKE_SIZE / 2.0;
         } else if (y === legendY + colorBarDim.top + colorBarDim.height) {
-            y -= 0.5;
+            y -= TICK_STROKE_SIZE / 2.0;
         }
 
         // ticks
@@ -152,19 +153,6 @@ export function drawColorLegendQuantitative(
 
         graphics.addChild(textGraphic);
     });
-
-    // ticks.forEach(t => {
-    //     const y = colorScale(t);
-    //     tickEnd = isLeft ? dx + TICK_SIZE * 2 : dx - TICK_SIZE * 2;
-
-    //     const textGraphic = new HGC.libraries.PIXI.Text(t, getAxisTextStyle(getTheme(theme).legend.labelColor));
-    //     textGraphic.anchor.x = isLeft ? 0 : 1;
-    //     textGraphic.anchor.y = y === 0 ? 0.9 : 0.5;
-    //     textGraphic.position.x = tickEnd;
-    //     textGraphic.position.y = dy + rowHeight - y;
-
-    //     graphics.addChild(textGraphic);
-    // });
 }
 
 export function drawColorLegendCategories(

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -2,6 +2,8 @@ import { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
 import { getTheme, Theme } from '../utils/theme';
+import { Dimension } from '../utils/position';
+import { ScaleLinear } from 'd3-scale';
 
 export const getLegendTextStyle = (fill = 'black') => {
     return {
@@ -18,11 +20,164 @@ export const getLegendTextStyle = (fill = 'black') => {
 };
 
 export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel, theme: Theme = 'light') {
+    const spec = tm.spec();
+
+    if (!IsChannelDeep(spec.color) || !spec.color.legend) {
+        // This means we do not need to draw a legend
+        return;
+    }
+
+    switch (spec.color.type) {
+        case 'nominal':
+            drawColorLegendCategories(HGC, trackInfo, tile, tm, theme);
+            break;
+        case 'quantitative':
+            drawColorLegendQuantitative(HGC, trackInfo, tile, tm, theme);
+            break;
+    }
+}
+
+export function drawColorLegendQuantitative(
+    HGC: any,
+    trackInfo: any,
+    tile: any,
+    tm: GoslingTrackModel,
+    theme: Theme = 'light'
+) {
+    const spec = tm.spec();
+
+    if (!IsChannelDeep(spec.color) || spec.color.type !== 'quantitative' || !spec.color.legend) {
+        // This means we do not need to draw legend
+        return;
+    }
+
+    /* track size */
+    const [trackX, trackY] = trackInfo.position;
+    const [trackWidth] = trackInfo.dimensions;
+
+    /* Visual Parameters */
+    const legendWidth = 80;
+    const legendHeight = 110;
+    const colorBarDim: Dimension = {
+        top: 10,
+        left: 55,
+        width: 20,
+        height: 90
+    };
+    const legendX = trackX + trackWidth - legendWidth - 1;
+    const legendY = trackY + 1;
+
+    /* Legend Components */
+    const colorScale = tm.getChannelScale('color');
+    const colorDomain = tm.getChannelDomainArray('color');
+
+    if (!colorScale || !colorDomain) {
+        // We do not have enough information for creating a color legend
+        return;
+    }
+
+    /* render */
+    const graphics = trackInfo.pBorder; // use pBorder not to be affected by zoomming
+
+    // Background
+    graphics.beginFill(colorToHex(getTheme(theme).legend.background), getTheme(theme).legend.backgroundOpacity);
+    graphics.lineStyle(
+        1,
+        colorToHex(getTheme(theme).legend.backgroundStroke),
+        1, // alpha
+        0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+    );
+    graphics.drawRect(legendX, legendY, legendWidth, legendHeight);
+
+    // Color bar
+    const [startValue, endValue] = colorDomain as [number, number];
+    const extent = endValue - startValue;
+    [...Array(colorBarDim.height).keys()].forEach(y => {
+        // For each pixel, draw a small rectangle with different color
+        const value = ((colorBarDim.height - y) / colorBarDim.height) * extent + startValue;
+
+        graphics.beginFill(
+            colorToHex(colorScale(value)),
+            1 // alpha
+        );
+        graphics.lineStyle(
+            1,
+            colorToHex(getTheme(theme).legend.backgroundStroke),
+            0, // alpha
+            0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+        );
+        graphics.drawRect(legendX + colorBarDim.left, legendY + colorBarDim.top + y, colorBarDim.width, 1);
+    });
+
+    // Ticks & labels
+    const tickCount = Math.max(Math.ceil(colorBarDim.height / 40), 1);
+    let ticks = (colorScale as ScaleLinear<any, any>)
+        .ticks(tickCount)
+        .filter(v => colorDomain[0] <= v && v <= colorDomain[1]);
+
+    if (ticks.length === 1) {
+        // Sometimes, ticks() gives a single value, so use a larger tickCount.
+        ticks = (colorScale as ScaleLinear<any, any>)
+            .ticks(tickCount + 1)
+            .filter(v => colorDomain[0] <= v && v <= colorDomain[1]);
+    }
+    graphics.lineStyle(
+        1,
+        colorToHex(getTheme(theme).axis.tickColor),
+        1, // alpha
+        0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+    );
+
+    const tickEnd = legendX + colorBarDim.left;
+    ticks.forEach(value => {
+        let y = legendY + colorBarDim.top + colorBarDim.height - ((value - startValue) / extent) * colorBarDim.height;
+
+        // Prevent ticks from going outside of the color bar by the stroke size of ticks
+        if (y === legendY + colorBarDim.top) {
+            y += 1;
+        } else if (y === legendY + colorBarDim.top + colorBarDim.height) {
+            y -= 0.5;
+        }
+
+        // ticks
+        graphics.moveTo(tickEnd - 3, y);
+        graphics.lineTo(tickEnd, y);
+
+        // labels
+        const textGraphic = new HGC.libraries.PIXI.Text(value, getLegendTextStyle(getTheme(theme).legend.labelColor));
+        textGraphic.anchor.x = 1;
+        textGraphic.anchor.y = 0.5;
+        textGraphic.position.x = tickEnd - 6;
+        textGraphic.position.y = y;
+
+        graphics.addChild(textGraphic);
+    });
+
+    // ticks.forEach(t => {
+    //     const y = colorScale(t);
+    //     tickEnd = isLeft ? dx + TICK_SIZE * 2 : dx - TICK_SIZE * 2;
+
+    //     const textGraphic = new HGC.libraries.PIXI.Text(t, getAxisTextStyle(getTheme(theme).legend.labelColor));
+    //     textGraphic.anchor.x = isLeft ? 0 : 1;
+    //     textGraphic.anchor.y = y === 0 ? 0.9 : 0.5;
+    //     textGraphic.position.x = tickEnd;
+    //     textGraphic.position.y = dy + rowHeight - y;
+
+    //     graphics.addChild(textGraphic);
+    // });
+}
+
+export function drawColorLegendCategories(
+    HGC: any,
+    trackInfo: any,
+    tile: any,
+    tm: GoslingTrackModel,
+    theme: Theme = 'light'
+) {
     /* track spec */
     const spec = tm.spec();
     if (!IsChannelDeep(spec.color) || spec.color.type !== 'nominal' || !spec.color.legend) {
-        // TODO: only support categorical color
-        // we do not need to draw legend
+        // This means we do not need to draw legend
         return;
     }
 
@@ -34,7 +189,7 @@ export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: Gosling
     }
 
     /* render */
-    const graphics = trackInfo.pBorder; // use pBorder not to affected by zoomming
+    const graphics = trackInfo.pBorder; // use pBorder not to be affected by zoomming
 
     const paddingX = 10;
     const paddingY = 4;

--- a/src/core/utils/position.ts
+++ b/src/core/utils/position.ts
@@ -1,0 +1,18 @@
+export interface Dimension {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+}
+export type Padding = SurroundingSize;
+export type Margin = SurroundingSize;
+export interface SurroundingSize {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+}
+export interface Offset {
+    top: number;
+    left: number;
+}

--- a/src/core/utils/theme.ts
+++ b/src/core/utils/theme.ts
@@ -80,6 +80,7 @@ export interface LegendStyle {
     background?: string;
     backgroundOpacity?: number;
     backgroundStroke?: string;
+    tickColor?: string;
     // ...
 }
 
@@ -151,7 +152,8 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
             background: 'white',
             backgroundOpacity: 0.7,
             labelColor: 'black',
-            backgroundStroke: '#DBDBDB'
+            backgroundStroke: '#DBDBDB',
+            tickColor: 'black'
         },
 
         axis: {
@@ -223,7 +225,8 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
             background: 'black',
             backgroundOpacity: 0.7,
             labelColor: 'white',
-            backgroundStroke: '#DBDBDB'
+            backgroundStroke: '#DBDBDB',
+            tickColor: 'white'
         },
 
         axis: {

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -141,6 +141,7 @@ export const examples: ReadonlyArray<{
         name: 'Custom Theme (Beta)',
         id: 'CUSTOM_THEME',
         spec: EX_SPEC_CUSTOM_THEME,
-        underDevelopment: true
+        underDevelopment: true,
+        hidden: true
     }
 ].filter(d => !d.hidden);

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -32,7 +32,7 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                         type: 'genomic'
                     },
                     row: { field: 'sample', type: 'nominal', legend: true },
-                    color: { field: 'peak', type: 'quantitative' },
+                    color: { field: 'peak', type: 'quantitative', legend: true },
                     tooltip: [
                         { field: 'peak', type: 'quantitative', alt: 'Value' },
                         { field: 'sample', type: 'nominal', alt: 'Sample' }
@@ -270,7 +270,7 @@ export const EX_SPEC_VISUAL_ENCODING_CIRCULAR: GoslingSpec = {
                                 type: 'genomic'
                             },
                             row: { field: 'sample', type: 'nominal', legend: true },
-                            color: { field: 'peak', type: 'quantitative' },
+                            color: { field: 'peak', type: 'quantitative', legend: true },
                             width: 350,
                             height: 130
                         }


### PR DESCRIPTION
This PR adds a color legend for quantitative values. The legend can be shown when a user sets `legend` as `true`:

```ts
color: { field: 'value', type: 'quantitative', legend: true })
```

![Screen Shot 2021-05-03 at 4 46 30 PM](https://user-images.githubusercontent.com/9922882/116931695-584fd780-ac2f-11eb-9cf8-a7d5ee87c0dc.png)

![Screen Shot 2021-05-03 at 4 55 45 PM](https://user-images.githubusercontent.com/9922882/116932575-6fdb9000-ac30-11eb-93e6-7834f7df07e5.png)


Fixes #32 