### PR TITLE
feat: allow vertical band connection w/o independent scales yet

### DIFF
--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -94,8 +94,15 @@ export function drawLink(g: PIXI.Graphics, model: GoslingTrackModel) {
             if (isBand) {
                 g.beginFill(color === 'none' ? colorToHex('white') : colorToHex(color), color === 'none' ? 0 : opacity);
 
+                let [_x1, _x2, _x3, _x4] = [x, xe, x1, x1e];
+
                 // Sort values to safely draw bands
-                const [_x1, _x2, _x3, _x4] = [x, xe, x1, x1e].sort((a, b) => a - b);
+                if (spec.style?.verticalLink) {
+                    [_x1, _x2] = [_x1, _x2].sort((a, b) => a - b);
+                    [_x3, _x4] = [_x3, _x4].sort((a, b) => a - b);
+                } else {
+                    [_x1, _x2, _x3, _x4] = [_x1, _x2, _x3, _x4].sort((a, b) => a - b);
+                }
 
                 if (_x1 > trackWidth || _x4 < 0 || Math.abs(_x4 - _x1) < 0.5) {
                     // Do not draw very small visual marks

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -143,6 +143,18 @@ export function drawLink(g: PIXI.Graphics, model: GoslingTrackModel) {
                     g.endFill();
                 } else {
                     // Linear mark
+
+                    // Experimental
+                    if (spec.style?.verticalLink) {
+                        g.moveTo(_x1, rowPosition);
+                        g.lineTo(_x2, rowPosition);
+                        g.lineTo(_x4, rowPosition + rowHeight);
+                        g.lineTo(_x3, rowPosition + rowHeight);
+                        g.lineTo(_x1, rowPosition);
+                        g.closePath();
+                        return;
+                    }
+
                     g.moveTo(_x1, baseY);
 
                     if (spec.style?.circularLink || DISABLE_BEZIER) {

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -18,6 +18,7 @@ import { EX_SPEC_PATHOGENIC } from './pathogenic';
 import { EX_SPEC_CYTOBANDS } from './ideograms';
 import { EX_SPEC_PILEUP } from './pileup';
 import { EX_SPEC_FUJI_PLOT } from './fuji';
+import { EX_SPEC_BAND } from './vertical-band';
 
 export const examples: ReadonlyArray<{
     name: string;
@@ -43,6 +44,11 @@ export const examples: ReadonlyArray<{
         name: 'Basic Example: Circular Visual Encoding',
         id: 'VISUAL_ENCODING_CIRCULAR',
         spec: EX_SPEC_VISUAL_ENCODING_CIRCULAR
+    },
+    {
+        name: 'Basic Example: Band Connection',
+        id: 'BAND',
+        spec: EX_SPEC_BAND
     },
     {
         name: 'Basic Example: Visual Linking',

--- a/src/editor/example/vertical-band.ts
+++ b/src/editor/example/vertical-band.ts
@@ -1,0 +1,71 @@
+import { GoslingSpec } from '../../core/gosling.schema';
+
+export const EX_SPEC_BAND: GoslingSpec = {
+    layout: 'linear',
+    xDomain: { chromosome: '1', interval: [103900000, 104100000] },
+    spacing: 0,
+    tracks: [
+        {
+            data: {
+                type: 'csv',
+                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                chromosomeField: 'c2',
+                genomicFields: ['s1', 'e1', 's2', 'e2']
+            },
+            mark: 'rect',
+            x: { field: 's1', type: 'genomic' },
+            xe: { field: 'e1', type: 'genomic' },
+            stroke: { value: '#4C6629' },
+            strokeWidth: { value: 0.8 },
+            tooltip: [
+                { field: 's1', type: 'genomic', alt: '<b style="color:green">Start Position</b>' },
+                { field: 'e1', type: 'genomic', alt: '<b style="color:green">End Position</b>' }
+            ],
+            opacity: { value: 0.15 },
+            color: { value: '#85B348' },
+            width: 500,
+            height: 20
+        },
+        {
+            data: {
+                type: 'csv',
+                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                chromosomeField: 'c2',
+                genomicFields: ['s1', 'e1', 's2', 'e2']
+            },
+            mark: 'link',
+            x: { field: 's1', type: 'genomic' },
+            xe: { field: 'e1', type: 'genomic' },
+            x1: { field: 's2', type: 'genomic' },
+            x1e: { field: 'e2', type: 'genomic' },
+            stroke: { value: '#4C6629' },
+            strokeWidth: { value: 0.8 },
+            opacity: { value: 0.15 },
+            color: { value: '#85B348' },
+            style: { verticalLink: true, outlineWidth: 0 },
+            width: 500,
+            height: 100
+        },
+        {
+            data: {
+                type: 'csv',
+                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                chromosomeField: 'c2',
+                genomicFields: ['s1', 'e1', 's2', 'e2']
+            },
+            mark: 'rect',
+            x: { field: 's2', type: 'genomic' },
+            xe: { field: 'e2', type: 'genomic' },
+            stroke: { value: '#4C6629' },
+            strokeWidth: { value: 0.8 },
+            tooltip: [
+                { field: 's2', type: 'genomic', alt: '<b style="color:green">Start Position</b>' },
+                { field: 'e2', type: 'genomic', alt: '<b style="color:green">End Position</b>' }
+            ],
+            opacity: { value: 0.15 },
+            color: { value: '#85B348' },
+            width: 500,
+            height: 20
+        }
+    ]
+};

--- a/src/editor/example/vertical-band.ts
+++ b/src/editor/example/vertical-band.ts
@@ -24,7 +24,7 @@ export const EX_SPEC_BAND: GoslingSpec = {
             opacity: { value: 0.15 },
             color: { value: '#85B348' },
             width: 500,
-            height: 20
+            height: 16
         },
         {
             data: {
@@ -65,7 +65,89 @@ export const EX_SPEC_BAND: GoslingSpec = {
             opacity: { value: 0.15 },
             color: { value: '#85B348' },
             width: 500,
-            height: 20
+            height: 16
+        },
+        {
+            data: {
+                type: 'csv',
+                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                chromosomeField: 'c2',
+                genomicFields: ['s1', 'e1', 's2', 'e2']
+            },
+            mark: 'link',
+            x1: { field: 's1', type: 'genomic' },
+            x1e: { field: 'e1', type: 'genomic' },
+            x: { field: 's2', type: 'genomic' },
+            xe: { field: 'e2', type: 'genomic' },
+            stroke: { value: '#4C6629' },
+            strokeWidth: { value: 0.8 },
+            opacity: { value: 0.15 },
+            color: { value: '#85B348' },
+            style: { verticalLink: true, outlineWidth: 0 },
+            width: 500,
+            height: 100
+        },
+        {
+            data: {
+                type: 'csv',
+                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                chromosomeField: 'c2',
+                genomicFields: ['s1', 'e1', 's2', 'e2']
+            },
+            mark: 'rect',
+            x: { field: 's1', type: 'genomic' },
+            xe: { field: 'e1', type: 'genomic' },
+            stroke: { value: '#4C6629' },
+            strokeWidth: { value: 0.8 },
+            tooltip: [
+                { field: 's1', type: 'genomic', alt: '<b style="color:green">Start Position</b>' },
+                { field: 'e1', type: 'genomic', alt: '<b style="color:green">End Position</b>' }
+            ],
+            opacity: { value: 0.15 },
+            color: { value: '#85B348' },
+            width: 500,
+            height: 16
+        },
+        {
+            data: {
+                type: 'csv',
+                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                chromosomeField: 'c2',
+                genomicFields: ['s1', 'e1', 's2', 'e2']
+            },
+            mark: 'link',
+            x: { field: 's1', type: 'genomic' },
+            xe: { field: 'e1', type: 'genomic' },
+            x1: { field: 's2', type: 'genomic' },
+            x1e: { field: 'e2', type: 'genomic' },
+            stroke: { value: '#4C6629' },
+            strokeWidth: { value: 0.8 },
+            opacity: { value: 0.15 },
+            color: { value: '#85B348' },
+            style: { verticalLink: true, outlineWidth: 0 },
+            width: 500,
+            height: 100
+        },
+        {
+            data: {
+                type: 'csv',
+                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                chromosomeField: 'c2',
+                genomicFields: ['s1', 'e1', 's2', 'e2']
+            },
+            mark: 'rect',
+            x: { field: 's2', type: 'genomic' },
+            xe: { field: 'e2', type: 'genomic' },
+            stroke: { value: '#4C6629' },
+            strokeWidth: { value: 0.8 },
+            tooltip: [
+                { field: 's2', type: 'genomic', alt: '<b style="color:green">Start Position</b>' },
+                { field: 'e2', type: 'genomic', alt: '<b style="color:green">End Position</b>' }
+            ],
+            opacity: { value: 0.15 },
+            color: { value: '#85B348' },
+            width: 500,
+            height: 16
         }
     ]
 };


### PR DESCRIPTION
```typescript
mark: 'link',
// Four visual channels to determine the band position and size
x: { ... },
xe: { ... },
x1: { ... },
x1e: { ... },
style: { verticalLink: true } // whether to draw vertical bands or arc
```

<img width="532" alt="Screen Shot 2021-05-27 at 12 03 16 PM" src="https://user-images.githubusercontent.com/9922882/119859629-8dc0ab80-bee3-11eb-9606-5aac7d961145.png">

**Question**
- [ ] Since we are now having many mark-specific properties in `style` (e.g., `verticalLink` for `link`, `dashPattern` for `rule`), should we move those to mark properties?:

```typescript
mark: { type: 'link', verticalLink: true }

// instead of
mark: 'link',
style: { verticalLink: true }
```
