### PR TITLE
feat: add a between-link mark

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -4904,9 +4904,6 @@
         },
         "textStrokeWidth": {
           "type": "number"
-        },
-        "verticalLink": {
-          "type": "boolean"
         }
       },
       "type": "object"

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1619,6 +1619,7 @@
         "rect",
         "text",
         "link",
+        "between-link",
         "rule",
         "triangleLeft",
         "triangleRight",

--- a/schema/history/0.8.3/gosling0.8.3.schema.json
+++ b/schema/history/0.8.3/gosling0.8.3.schema.json
@@ -4904,9 +4904,6 @@
         },
         "textStrokeWidth": {
           "type": "number"
-        },
-        "verticalLink": {
-          "type": "boolean"
         }
       },
       "type": "object"

--- a/schema/history/0.8.3/gosling0.8.3.schema.json
+++ b/schema/history/0.8.3/gosling0.8.3.schema.json
@@ -1619,6 +1619,7 @@
         "rect",
         "text",
         "link",
+        "between-link",
         "rule",
         "triangleLeft",
         "triangleRight",

--- a/schema/history/0.8.3/gosling0.8.3.schema.ts
+++ b/schema/history/0.8.3/gosling0.8.3.schema.ts
@@ -217,7 +217,6 @@ export interface Style {
     curve?: 'top' | 'bottom' | 'left' | 'right'; // for genomic range rules
     align?: 'left' | 'right'; // currently, only supported for triangles
     dy?: number; // currently, only used for text marks
-    verticalLink?: boolean; // Should bands be connected from the top to bottom?
     bazierLink?: boolean; // use bazier curves instead
     circularLink?: boolean; // !! Deprecated: draw arc instead of bazier curve?
     inlineLegend?: boolean; // show legend in a single horizontal line?

--- a/schema/history/0.8.3/gosling0.8.3.schema.ts
+++ b/schema/history/0.8.3/gosling0.8.3.schema.ts
@@ -118,6 +118,7 @@ export type MarkType =
     | 'rect'
     | 'text'
     | 'link'
+    | 'between-link'
     | 'rule'
     | 'triangleLeft'
     | 'triangleRight'

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -217,7 +217,6 @@ export interface Style {
     curve?: 'top' | 'bottom' | 'left' | 'right'; // for genomic range rules
     align?: 'left' | 'right'; // currently, only supported for triangles
     dy?: number; // currently, only used for text marks
-    verticalLink?: boolean; // Should bands be connected from the top to bottom?
     bazierLink?: boolean; // use bazier curves instead
     circularLink?: boolean; // !! Deprecated: draw arc instead of bazier curve?
     inlineLegend?: boolean; // show legend in a single horizontal line?

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -118,6 +118,7 @@ export type MarkType =
     | 'rect'
     | 'text'
     | 'link'
+    | 'between-link'
     | 'rule'
     | 'triangleLeft'
     | 'triangleRight'

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -102,6 +102,7 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
             drawRule(HGC, trackInfo, tile, model);
             break;
         case 'link':
+        case 'between-link':
             drawLink(tile.graphics, model);
             break;
         default:

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -152,7 +152,7 @@ export function drawLink(g: PIXI.Graphics, model: GoslingTrackModel) {
                     // Linear mark
 
                     // Experimental
-                    if (spec.style?.verticalLink) {
+                    if (spec.mark === 'between-link') {
                         g.moveTo(_x1, rowPosition);
                         g.lineTo(_x2, rowPosition);
                         g.lineTo(_x4, rowPosition + rowHeight);

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -97,7 +97,7 @@ export function drawLink(g: PIXI.Graphics, model: GoslingTrackModel) {
                 let [_x1, _x2, _x3, _x4] = [x, xe, x1, x1e];
 
                 // Sort values to safely draw bands
-                if (spec.style?.verticalLink) {
+                if (spec.mark === 'between-link') {
                     [_x1, _x2] = [_x1, _x2].sort((a, b) => a - b);
                     [_x3, _x4] = [_x3, _x4].sort((a, b) => a - b);
                 } else {
@@ -205,7 +205,7 @@ export function drawLink(g: PIXI.Graphics, model: GoslingTrackModel) {
                 /* Line Connection */
 
                 // Experimental
-                if (spec.style?.verticalLink) {
+                if (spec.mark === 'between-link') {
                     g.moveTo(xe, rowPosition + rowHeight);
                     g.lineTo(x, rowPosition);
                     return;

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -136,8 +136,7 @@ export const examples: ReadonlyArray<{
         name: 'Breast Cancer Variant (Staaf et al. 2019)',
         id: 'CANCER_VARIANT',
         spec: EX_SPEC_CANCER_VARIANT_PROTOTYPE,
-        underDevelopment: true,
-        forceShow: true
+        underDevelopment: true
     },
     {
         name: 'BAM file pileup tracks',

--- a/src/editor/example/mark-displacement.ts
+++ b/src/editor/example/mark-displacement.ts
@@ -93,7 +93,7 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                             newField: 'a'
                         }
                     ],
-                    mark: 'link',
+                    mark: 'between-link',
                     xe: { field: 'start', type: 'genomic' },
                     x: { field: 'aStart', type: 'genomic' },
                     // xe: { field: 'end', type: 'genomic' },
@@ -103,7 +103,6 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                     stroke: { value: 'lightgrey' },
                     strokeWidth: { value: 0.5 },
                     opacity: { value: 0.8 },
-                    style: { verticalLink: true },
                     width: 700,
                     height: 60
                 },

--- a/src/editor/example/vertical-band.ts
+++ b/src/editor/example/vertical-band.ts
@@ -42,7 +42,7 @@ export const EX_SPEC_BAND: GoslingSpec = {
             strokeWidth: { value: 0.8 },
             opacity: { value: 0.15 },
             color: { value: '#85B348' },
-            style: { verticalLink: true, outlineWidth: 0 },
+            style: { outlineWidth: 0 },
             width: 500,
             height: 100
         },
@@ -83,7 +83,7 @@ export const EX_SPEC_BAND: GoslingSpec = {
             strokeWidth: { value: 0.8 },
             opacity: { value: 0.15 },
             color: { value: '#85B348' },
-            style: { verticalLink: true, outlineWidth: 0 },
+            style: { outlineWidth: 0 },
             width: 500,
             height: 100
         },
@@ -124,7 +124,7 @@ export const EX_SPEC_BAND: GoslingSpec = {
             strokeWidth: { value: 0.8 },
             opacity: { value: 0.15 },
             color: { value: '#85B348' },
-            style: { verticalLink: true, outlineWidth: 0 },
+            style: { outlineWidth: 0 },
             width: 500,
             height: 100
         },

--- a/src/editor/example/vertical-band.ts
+++ b/src/editor/example/vertical-band.ts
@@ -33,7 +33,7 @@ export const EX_SPEC_BAND: GoslingSpec = {
                 chromosomeField: 'c2',
                 genomicFields: ['s1', 'e1', 's2', 'e2']
             },
-            mark: 'link',
+            mark: 'between-link',
             x: { field: 's1', type: 'genomic' },
             xe: { field: 'e1', type: 'genomic' },
             x1: { field: 's2', type: 'genomic' },
@@ -74,7 +74,7 @@ export const EX_SPEC_BAND: GoslingSpec = {
                 chromosomeField: 'c2',
                 genomicFields: ['s1', 'e1', 's2', 'e2']
             },
-            mark: 'link',
+            mark: 'between-link',
             x1: { field: 's1', type: 'genomic' },
             x1e: { field: 'e1', type: 'genomic' },
             x: { field: 's2', type: 'genomic' },
@@ -115,7 +115,7 @@ export const EX_SPEC_BAND: GoslingSpec = {
                 chromosomeField: 'c2',
                 genomicFields: ['s1', 'e1', 's2', 'e2']
             },
-            mark: 'link',
+            mark: 'between-link',
             x: { field: 's1', type: 'genomic' },
             xe: { field: 'e1', type: 'genomic' },
             x1: { field: 's2', type: 'genomic' },


### PR DESCRIPTION
We previously used `link` mark with `style.verticalLink`, and this PR changes to use `between-link` instead.

Fix #406