### PR TITLE
feat: support tooltips for most marks in linear layouts, showing relative genomic position, formatting

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1996,23 +1996,7 @@
               },
               "tooltip": {
                 "items": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "alt": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    },
-                    "type": {
-                      "$ref": "#/definitions/FieldType"
-                    }
-                  },
-                  "required": [
-                    "field",
-                    "type"
-                  ],
-                  "type": "object"
+                  "$ref": "#/definitions/Tooltip"
                 },
                 "type": "array"
               },
@@ -2120,23 +2104,7 @@
         },
         "tooltip": {
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "alt": {
-                "type": "string"
-              },
-              "field": {
-                "type": "string"
-              },
-              "type": {
-                "$ref": "#/definitions/FieldType"
-              }
-            },
-            "required": [
-              "field",
-              "type"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/Tooltip"
           },
           "type": "array"
         },
@@ -2318,23 +2286,7 @@
         },
         "tooltip": {
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "alt": {
-                "type": "string"
-              },
-              "field": {
-                "type": "string"
-              },
-              "type": {
-                "$ref": "#/definitions/FieldType"
-              }
-            },
-            "required": [
-              "field",
-              "type"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/Tooltip"
           },
           "type": "array"
         },
@@ -2509,23 +2461,7 @@
                     },
                     "tooltip": {
                       "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "alt": {
-                            "type": "string"
-                          },
-                          "field": {
-                            "type": "string"
-                          },
-                          "type": {
-                            "$ref": "#/definitions/FieldType"
-                          }
-                        },
-                        "required": [
-                          "field",
-                          "type"
-                        ],
-                        "type": "object"
+                        "$ref": "#/definitions/Tooltip"
                       },
                       "type": "array"
                     },
@@ -2633,23 +2569,7 @@
               },
               "tooltip": {
                 "items": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "alt": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    },
-                    "type": {
-                      "$ref": "#/definitions/FieldType"
-                    }
-                  },
-                  "required": [
-                    "field",
-                    "type"
-                  ],
-                  "type": "object"
+                  "$ref": "#/definitions/Tooltip"
                 },
                 "type": "array"
               },
@@ -3036,23 +2956,7 @@
             },
             "tooltip": {
               "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "alt": {
-                    "type": "string"
-                  },
-                  "field": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "$ref": "#/definitions/FieldType"
-                  }
-                },
-                "required": [
-                  "field",
-                  "type"
-                ],
-                "type": "object"
+                "$ref": "#/definitions/Tooltip"
               },
               "type": "array"
             },
@@ -3227,23 +3131,7 @@
                         },
                         "tooltip": {
                           "items": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "alt": {
-                                "type": "string"
-                              },
-                              "field": {
-                                "type": "string"
-                              },
-                              "type": {
-                                "$ref": "#/definitions/FieldType"
-                              }
-                            },
-                            "required": [
-                              "field",
-                              "type"
-                            ],
-                            "type": "object"
+                            "$ref": "#/definitions/Tooltip"
                           },
                           "type": "array"
                         },
@@ -3351,23 +3239,7 @@
                   },
                   "tooltip": {
                     "items": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "alt": {
-                          "type": "string"
-                        },
-                        "field": {
-                          "type": "string"
-                        },
-                        "type": {
-                          "$ref": "#/definitions/FieldType"
-                        }
-                      },
-                      "required": [
-                        "field",
-                        "type"
-                      ],
-                      "type": "object"
+                      "$ref": "#/definitions/Tooltip"
                     },
                     "type": "array"
                   },
@@ -3610,23 +3482,7 @@
             },
             "tooltip": {
               "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "alt": {
-                    "type": "string"
-                  },
-                  "field": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "$ref": "#/definitions/FieldType"
-                  }
-                },
-                "required": [
-                  "field",
-                  "type"
-                ],
-                "type": "object"
+                "$ref": "#/definitions/Tooltip"
               },
               "type": "array"
             },
@@ -3803,23 +3659,7 @@
                             },
                             "tooltip": {
                               "items": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "alt": {
-                                    "type": "string"
-                                  },
-                                  "field": {
-                                    "type": "string"
-                                  },
-                                  "type": {
-                                    "$ref": "#/definitions/FieldType"
-                                  }
-                                },
-                                "required": [
-                                  "field",
-                                  "type"
-                                ],
-                                "type": "object"
+                                "$ref": "#/definitions/Tooltip"
                               },
                               "type": "array"
                             },
