### PR TITLE
feat: expose mouse position color to theme and change default color

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -3921,6 +3921,9 @@
         "background": {
           "type": "string"
         },
+        "mousePositionColor": {
+          "type": "string"
+        },
         "subtitleColor": {
           "type": "string"
         },

--- a/schema/history/0.7.7/gosling0.7.7.schema.json
+++ b/schema/history/0.7.7/gosling0.7.7.schema.json
@@ -3921,6 +3921,9 @@
         "background": {
           "type": "string"
         },
+        "mousePositionColor": {
+          "type": "string"
+        },
         "subtitleColor": {
           "type": "string"
         },

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -55,7 +55,7 @@ export function goslingToHiGlass(
             options: {
                 /* Mouse hover position */
                 showMousePosition: firstResolvedSpec.layout === 'circular' ? false : true, // show mouse position only for linear tracks // TODO: or vertical
-                mousePositionColor: '#B8BCC1',
+                mousePositionColor: getTheme(theme).root.mousePositionColor,
                 /* Track title */
                 name: firstResolvedSpec.title,
                 fontSize: 12,

--- a/src/core/utils/theme.ts
+++ b/src/core/utils/theme.ts
@@ -65,6 +65,7 @@ export interface RootStyle {
     background?: string;
     titleColor?: string;
     subtitleColor?: string;
+    mousePositionColor?: string;
 }
 
 export interface TrackStyle {
@@ -138,13 +139,14 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
         root: {
             background: 'white',
             titleColor: 'black',
-            subtitleColor: 'gray'
+            subtitleColor: 'gray',
+            mousePositionColor: '#000000'
         },
 
         track: {
             titleColor: 'black',
             titleBackground: 'white',
-            outline: 'gray',
+            outline: 'black',
             outlineWidth: 1
         },
 
@@ -211,13 +213,14 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
         root: {
             background: 'black',
             titleColor: 'white',
-            subtitleColor: 'lightgray'
+            subtitleColor: 'lightgray',
+            mousePositionColor: '#FFFFFF'
         },
 
         track: {
             titleColor: 'white',
             titleBackground: 'black',
-            outline: 'lightgray',
+            outline: 'white',
             outlineWidth: 1
         },
 


### PR DESCRIPTION
```ts
theme: {
   base: 'light',
   root: { mousePositionColor: 'black'}, ...
```

![Screen Shot 2021-05-03 at 5 28 56 PM](https://user-images.githubusercontent.com/9922882/116935916-12960d80-ac35-11eb-8ef4-e8dc532e1139.png)
