### PR TITLE
feat: add `margin` and `border` as props of GoslingComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.8.4](https://github.com/gosling-lang/gosling.js/compare/v0.8.3...v0.8.4) (2021-07-02)
+## [0.8.4](https://github.com/gosling-lang/gosling.js/compare/v0.8.3...v0.8.4) (2021-07-06)
 
 
 ### Bug Fixes
@@ -10,6 +10,7 @@
 
 ### Features
 
+* allow specifying `id` and `className` in `GoslingComponent` ([#419](https://github.com/gosling-lang/gosling.js/issues/419)) ([30d45a3](https://github.com/gosling-lang/gosling.js/commit/30d45a31b057ee5884b55a14224417dddaee96a4))
 * rename link marks to betweenLink and withinLink ([#416](https://github.com/gosling-lang/gosling.js/issues/416)) ([8e7556c](https://github.com/gosling-lang/gosling.js/commit/8e7556cfbfd674ec21e7783df8e37513d0cad7ec))
 * **api:** zoom to extent ([#408](https://github.com/gosling-lang/gosling.js/issues/408)) ([0b3c71f](https://github.com/gosling-lang/gosling.js/commit/0b3c71ff3ab99ee7b5cb445c704c2fe35145be99))
 * add a between-link mark ([#405](https://github.com/gosling-lang/gosling.js/issues/405)) ([c7a76e2](https://github.com/gosling-lang/gosling.js/commit/c7a76e22df9e7755242a764c70400c6beeb9cdb8))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Features
 
+* add margin and border as props of GoslingComponent ([aa681ec](https://github.com/gosling-lang/gosling.js/commit/aa681ecf92e08157532b07e3ee3048cb0dc6b8f1))
 * allow specifying `id` and `className` in `GoslingComponent` ([#419](https://github.com/gosling-lang/gosling.js/issues/419)) ([30d45a3](https://github.com/gosling-lang/gosling.js/commit/30d45a31b057ee5884b55a14224417dddaee96a4))
 * rename link marks to betweenLink and withinLink ([#416](https://github.com/gosling-lang/gosling.js/issues/416)) ([8e7556c](https://github.com/gosling-lang/gosling.js/commit/8e7556cfbfd674ec21e7783df8e37513d0cad7ec))
 * **api:** zoom to extent ([#408](https://github.com/gosling-lang/gosling.js/issues/408)) ([0b3c71f](https://github.com/gosling-lang/gosling.js/commit/0b3c71ff3ab99ee7b5cb445c704c2fe35145be99))

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -21,6 +21,8 @@ interface GoslingCompProps {
     spec?: gosling.GoslingSpec;
     compiled?: (goslingSpec: gosling.GoslingSpec, higlassSpec: gosling.HiGlassSpec) => void;
     padding?: number;
+    margin?: number;
+    border?: string;
     id?: string;
     className?: string;
 }
@@ -34,6 +36,8 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
 
     // Styling
     const padding = typeof props.padding !== 'undefined' ? props.padding : 60;
+    const margin = typeof props.margin !== 'undefined' ? props.margin : 0;
+    const border = typeof props.border !== 'undefined' ? props.border : 'none';
 
     // div `id` and `className` for detailed customization
     const wrapperDivId = typeof props.id !== 'undefined' ? props.id : uuid.v4();
@@ -217,6 +221,8 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     style={{
                         position: 'relative',
                         padding,
+                        margin,
+                        border,
                         background: getTheme(gs?.theme).root.background,
                         width: size.width + padding * 2,
                         height: size.height + padding * 2,
@@ -225,7 +231,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                 >
                     <div
                         key={JSON.stringify(hs)}
-                        className='higlass-wrapper'
+                        className="higlass-wrapper"
                         style={{
                             position: 'relative',
                             display: 'block',

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -21,7 +21,7 @@ interface GoslingCompProps {
     spec?: gosling.GoslingSpec;
     compiled?: (goslingSpec: gosling.GoslingSpec, higlassSpec: gosling.HiGlassSpec) => void;
     padding?: number;
-    margin?: number;
+    margin?: number | string;
     border?: string;
     id?: string;
     className?: string;

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -675,6 +675,10 @@ function Editor(props: any) {
                                         ref={gosRef}
                                         spec={goslingSpec}
                                         padding={60}
+                                        margin={0}
+                                        border={'none'}
+                                        id={'goslig-component-root'}
+                                        className={'goslig-component'}
                                         compiled={(g, h) => {
                                             setHg(h);
                                         }}


### PR DESCRIPTION
In addition to `id` and `className`, I think directly specifying `margin` and `border` can be useful since users may not want to create styling sheets at all (e.g., CSS).

```js
<GoslingComponent
   spec={spec}
   padding={30}
   margin={'auto'}
   border={'1px solid black'}
/>
```

@wangqianwen0418 Can you think of any other styling props that we can add?