@@ -3927,23 +3767,7 @@
                       },
                       "tooltip": {
                         "items": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "alt": {
-                              "type": "string"
-                            },
-                            "field": {
-                              "type": "string"
-                            },
-                            "type": {
-                              "$ref": "#/definitions/FieldType"
-                            }
-                          },
-                          "required": [
-                            "field",
-                            "type"
-                          ],
-                          "type": "object"
+                          "$ref": "#/definitions/Tooltip"
                         },
                         "type": "array"
                       },
@@ -4266,23 +4090,7 @@
         },
         "tooltip": {
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "alt": {
-                "type": "string"
-              },
-              "field": {
-                "type": "string"
-              },
-              "type": {
-                "$ref": "#/definitions/FieldType"
-              }
-            },
-            "required": [
-              "field",
-              "type"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/Tooltip"
           },
           "type": "array"
         },
@@ -4524,23 +4332,7 @@
         },
         "tooltip": {
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "alt": {
-                "type": "string"
-              },
-              "field": {
-                "type": "string"
-              },
-              "type": {
-                "$ref": "#/definitions/FieldType"
-              }
-            },
-            "required": [
-              "field",
-              "type"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/Tooltip"
           },
           "type": "array"
         },
@@ -4717,23 +4509,7 @@
                         },
                         "tooltip": {
                           "items": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "alt": {
-                                "type": "string"
-                              },
-                              "field": {
-                                "type": "string"
-                              },
-                              "type": {
-                                "$ref": "#/definitions/FieldType"
-                              }
-                            },
-                            "required": [
-                              "field",
-                              "type"
-                            ],
-                            "type": "object"
+                            "$ref": "#/definitions/Tooltip"
                           },
                           "type": "array"
                         },
@@ -4841,23 +4617,7 @@
                   },
                   "tooltip": {
                     "items": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "alt": {
-                          "type": "string"
-                        },
-                        "field": {
-                          "type": "string"
-                        },
-                        "type": {
-                          "$ref": "#/definitions/FieldType"
-                        }
-                      },
-                      "required": [
-                        "field",
-                        "type"
-                      ],
-                      "type": "object"
+                      "$ref": "#/definitions/Tooltip"
                     },
                     "type": "array"
                   },
@@ -5272,6 +5032,28 @@
         "dark"
       ],
       "type": "string"
+    },
+    "Tooltip": {
+      "additionalProperties": false,
+      "properties": {
+        "alt": {
+          "type": "string"
+        },
+        "field": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/FieldType"
+        }
+      },
+      "required": [
+        "field",
+        "type"
+      ],
+      "type": "object"
     },
     "Track": {
       "anyOf": [

--- a/schema/history/0.8.1/gosling0.8.1.schema.json
+++ b/schema/history/0.8.1/gosling0.8.1.schema.json
@@ -1996,23 +1996,7 @@
               },
               "tooltip": {
                 "items": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "alt": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    },
-                    "type": {
-                      "$ref": "#/definitions/FieldType"
-                    }
-                  },
-                  "required": [
-                    "field",
-                    "type"
-                  ],
-                  "type": "object"
+                  "$ref": "#/definitions/Tooltip"
                 },
                 "type": "array"
               },
@@ -2120,23 +2104,7 @@
         },
         "tooltip": {
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "alt": {
-                "type": "string"
-              },
-              "field": {
-                "type": "string"
-              },
-              "type": {
-                "$ref": "#/definitions/FieldType"
-              }
-            },
-            "required": [
-              "field",
-              "type"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/Tooltip"
           },
           "type": "array"
         },
@@ -2318,23 +2286,7 @@
         },
         "tooltip": {
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "alt": {
-                "type": "string"
-              },
-              "field": {
-                "type": "string"
-              },
-              "type": {
-                "$ref": "#/definitions/FieldType"
-              }
-            },
-            "required": [
-              "field",
-              "type"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/Tooltip"
           },
           "type": "array"
         },
@@ -2509,23 +2461,7 @@
                     },
                     "tooltip": {
                       "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "alt": {
-                            "type": "string"
-                          },
-                          "field": {
-                            "type": "string"
-                          },
-                          "type": {
-                            "$ref": "#/definitions/FieldType"
-                          }
-                        },
-                        "required": [
-                          "field",
-                          "type"
-                        ],
-                        "type": "object"
+                        "$ref": "#/definitions/Tooltip"
                       },
                       "type": "array"
                     },
@@ -2633,23 +2569,7 @@
               },
               "tooltip": {
                 "items": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "alt": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    },
