### PR TITLE
feat(api): zoom to extent

### DIFF
--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -88,6 +88,11 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
 
                     hgRef?.current?.api?.zoomTo(viewId, start, end, start, end, duration);
                 },
+                // TODO: Support assemblies (we can infer this from the spec)
+                zoomToExtent: (viewId: string, duration = 1000) => {
+                    const [start, end] = [0, GET_CHROM_SIZES().total];
+                    hgRef?.current?.api?.zoomTo(viewId, start, end, start, end, duration);
+                },
                 zoomToGene: (viewId: string, gene: string, duration = 1000) => {
                     hgRef?.current?.api?.zoomToGene(viewId, gene, duration);
                 },

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -386,7 +386,19 @@ function Editor(props: any) {
     // console.log('editor.render()');
     return (
         <>
-            <div className={`demo-navbar ${theme === 'dark' ? 'dark' : ''}`}>
+            <div
+                className={`demo-navbar ${theme === 'dark' ? 'dark' : ''}`}
+                onClick={() => {
+                    if (!gosRef.current) return;
+
+                    // To test APIs, uncomment the following code.
+                    // ! Be aware that the first view is for the title/subtitle track. So navigation API does not work.
+                    // const id = gosRef.current.api.getViewIds()?.[1]; //'view-1';
+                    // if(id) {
+                    //     gosRef.current.api.zoomToExtent(id);
+                    // }
+                }}
+            >
                 <span style={{ cursor: 'pointer' }} onClick={() => window.open('https://gosling.js.org', '_blank')}>
                     <span className="logo">{LogoSVG(20, 20)}</span>
                     Gosling.js Editor
@@ -430,17 +442,6 @@ function Editor(props: any) {
                         🚧 This example is under development 🚧
                     </span>
                 ) : null}
-                <span
-                    style={{ color: 'white', cursor: 'default', userSelect: 'none' }}
-                    onClick={() => {
-                        // if (hgRef.current) {
-                        //     console.warn('Exporting SVG', hgRef.current.api.exportAsSvg());
-                        //     // TODO: save as a html file
-                        // }
-                    }}
-                >
-                    {'‌‌ ‌‌ ‌‌ ‌‌ ‌‌ ‌‌ ‌‌ ‌‌ '}
-                </span>
                 <input type="hidden" id="spec-url-exporter" />
                 {description ? (
                     <span title="Open Textual Description" className="description-button" onClick={openDescription}>

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -10,6 +10,7 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
     xDomain: { chromosome: '1', interval: [1, 3000500] },
     views: [
         {
+            id: 'view-1',
             tracks: [
                 {
                     data: {


### PR DESCRIPTION
Fix #395 

## Example
```js
gosRef.current.zoomToExtent('view-1', 1000); // zoom out to see entire genome
```