### PR TITLE
chore: split examples

### DIFF
--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -11,10 +11,9 @@ import { EX_SPEC_SARS_COV_2 } from './sars-cov-2';
 import { EX_SPEC_CIRCOS } from './circos';
 import { EX_SPEC_GREMLIN } from './gremlin';
 import { EX_SPEC_GENE_ANNOTATION } from './gene-annotation';
-import { EX_SPEC_SEMANTIC_ZOOM } from './semantic-zoom';
+import { EX_SPEC_CLINVAR_LOLLIPOP, EX_SPEC_SEQUENCE_TRACK } from './semantic-zoom';
 import { EX_SPEC_GIVE } from './give';
 import { EX_SPEC_CORCES_ET_AL } from './corces';
-import { EX_SPEC_PATHOGENIC } from './pathogenic';
 import { EX_SPEC_CYTOBANDS } from './ideograms';
 import { EX_SPEC_PILEUP } from './pileup';
 import { EX_SPEC_FUJI_PLOT } from './fuji';
@@ -58,7 +57,8 @@ export const examples: ReadonlyArray<{
     {
         name: 'Basic Example: Layouts and Arrangements',
         id: 'LAYOUT_AND_ARRANGEMENT_1',
-        spec: EX_SPEC_LAYOUT_AND_ARRANGEMENT_1
+        spec: EX_SPEC_LAYOUT_AND_ARRANGEMENT_1,
+        hidden: true
     },
     {
         name: 'Layouts and Arrangements 2',
@@ -69,7 +69,8 @@ export const examples: ReadonlyArray<{
     {
         name: 'Basic Example: Basic Idea of Semantic Zoom',
         id: 'BASIC_SEMANTIC_ZOOM',
-        spec: EX_SPEC_BASIC_SEMANTIC_ZOOM
+        spec: EX_SPEC_BASIC_SEMANTIC_ZOOM,
+        hidden: true
     },
     {
         name: 'Basic Example: Mark Displacement',
@@ -82,9 +83,14 @@ export const examples: ReadonlyArray<{
         spec: EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL
     },
     {
-        name: 'Semantic Zoom Examples',
+        name: 'Scalable Sequence Track',
+        id: 'SEQUENCE',
+        spec: EX_SPEC_SEQUENCE_TRACK
+    },
+    {
+        name: 'Clinvar Lollipop Plot',
         id: 'SEMANTIC_ZOOM',
-        spec: EX_SPEC_SEMANTIC_ZOOM
+        spec: EX_SPEC_CLINVAR_LOLLIPOP
     },
     {
         name: 'Ideograms',
@@ -117,20 +123,16 @@ export const examples: ReadonlyArray<{
         spec: EX_SPEC_CORCES_ET_AL
     },
     {
-        name: 'Pathogenic Lollipop Plot',
-        id: 'PATHOGENIC',
-        spec: EX_SPEC_PATHOGENIC,
-        hidden: true
-    },
-    {
         name: "Gremlin (O'Brien et al. 2010)",
         id: 'GREMLIN',
-        spec: EX_SPEC_GREMLIN
+        spec: EX_SPEC_GREMLIN,
+        underDevelopment: true
     },
     {
         name: 'GIVE (Cao et al. 2018)',
         id: 'GIVE',
-        spec: EX_SPEC_GIVE
+        spec: EX_SPEC_GIVE,
+        underDevelopment: true
     },
     {
         name: 'Breast Cancer Variant (Staaf et al. 2019)',

--- a/src/editor/example/semantic-zoom.ts
+++ b/src/editor/example/semantic-zoom.ts
@@ -242,3 +242,34 @@ export const EX_SPEC_SEMANTIC_ZOOM: GoslingSpec = {
         }
     ]
 };
+
+export const EX_SPEC_SEQUENCE_TRACK: GoslingSpec = {
+    arrangement: 'vertical',
+    views: [
+        {
+            layout: 'linear',
+            xDomain: { chromosome: '1', interval: [3000000, 3000010] },
+            ...EX_TRACK_SEMANTIC_ZOOM.sequence,
+            width: 800,
+            height: 100
+        }
+    ]
+};
+
+export const EX_SPEC_CLINVAR_LOLLIPOP: GoslingSpec = {
+    arrangement: 'vertical',
+    views: [
+        {
+            ...EX_SPEC_PATHOGENIC,
+            xDomain: { chromosome: '13', interval: [31500000, 33150000] }
+        },
+        {
+            ...EX_SPEC_PATHOGENIC,
+            xDomain: { chromosome: '13', interval: [32000000, 32700000] }
+        },
+        {
+            ...EX_SPEC_PATHOGENIC,
+            xDomain: { chromosome: '13', interval: [32314000, 32402500] }
+        }
+    ]
+};


### PR DESCRIPTION
Made the semantic zoom example into two examples: (1) sequence track and (2) Clinvar lollipop plots.

Fix #368 