-                    "type": {
-                      "$ref": "#/definitions/FieldType"
-                    }
-                  },
-                  "required": [
-                    "field",
-                    "type"
-                  ],
-                  "type": "object"
+                  "$ref": "#/definitions/Tooltip"
                 },
                 "type": "array"
               },
@@ -3036,23 +2956,7 @@
             },
             "tooltip": {
               "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "alt": {
-                    "type": "string"
-                  },
-                  "field": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "$ref": "#/definitions/FieldType"
-                  }
-                },
-                "required": [
-                  "field",
-                  "type"
-                ],
-                "type": "object"
+                "$ref": "#/definitions/Tooltip"
               },
               "type": "array"
             },
@@ -3227,23 +3131,7 @@
                         },
                         "tooltip": {
                           "items": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "alt": {
-                                "type": "string"
-                              },
-                              "field": {
-                                "type": "string"
-                              },
-                              "type": {
-                                "$ref": "#/definitions/FieldType"
-                              }
-                            },
-                            "required": [
-                              "field",
-                              "type"
-                            ],
-                            "type": "object"
+                            "$ref": "#/definitions/Tooltip"
                           },
                           "type": "array"
                         },
@@ -3351,23 +3239,7 @@
                   },
                   "tooltip": {
                     "items": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "alt": {
-                          "type": "string"
-                        },
-                        "field": {
-                          "type": "string"
-                        },
-                        "type": {
-                          "$ref": "#/definitions/FieldType"
-                        }
-                      },
-                      "required": [
-                        "field",
-                        "type"
-                      ],
-                      "type": "object"
+                      "$ref": "#/definitions/Tooltip"
                     },
                     "type": "array"
                   },
@@ -3610,23 +3482,7 @@
             },
             "tooltip": {
               "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "alt": {
-                    "type": "string"
-                  },
-                  "field": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "$ref": "#/definitions/FieldType"
-                  }
-                },
-                "required": [
-                  "field",
-                  "type"
-                ],
-                "type": "object"
+                "$ref": "#/definitions/Tooltip"
               },
               "type": "array"
             },
@@ -3803,23 +3659,7 @@
                             },
                             "tooltip": {
                               "items": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "alt": {
-                                    "type": "string"
-                                  },
-                                  "field": {
-                                    "type": "string"
-                                  },
-                                  "type": {
-                                    "$ref": "#/definitions/FieldType"
-                                  }
-                                },
-                                "required": [
-                                  "field",
-                                  "type"
-                                ],
-                                "type": "object"
+                                "$ref": "#/definitions/Tooltip"
                               },
                               "type": "array"
                             },
@@ -3927,23 +3767,7 @@
                       },
                       "tooltip": {
                         "items": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "alt": {
-                              "type": "string"
-                            },
-                            "field": {
-                              "type": "string"
-                            },
-                            "type": {
-                              "$ref": "#/definitions/FieldType"
-                            }
-                          },
-                          "required": [
-                            "field",
-                            "type"
-                          ],
-                          "type": "object"
+                          "$ref": "#/definitions/Tooltip"
                         },
                         "type": "array"
                       },
@@ -4266,23 +4090,7 @@
         },
         "tooltip": {
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "alt": {
-                "type": "string"
-              },
-              "field": {
-                "type": "string"
-              },
-              "type": {
-                "$ref": "#/definitions/FieldType"
-              }
-            },
-            "required": [
-              "field",
-              "type"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/Tooltip"
           },
           "type": "array"
         },
@@ -4524,23 +4332,7 @@
         },
         "tooltip": {
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "alt": {
-                "type": "string"
-              },
-              "field": {
-                "type": "string"
-              },
-              "type": {
-                "$ref": "#/definitions/FieldType"
-              }
-            },
-            "required": [
-              "field",
-              "type"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/Tooltip"
           },
           "type": "array"
         },
@@ -4717,23 +4509,7 @@
                         },
                         "tooltip": {
                           "items": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "alt": {
-                                "type": "string"
-                              },
-                              "field": {
-                                "type": "string"
-                              },
-                              "type": {
-                                "$ref": "#/definitions/FieldType"
-                              }
-                            },
-                            "required": [
-                              "field",
-                              "type"
-                            ],
-                            "type": "object"
+                            "$ref": "#/definitions/Tooltip"
                           },
                           "type": "array"
                         },
@@ -4841,23 +4617,7 @@
                   },
                   "tooltip": {
                     "items": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "alt": {
-                          "type": "string"
-                        },
-                        "field": {
-                          "type": "string"
-                        },
-                        "type": {
-                          "$ref": "#/definitions/FieldType"
-                        }
-                      },
-                      "required": [
-                        "field",
-                        "type"
-                      ],
-                      "type": "object"
+                      "$ref": "#/definitions/Tooltip"
                     },
                     "type": "array"
                   },
@@ -5272,6 +5032,28 @@
         "dark"
       ],
       "type": "string"
+    },
+    "Tooltip": {
+      "additionalProperties": false,
+      "properties": {
+        "alt": {
+          "type": "string"
+        },
+        "field": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/FieldType"
+        }
+      },
+      "required": [
+        "field",
+        "type"
+      ],
+      "type": "object"
     },
     "Track": {
       "anyOf": [

--- a/schema/history/0.8.1/gosling0.8.1.schema.ts
+++ b/schema/history/0.8.1/gosling0.8.1.schema.ts
@@ -136,7 +136,7 @@ export interface SingleTrack extends CommonTrackDef {
     // Data transformation
     dataTransform?: DataTransform[];
 
-    tooltip?: { field: string; type: FieldType; alt?: string }[];
+    tooltip?: Tooltip[];
 
     // Mark
     mark: Mark;
@@ -173,6 +173,13 @@ export interface SingleTrack extends CommonTrackDef {
     flipY?: boolean; // This is only supported for `link` marks.
     stretch?: boolean; // Stretch the size to the given range? (e.g., [x, xe])
     overrideTemplate?: boolean; // Override a spec template that is defined for a given data type.
+}
+
+export interface Tooltip {
+    field: string;
+    type: FieldType;
+    alt?: string;
+    format?: string;
 }
 
 export interface Displacement {

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -136,7 +136,7 @@ export interface SingleTrack extends CommonTrackDef {
     // Data transformation
     dataTransform?: DataTransform[];
 
-    tooltip?: { field: string; type: FieldType; alt?: string }[];
+    tooltip?: Tooltip[];
 
     // Mark
     mark: Mark;
@@ -173,6 +173,13 @@ export interface SingleTrack extends CommonTrackDef {
     flipY?: boolean; // This is only supported for `link` marks.
     stretch?: boolean; // Stretch the size to the given range? (e.g., [x, xe])
     overrideTemplate?: boolean; // Override a spec template that is defined for a given data type.
+}
+
+export interface Tooltip {
+    field: string;
+    type: FieldType;
+    alt?: string;
+    format?: string;
 }
 
 export interface Displacement {

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -89,7 +89,7 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
             drawBar(trackInfo, tile, model);
             break;
         case 'line':
-            drawLine(tile.graphics, model);
+            drawLine(tile.graphics, model, trackInfo.tooltips);
             break;
         case 'area':
             drawArea(HGC, trackInfo, tile, model);

--- a/src/core/mark/line.test.ts
+++ b/src/core/mark/line.test.ts
@@ -20,6 +20,6 @@ describe('Rendering Point', () => {
             { x: 111, y: 222 }
         ];
         const model = new GoslingTrackModel(t, d);
-        drawLine(g, model);
+        drawLine(g, model, []);
     });
 });

--- a/src/core/mark/point.ts
+++ b/src/core/mark/point.ts
@@ -5,7 +5,7 @@ import { getValueUsingChannel } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
 import { cartesianToPolar } from '../utils/polar';
 import { PIXIVisualProperty } from '../visual-property.schema';
-import { Tooltip, TOOLTIP_MOUSEOVER_MARGIN as G } from '../../gosling-tooltip';
+import { TooltipData, TOOLTIP_MOUSEOVER_MARGIN as G } from '../../gosling-tooltip';
 
 export function drawPoint(trackInfo: any, g: PIXI.Graphics, model: GoslingTrackModel) {
     /* track spec */
@@ -85,14 +85,14 @@ export function drawPoint(trackInfo: any, g: PIXI.Graphics, model: GoslingTrackM
 
                 /* Tooltip data */
                 if (trackInfo?.tooltips) {
-                    const _cy = rowPosition + rowHeight - cy;
+                    const gcy = rowPosition + rowHeight - cy;
                     trackInfo.tooltips.push({
                         datum: d,
                         isMouseOver: (x: number, y: number) =>
-                            Math.sqrt(Math.abs(x - cx) * Math.abs(x - cx) + Math.abs(y - _cy) * Math.abs(y - _cy)) <
+                            Math.sqrt(Math.abs(x - cx) * Math.abs(x - cx) + Math.abs(y - gcy) * Math.abs(y - gcy)) <
                             size + G,
                         markInfo: { x: cx, y: rowPosition + rowHeight - cy, width: size, height: size, type: 'point' }
-                    } as Tooltip);
+                    } as TooltipData);
                 }
             }
         });

--- a/src/core/mark/rect.ts
+++ b/src/core/mark/rect.ts
@@ -1,4 +1,4 @@
-import { Tooltip, TOOLTIP_MOUSEOVER_MARGIN as G } from '../../gosling-tooltip';
+import { TooltipData, TOOLTIP_MOUSEOVER_MARGIN as G } from '../../gosling-tooltip';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import { PIXIVisualProperty } from '../visual-property.schema';
@@ -108,7 +108,8 @@ export function drawRect(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
             g.drawRect(xs, rowPosition + ys, xe - xs, ye - ys);
 
             /* SVG data */
-            trackInfo.svgData.push({ type: 'rect', xs, xe, ys, ye, color, stroke, opacity });
+            // We do not currently plan to support SVG elements.
+            // trackInfo.svgData.push({ type: 'rect', xs, xe, ys, ye, color, stroke, opacity });
 
             /* Tooltip data */
             if (spec.tooltip) {
@@ -117,7 +118,7 @@ export function drawRect(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
                     isMouseOver: (x: number, y: number) =>
                         xs - G < x && x < xe + G && rowPosition + ys - G < y && y < rowPosition + ye + G,
                     markInfo: { x: xs, y: ys + rowPosition, width: xe - xs, height: ye - ys, type: 'rect' }
-                } as Tooltip);
+                } as TooltipData);
             }
         }
     });

--- a/src/core/utils/assembly.ts
+++ b/src/core/utils/assembly.ts
@@ -1,3 +1,4 @@
+import { format } from 'd3-format';
 import {
     CHROM_SIZE_HG16,
     CHROM_SIZE_HG17,
@@ -13,6 +14,24 @@ export interface ChromSize {
     interval: { [chr: string]: [number, number] };
     total: number;
     path: string;
+}
+
+/**
+ * Get relative chromosome position (e.g., `100` => `chr:100`)
+ */
+export function getRelativeGenomicPosition(absPos: number, assembly?: string): string {
+    const chrAndRange = Object.entries(GET_CHROM_SIZES(assembly).interval).find(d => {
+        const [, [start, end]] = d;
+        return start <= absPos && absPos < end;
+    });
+
+    if (!chrAndRange) {
+        // The number is out of range
+        return `${absPos}`;
+    }
+
+    const pos = format(',')(absPos - chrAndRange[1][0]);
+    return `${chrAndRange[0]}:${pos}`;
 }
 
 /**

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -34,7 +34,9 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                     row: { field: 'sample', type: 'nominal', legend: true },
                     color: { field: 'peak', type: 'quantitative', legend: true },
                     tooltip: [
-                        { field: 'peak', type: 'quantitative', alt: 'Value' },
+                        { field: 'start', type: 'genomic', alt: 'Start Position' },
+                        { field: 'end', type: 'genomic', alt: 'End Position' },
+                        { field: 'peak', type: 'quantitative', alt: 'Value', format: '.2' },
                         { field: 'sample', type: 'nominal', alt: 'Sample' }
                     ],
                     width: 600,
@@ -62,6 +64,11 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                     y: { field: 'peak', type: 'quantitative' },
                     row: { field: 'sample', type: 'nominal' },
                     color: { field: 'sample', type: 'nominal', legend: true },
+                    tooltip: [
+                        { field: 'position', type: 'genomic', alt: 'Position' },
+                        { field: 'peak', type: 'quantitative', alt: 'Value', format: '.2' },
+                        { field: 'sample', type: 'nominal', alt: 'Sample' }
+                    ],
                     width: 600,
                     height: 130
                 }
@@ -86,6 +93,11 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                     },
                     y: { field: 'peak', type: 'quantitative', grid: true },
                     color: { field: 'sample', type: 'nominal', legend: true },
+                    tooltip: [
+                        { field: 'position', type: 'genomic', alt: 'Position' },
+                        { field: 'peak', type: 'quantitative', alt: 'Value', format: '.2' },
+                        { field: 'sample', type: 'nominal', alt: 'Sample' }
+                    ],
                     width: 600,
                     height: 130
                 }
@@ -110,6 +122,11 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
             row: { field: 'sample', type: 'nominal' },
             color: { field: 'sample', type: 'nominal', legend: true },
             tracks: [{ mark: 'line' }, { mark: 'point', size: { field: 'peak', type: 'quantitative', range: [0, 2] } }],
+            tooltip: [
+                { field: 'position', type: 'genomic', alt: 'Position' },
+                { field: 'peak', type: 'quantitative', alt: 'Value', format: '.2' },
+                { field: 'sample', type: 'nominal', alt: 'Sample' }
+            ],
             width: 600,
             height: 130
         },
@@ -135,6 +152,11 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                     size: { field: 'peak', type: 'quantitative' },
                     color: { field: 'sample', type: 'nominal', legend: true },
                     opacity: { value: 0.5 },
+                    tooltip: [
+                        { field: 'position', type: 'genomic', alt: 'Position' },
+                        { field: 'peak', type: 'quantitative', alt: 'Value', format: '.2' },
+                        { field: 'sample', type: 'nominal', alt: 'Sample' }
+                    ],
                     width: 600,
                     height: 130
                 }
@@ -161,6 +183,11 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                     size: { field: 'peak', type: 'quantitative' },
                     color: { field: 'sample', type: 'nominal', legend: true },
                     opacity: { value: 0.5 },
+                    tooltip: [
+                        { field: 'position', type: 'genomic', alt: 'Position' },
+                        { field: 'peak', type: 'quantitative', alt: 'Value', format: '.2' },
+                        { field: 'sample', type: 'nominal', alt: 'Sample' }
+                    ],
                     width: 600,
                     height: 130
                 }
@@ -188,6 +215,11 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                     color: { field: 'sample', type: 'nominal', legend: true },
                     stroke: { value: 'white' },
                     strokeWidth: { value: 0.5 },
+                    tooltip: [
+                        { field: 'position', type: 'genomic', alt: 'Position' },
+                        { field: 'peak', type: 'quantitative', alt: 'Value', format: '.2' },
+                        { field: 'sample', type: 'nominal', alt: 'Sample' }
+                    ],
                     width: 600,
                     height: 130
                 }
@@ -226,6 +258,10 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                     stroke: { value: 'black' },
                     strokeWidth: { value: 0.5 },
                     opacity: { value: 0.2 },
+                    tooltip: [
+                        { field: 's1', type: 'genomic' },
+                        { field: 'e2', type: 'genomic' }
+                    ],
                     width: 600,
                     height: 130
                 }

--- a/src/gosling-tooltip/index.ts
+++ b/src/gosling-tooltip/index.ts
@@ -2,7 +2,7 @@ import { Datum } from '../core/gosling.schema';
 
 export const TOOLTIP_MOUSEOVER_MARGIN = 1;
 
-export type Tooltip = {
+export type TooltipData = {
     datum: Datum;
     isMouseOver: (x: number, y: number) => boolean;
     markInfo: {
@@ -10,6 +10,6 @@ export type Tooltip = {
         y: number;
         width: number;
         height: number;
-        type: 'rect' | 'point'; // ...
+        type: 'bar' | 'rect' | 'point' | 'line' | 'area'; // ...
     };
 };


### PR DESCRIPTION
This PR enables showing tooltips in bar, line, area, rect, and point marks in linear layouts. Along with the additional mark support, this PR also allows to format numeric values using `d3.format()` and showing relative genomic position (e.g., `chr1:423,000`).

# Grammar
```ts
..., // Track definition
"tooltip": [
  {"field": "start", "type": "genomic", "alt": "Start Position"},
  {"field": "end", "type": "genomic", "alt": "End Position"},
  {
    "field": "peak",               // Field name
    "type": "quantitative",        // Type of a field
    "alt": "Value",                // Alternative title for this information
    "format": ".2"                 // Supports d3.format()
  },
  {"field": "sample", "type": "nominal", "alt": "Sample"}
],
```

You can also use HTML elements in the `alt` properties to customize the display:

```ts
{
  "field": "peak",
  "type": "quantitative",
  "alt": "<b style='color:red'>Value</b>",
  "format": ".2"
}
```

# Screenshot
![Screen Shot 2021-05-19 at 5 10 48 PM](https://user-images.githubusercontent.com/9922882/118885772-2d6bb180-b8c6-11eb-8385-51af2ea36779.png)

![May-19-2021 17-23-44](https://user-images.githubusercontent.com/9922882/118886504-0366bf00-b8c7-11eb-8eaf-180c2de6fa53.gif)

Towards #30 

