### PR TITLE
feat: background of circular tracks, legend titles, and better brush style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.8.4](https://github.com/gosling-lang/gosling.js/compare/v0.8.3...v0.8.4) (2021-07-06)
+## [0.8.4](https://github.com/gosling-lang/gosling.js/compare/v0.8.3...v0.8.4) (2021-07-08)
 
 
 ### Bug Fixes
@@ -10,7 +10,7 @@
 
 ### Features
 
-* add margin and border as props of GoslingComponent ([aa681ec](https://github.com/gosling-lang/gosling.js/commit/aa681ecf92e08157532b07e3ee3048cb0dc6b8f1))
+* add `margin` and `border` as props of GoslingComponent ([#420](https://github.com/gosling-lang/gosling.js/issues/420)) ([4df2b2e](https://github.com/gosling-lang/gosling.js/commit/4df2b2e00445a786833ce4a3d79bf1a07837c79c))
 * allow specifying `id` and `className` in `GoslingComponent` ([#419](https://github.com/gosling-lang/gosling.js/issues/419)) ([30d45a3](https://github.com/gosling-lang/gosling.js/commit/30d45a31b057ee5884b55a14224417dddaee96a4))
 * rename link marks to betweenLink and withinLink ([#416](https://github.com/gosling-lang/gosling.js/issues/416)) ([8e7556c](https://github.com/gosling-lang/gosling.js/commit/8e7556cfbfd674ec21e7783df8e37513d0cad7ec))
 * **api:** zoom to extent ([#408](https://github.com/gosling-lang/gosling.js/issues/408)) ([0b3c71f](https://github.com/gosling-lang/gosling.js/commit/0b3c71ff3ab99ee7b5cb445c704c2fe35145be99))

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -4849,11 +4849,20 @@
           "minItems": 2,
           "type": "array"
         },
+        "dx": {
+          "type": "number"
+        },
         "dy": {
           "type": "number"
         },
+        "enableSmoothPath": {
+          "type": "boolean"
+        },
         "inlineLegend": {
           "type": "boolean"
+        },
+        "legendTitle": {
+          "type": "string"
         },
         "linePattern": {
           "additionalProperties": false,

--- a/schema/history/0.8.4/gosling0.8.4.schema.json
+++ b/schema/history/0.8.4/gosling0.8.4.schema.json
@@ -4849,11 +4849,20 @@
           "minItems": 2,
           "type": "array"
         },
+        "dx": {
+          "type": "number"
+        },
         "dy": {
           "type": "number"
         },
+        "enableSmoothPath": {
+          "type": "boolean"
+        },
         "inlineLegend": {
           "type": "boolean"
+        },
+        "legendTitle": {
+          "type": "string"
         },
         "linePattern": {
           "additionalProperties": false,

--- a/schema/history/0.8.4/gosling0.8.4.schema.ts
+++ b/schema/history/0.8.4/gosling0.8.4.schema.ts
@@ -210,16 +210,19 @@ export interface Style {
     backgroundOpacity?: number;
     outline?: string;
     outlineWidth?: number;
+    enableSmoothPath?: boolean;
 
     // Mark-level styles
     dashed?: [number, number];
     linePattern?: { type: 'triangleLeft' | 'triangleRight'; size: number };
     curve?: 'top' | 'bottom' | 'left' | 'right'; // for genomic range rules
     align?: 'left' | 'right'; // currently, only supported for triangles
+    dx?: number; // currently, only used for text marks
     dy?: number; // currently, only used for text marks
     bazierLink?: boolean; // use bazier curves instead
     circularLink?: boolean; // !! Deprecated: draw arc instead of bazier curve?
     inlineLegend?: boolean; // show legend in a single horizontal line?
+    legendTitle?: string; // if defined, show legend title on the top or left
     // below options could instead be used with channel options (e.g., size, stroke, strokeWidth)
     textFontSize?: number;
     textStroke?: string;

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -210,16 +210,19 @@ export interface Style {
     backgroundOpacity?: number;
     outline?: string;
     outlineWidth?: number;
+    enableSmoothPath?: boolean;
 
     // Mark-level styles
     dashed?: [number, number];
     linePattern?: { type: 'triangleLeft' | 'triangleRight'; size: number };
     curve?: 'top' | 'bottom' | 'left' | 'right'; // for genomic range rules
     align?: 'left' | 'right'; // currently, only supported for triangles
+    dx?: number; // currently, only used for text marks
     dy?: number; // currently, only used for text marks
     bazierLink?: boolean; // use bazier curves instead
     circularLink?: boolean; // !! Deprecated: draw arc instead of bazier curve?
     inlineLegend?: boolean; // show legend in a single horizontal line?
+    legendTitle?: string; // if defined, show legend title on the top or left
     // below options could instead be used with channel options (e.g., size, stroke, strokeWidth)
     textFontSize?: number;
     textStroke?: string;

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -105,7 +105,7 @@ export class HiGlassModel {
                     textColor,
                     fontSize,
                     fontWeight,
-                    fontFamily: 'Arial',
+                    fontFamily: 'sans-serif', // 'Arial',
                     offsetY: 0, // offset from the top of the track
                     align: 'left',
                     text

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -14,7 +14,7 @@ const TICK_SIZE = 6;
 export const getAxisTextStyle = (fill = 'black') => {
     return {
         fontSize: '10px',
-        fontFamily: 'Arial',
+        fontFamily: 'sans-serif', // 'Arial',
         fontWeight: 'normal',
         fill,
         background: 'white',

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -141,10 +141,10 @@ export function drawPreEmbellishment(
         // }
     });
 
-    drawBackground(HGC, trackInfo, tile, model);
     if (CIRCULAR) {
         drawCircularOutlines(HGC, trackInfo, tile, model);
     } else {
+        drawBackground(HGC, trackInfo, tile, model);
         drawChartOutlines(HGC, trackInfo, model, theme);
     }
     drawGrid(trackInfo, model, theme);

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -5,11 +5,11 @@ import { getTheme, Theme } from '../utils/theme';
 import { Dimension } from '../utils/position';
 import { ScaleLinear } from 'd3-scale';
 
-export const getLegendTextStyle = (fill = 'black') => {
+export const getLegendTextStyle = (fill = 'black', fontWeight = 'normal') => {
     return {
         fontSize: '12px',
-        fontFamily: 'Arial',
-        fontWeight: 'normal',
+        fontFamily: 'sans-serif', // 'Arial',
+        fontWeight,
         fill,
         background: 'white',
         lineJoin: 'round'
@@ -84,7 +84,7 @@ export function drawColorLegendQuantitative(
     graphics.lineStyle(
         1,
         colorToHex(getTheme(theme).legend.backgroundStroke),
-        1, // alpha
+        getTheme(theme).legend.backgroundOpacity, // alpha
         0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
     graphics.drawRect(legendX, legendY, legendWidth, legendHeight);
@@ -231,6 +231,26 @@ export function drawColorLegendCategories(
     } else {
         // Show legend vertically
 
+        if (spec.style?.legendTitle) {
+            const textGraphic = new HGC.libraries.PIXI.Text(
+                spec.style?.legendTitle,
+                getLegendTextStyle(getTheme(theme).legend.labelColor, 'bold')
+            );
+            textGraphic.anchor.x = 1;
+            textGraphic.anchor.y = 0;
+            textGraphic.position.x = trackInfo.position[0] + trackInfo.dimensions[0] - paddingX;
+            textGraphic.position.y = trackInfo.position[1] + cumY;
+
+            const textStyleObj = new HGC.libraries.PIXI.TextStyle(
+                getLegendTextStyle(getTheme(theme).legend.labelColor, 'bold')
+            );
+            const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(spec.style?.legendTitle, textStyleObj);
+
+            graphics.addChild(textGraphic);
+
+            cumY += textMetrics.height + paddingY * 2;
+        }
+
         colorCategories.forEach(category => {
             if (cumY > trackInfo.dimensions[1]) {
                 // We do not draw labels overflow
@@ -273,7 +293,7 @@ export function drawColorLegendCategories(
     graphics.lineStyle(
         1,
         colorToHex(getTheme(theme).legend.backgroundStroke),
-        1, // alpha
+        getTheme(theme).legend.backgroundOpacity, // alpha
         0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
     graphics.drawRect(

--- a/src/core/mark/outline-circular.ts
+++ b/src/core/mark/outline-circular.ts
@@ -25,7 +25,7 @@ export function drawCircularOutlines(HGC: any, trackInfo: any, tile: any, tm: Go
     /* render */
     const g = tile.graphics;
 
-    if (spec.style?.outlineWidth !== 0 && !(spec.layout === 'circular' && spec.mark === 'withinLink')) {
+    if (!(spec.layout === 'circular' && spec.mark === 'withinLink')) {
         // circular link marks usually use entire inner space
         g.lineStyle(
             spec.style?.outlineWidth ? spec.style?.outlineWidth / 2.5 : 0,
@@ -33,7 +33,7 @@ export function drawCircularOutlines(HGC: any, trackInfo: any, tile: any, tm: Go
             1, // 0.4, // alpha
             1 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
         );
-        g.beginFill(colorToHex('lightgray'), 0.05);
+        g.beginFill(colorToHex(tm.spec().style?.background ?? 'lightgray'), tm.spec().style?.backgroundOpacity ?? 0.05);
         g.moveTo(posStartInner.x, posStartInner.y);
         g.arc(cx, cy, trackInnerRadius, startRad, endRad, true);
         g.arc(cx, cy, trackOuterRadius, endRad, startRad, false);

--- a/src/core/mark/outline.ts
+++ b/src/core/mark/outline.ts
@@ -5,7 +5,7 @@ import { Theme, getTheme } from '../utils/theme';
 
 export const TITLE_STYLE = {
     fontSize: '12px',
-    fontFamily: 'Arial',
+    fontFamily: 'sans-serif', // 'Arial',
     fontWeight: 'normal',
     fill: 'black',
     background: 'white',

--- a/src/core/mark/text.ts
+++ b/src/core/mark/text.ts
@@ -6,7 +6,7 @@ import { cartesianToPolar } from '../utils/polar';
 
 export const TEXT_STYLE_GLOBAL = {
     fontSize: '12px',
-    fontFamily: 'Arial',
+    fontFamily: 'sans-serif', // 'Arial',
     fontWeight: 'normal',
     fill: 'black',
     background: 'white',
@@ -50,6 +50,7 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackMo
     const textStyleObj = new HGC.libraries.PIXI.TextStyle(localTextStyle);
 
     /* styles */
+    const dx = spec.style?.dx ?? 0;
     const dy = spec.style?.dy ?? 0;
 
     /* render */
@@ -75,9 +76,9 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackMo
             pivotedData.get(k)?.forEach(d => {
                 const text = tm.encodedPIXIProperty('text', d);
                 const color = tm.encodedPIXIProperty('color', d);
-                const x = tm.encodedPIXIProperty('x', d);
-                const xe = tm.encodedPIXIProperty('xe', d);
-                const cx = tm.encodedPIXIProperty('x-center', d);
+                const x = tm.encodedPIXIProperty('x', d) + dx;
+                const xe = tm.encodedPIXIProperty('xe', d) + dx;
+                const cx = tm.encodedPIXIProperty('x-center', d) + dx;
                 const y = tm.encodedPIXIProperty('y', d) + dy;
                 const opacity = tm.encodedPIXIProperty('opacity', d);
 
@@ -152,7 +153,7 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackMo
             ).forEach(d => {
                 const text = tm.encodedPIXIProperty('text', d);
                 const color = tm.encodedPIXIProperty('color', d);
-                const cx = tm.encodedPIXIProperty('x-center', d);
+                const cx = tm.encodedPIXIProperty('x-center', d) + dx;
                 const y = tm.encodedPIXIProperty('y', d) + dy;
                 const opacity = tm.encodedPIXIProperty('opacity', d);
 

--- a/src/core/mark/triangle.ts
+++ b/src/core/mark/triangle.ts
@@ -65,7 +65,8 @@ export function drawTriangle(g: PIXI.Graphics, model: GoslingTrackModel) {
             if (circular) {
                 let x0 = x ? x : xe - markWidth;
                 let x1 = xe ? xe : x + markWidth;
-                // let xm = x0 + (x1 - x0) / 2.0;
+                let xm = (x0 + x1) / 2.0;
+
                 const rm = trackOuterRadius - ((rowPosition + y) / trackHeight) * trackRingSize;
                 const r0 = rm - triHeight / 2.0;
                 const r1 = rm + triHeight / 2.0;
@@ -73,7 +74,7 @@ export function drawTriangle(g: PIXI.Graphics, model: GoslingTrackModel) {
                 if (spec.style?.align === 'right' && !xe) {
                     x0 -= markWidth;
                     x1 -= markWidth;
-                    // xm -= markWidth;
+                    xm -= markWidth;
                 }
 
                 let markToPoints: number[] = [];
@@ -88,6 +89,14 @@ export function drawTriangle(g: PIXI.Graphics, model: GoslingTrackModel) {
                     const p1 = cartesianToPolar(x1, trackWidth, rm, cx, cy, startAngle, endAngle);
                     const p2 = cartesianToPolar(x0, trackWidth, r1, cx, cy, startAngle, endAngle);
                     const p3 = cartesianToPolar(x0, trackWidth, r0, cx, cy, startAngle, endAngle);
+                    markToPoints = [p0.x, p0.y, p1.x, p1.y, p2.x, p2.y, p3.x, p3.y];
+                } else if (spec.mark === 'triangleBottom') {
+                    x0 = xm - markWidth / 2.0;
+                    x1 = xm + markWidth / 2.0;
+                    const p0 = cartesianToPolar(x0, trackWidth, r1, cx, cy, startAngle, endAngle);
+                    const p1 = cartesianToPolar(x1, trackWidth, r1, cx, cy, startAngle, endAngle);
+                    const p2 = cartesianToPolar(xm, trackWidth, r0, cx, cy, startAngle, endAngle);
+                    const p3 = cartesianToPolar(x0, trackWidth, r1, cx, cy, startAngle, endAngle);
                     markToPoints = [p0.x, p0.y, p1.x, p1.y, p2.x, p2.y, p3.x, p3.y];
                 }
 

--- a/src/editor/example/cancer-variant.ts
+++ b/src/editor/example/cancer-variant.ts
@@ -1,5 +1,892 @@
 import { GoslingSpec } from '../..';
 
+export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
+    title: 'Breast Cancer Variant (Staaf et al. 2019)',
+    subtitle: 'Genetic characteristics of RAD51C- and PALB2-altered TNBCs',
+    theme: { base: 'light', legend: { backgroundOpacity: 0, backgroundStroke: 'white' } },
+    layout: 'linear',
+    arrangement: 'vertical',
+    centerRadius: 0.5,
+    assembly: 'hg19',
+    spacing: 40,
+    style: { outlineWidth: 1, outline: 'lightgray', enableSmoothPath: true },
+    views: [
+        {
+            arrangement: 'horizontal',
+            views: [
+                {
+                    layout: 'circular',
+                    spacing: 1,
+                    tracks: [
+                        {
+                            title: 'Patient Overview (PD35930a)',
+                            alignment: 'overlay',
+                            data: {
+                                url:
+                                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                                type: 'csv',
+                                chromosomeField: 'Chromosome',
+                                genomicFields: ['chromStart', 'chromEnd']
+                            },
+                            tracks: [
+                                { mark: 'rect' },
+                                {
+                                    mark: 'brush',
+                                    x: { linkingId: 'mid-scale' },
+                                    strokeWidth: { value: 1.5 },
+                                    stroke: { value: '#0070DC' },
+                                    color: { value: '#AFD8FF' },
+                                    opacity: { value: 0.5 }
+                                }
+                            ],
+                            color: {
+                                field: 'Stain',
+                                type: 'nominal',
+                                domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
+                                range: ['white', 'lightgray', 'gray', 'gray', 'black', '#7B9CC8', '#DC4542']
+                            },
+                            size: { value: 18 },
+                            x: { field: 'chromStart', type: 'genomic' },
+                            xe: { field: 'chromEnd', type: 'genomic' },
+                            stroke: { value: 'gray' },
+                            strokeWidth: { value: 0.3 },
+                            width: 500,
+                            height: 100
+                        },
+                        {
+                            alignment: 'overlay',
+                            data: {
+                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/SV/driver.df.scanb.complete.csv',
+                                type: 'csv',
+                                chromosomeField: 'Chr',
+                                genomicFields: ['ChrStart', 'ChrEnd']
+                            },
+                            dataTransform: [{ type: 'filter', field: 'Sample', oneOf: ['PD35930a'] }],
+                            tracks: [
+                                { mark: 'text' },
+                                {
+                                    mark: 'triangleBottom',
+                                    size: { value: 5 }
+                                }
+                            ],
+                            x: { field: 'ChrStart', type: 'genomic' },
+                            xe: { field: 'ChrEnd', type: 'genomic' },
+                            text: { field: 'Gene', type: 'nominal' },
+                            color: { value: 'black' },
+                            style: { textFontWeight: 'normal', dx: -10, outlineWidth: 0 },
+                            width: 500,
+                            height: 40
+                        },
+                        {
+                            style: { background: 'lightgray', backgroundOpacity: 0.2 },
+                            alignment: 'overlay',
+                            data: {
+                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
+                                headerNames: [
+                                    'id',
+                                    'chr',
+                                    'start',
+                                    'end',
+                                    'total_cn_normal',
+                                    'minor_cp_normal',
+                                    'total_cn_tumor',
+                                    'minor_cn_tumor'
+                                ],
+                                type: 'csv',
+                                chromosomeField: 'chr',
+                                genomicFields: ['start', 'end']
+                            },
+                            dataTransform: [{ type: 'filter', field: 'minor_cn_tumor', oneOf: ['0'] }],
+                            tracks: [
+                                { mark: 'rect' },
+                                {
+                                    mark: 'brush',
+                                    x: { linkingId: 'mid-scale' },
+                                    strokeWidth: { value: 1 },
+                                    stroke: { value: '#94C2EF' },
+                                    color: { value: '#AFD8FF' }
+                                }
+                            ],
+                            x: { field: 'start', type: 'genomic' },
+                            xe: { field: 'end', type: 'genomic' },
+                            color: { value: '#FB6A4B' },
+                            // stroke: { value: '#444444' },
+                            // strokeWidth: { value: 0.6 },
+                            width: 620,
+                            height: 40
+                        },
+                        {
+                            style: { background: 'lightgray', backgroundOpacity: 0.2 },
+                            alignment: 'overlay',
+                            data: {
+                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
+                                headerNames: [
+                                    'id',
+                                    'chr',
+                                    'start',
+                                    'end',
+                                    'total_cn_normal',
+                                    'minor_cp_normal',
+                                    'total_cn_tumor',
+                                    'minor_cn_tumor'
+                                ],
+                                type: 'csv',
+                                chromosomeField: 'chr',
+                                genomicFields: ['start', 'end']
+                            },
+                            dataTransform: [
+                                {
+                                    type: 'filter',
+                                    field: 'total_cn_tumor',
+                                    inRange: [4.5, 900]
+                                }
+                            ],
+                            tracks: [
+                                { mark: 'rect' },
+                                {
+                                    mark: 'brush',
+                                    x: { linkingId: 'mid-scale' },
+                                    strokeWidth: { value: 0 }
+                                }
+                            ],
+                            x: { field: 'start', type: 'genomic' },
+                            xe: { field: 'end', type: 'genomic' },
+                            color: { value: '#73C475' },
+                            // stroke: { value: 'black' },
+                            // strokeWidth: { value: 0.6 },
+                            width: 500,
+                            height: 40
+                        },
+                        {
+                            data: {
+                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/rearrangement.PD35930a.csv',
+                                type: 'csv',
+                                genomicFieldsToConvert: [
+                                    {
+                                        chromosomeField: 'chr1',
+                                        genomicFields: ['start1', 'end1']
+                                    },
+                                    {
+                                        chromosomeField: 'chr2',
+                                        genomicFields: ['start2', 'end2']
+                                    }
+                                ]
+                            },
+                            mark: 'withinLink',
+                            x: { field: 'start1', type: 'genomic' },
+                            xe: { field: 'end2', type: 'genomic' },
+                            color: {
+                                field: 'svclass',
+                                type: 'nominal',
+                                legend: true,
+                                domain: ['tandem-duplication', 'translocation', 'delection', 'inversion'],
+                                range: ['#569C4D', '#4C75A2', '#DA5456', '#EA8A2A']
+                            },
+                            stroke: {
+                                field: 'svclass',
+                                type: 'nominal',
+                                domain: ['tandem-duplication', 'translocation', 'delection', 'inversion'],
+                                range: ['#569C4D', '#4C75A2', '#DA5456', '#EA8A2A']
+                            },
+                            strokeWidth: { value: 1 },
+                            opacity: { value: 0.6 },
+                            style: { legendTitle: 'SV Class' },
+                            width: 500,
+                            height: 80
+                        }
+                    ]
+                },
+                {
+                    linkingId: 'mid-scale',
+                    xDomain: { chromosome: '1' },
+                    layout: 'linear',
+                    tracks: [
+                        {
+                            title: 'Ideogram',
+                            alignment: 'overlay',
+                            data: {
+                                url:
+                                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                                type: 'csv',
+                                chromosomeField: 'Chromosome',
+                                genomicFields: ['chromStart', 'chromEnd']
+                            },
+                            tracks: [
+                                {
+                                    mark: 'rect',
+                                    dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }]
+                                },
+                                {
+                                    mark: 'triangleRight',
+                                    dataTransform: [
+                                        { type: 'filter', field: 'Stain', oneOf: ['acen'] },
+                                        { type: 'filter', field: 'Name', include: 'q' }
+                                    ]
+                                },
+                                {
+                                    mark: 'triangleLeft',
+                                    dataTransform: [
+                                        { type: 'filter', field: 'Stain', oneOf: ['acen'] },
+                                        { type: 'filter', field: 'Name', include: 'p' }
+                                    ]
+                                },
+                                {
+                                    mark: 'text',
+                                    dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }],
+                                    color: {
+                                        field: 'Stain',
+                                        type: 'nominal',
+                                        domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar'],
+                                        range: ['black', 'black', 'black', 'black', 'white', 'black']
+                                    },
+                                    visibility: [
+                                        {
+                                            operation: 'less-than',
+                                            measure: 'width',
+                                            threshold: '|xe-x|',
+                                            transitionPadding: 10,
+                                            target: 'mark'
+                                        }
+                                    ]
+                                }
+                            ],
+                            color: {
+                                field: 'Stain',
+                                type: 'nominal',
+                                domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
+                                range: ['white', 'lightgray', 'gray', 'gray', 'black', '#7B9CC8', '#DC4542']
+                            },
+                            size: { value: 18 },
+                            x: { field: 'chromStart', type: 'genomic' },
+                            xe: { field: 'chromEnd', type: 'genomic' },
+                            text: { field: 'Name', type: 'nominal' },
+                            stroke: { value: 'gray' },
+                            strokeWidth: { value: 0.3 },
+                            width: 500,
+                            height: 30
+                        },
+                        {
+                            title: 'Putative Driver',
+                            data: {
+                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/SV/driver.df.scanb.complete.csv',
+                                type: 'csv',
+                                chromosomeField: 'Chr',
+                                genomicFields: ['ChrStart', 'ChrEnd']
+                            },
+                            dataTransform: [{ type: 'filter', field: 'Sample', oneOf: ['PD35930a'] }],
+                            mark: 'text',
+                            x: { field: 'ChrStart', type: 'genomic' },
+                            xe: { field: 'ChrEnd', type: 'genomic' },
+                            text: { field: 'Gene', type: 'nominal' },
+                            color: { value: 'black' },
+                            style: { textFontWeight: 'normal', dx: -10 },
+                            width: 500,
+                            height: 20
+                        },
+                        {
+                            alignment: 'overlay',
+                            title: 'hg38 | Genes',
+                            data: {
+                                url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
+                                type: 'beddb',
+                                genomicFields: [
+                                    { index: 1, name: 'start' },
+                                    { index: 2, name: 'end' }
+                                ],
+                                valueFields: [
+                                    { index: 5, name: 'strand', type: 'nominal' },
+                                    { index: 3, name: 'name', type: 'nominal' }
+                                ],
+                                exonIntervalFields: [
+                                    { index: 12, name: 'start' },
+                                    { index: 13, name: 'end' }
+                                ]
+                            },
+                            tracks: [
+                                {
+                                    dataTransform: [
+                                        { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                        { type: 'filter', field: 'strand', oneOf: ['+'] }
+                                    ],
+                                    mark: 'triangleRight',
+                                    x: { field: 'end', type: 'genomic' },
+                                    size: { value: 15 }
+                                },
+                                {
+                                    dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
+                                    mark: 'text',
+                                    text: { field: 'name', type: 'nominal' },
+                                    x: { field: 'start', type: 'genomic' },
+                                    xe: { field: 'end', type: 'genomic' },
+                                    style: { dy: -15, outline: 'black', outlineWidth: 0 }
+                                },
+                                {
+                                    dataTransform: [
+                                        { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                        { type: 'filter', field: 'strand', oneOf: ['-'] }
+                                    ],
+                                    mark: 'triangleLeft',
+                                    x: { field: 'start', type: 'genomic' },
+                                    size: { value: 15 },
+                                    style: { align: 'right', outline: 'black', outlineWidth: 0 }
+                                },
+                                {
+                                    dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
+                                    mark: 'rect',
+                                    x: { field: 'start', type: 'genomic' },
+                                    size: { value: 15 },
+                                    xe: { field: 'end', type: 'genomic' }
+                                },
+                                {
+                                    dataTransform: [
+                                        { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                        { type: 'filter', field: 'strand', oneOf: ['+'] }
+                                    ],
+                                    mark: 'rule',
+                                    x: { field: 'start', type: 'genomic' },
+                                    strokeWidth: { value: 2 },
+                                    xe: { field: 'end', type: 'genomic' },
+                                    style: {
+                                        linePattern: { type: 'triangleRight', size: 3.5 },
+                                        outline: 'black',
+                                        outlineWidth: 0
+                                    }
+                                },
+                                {
+                                    dataTransform: [
+                                        { type: 'filter', field: 'type', oneOf: ['gene'] },
+                                        { type: 'filter', field: 'strand', oneOf: ['-'] }
+                                    ],
+                                    mark: 'rule',
+                                    x: { field: 'start', type: 'genomic' },
+                                    strokeWidth: { value: 2 },
+                                    xe: { field: 'end', type: 'genomic' },
+                                    style: {
+                                        linePattern: { type: 'triangleLeft', size: 3.5 },
+                                        outline: 'black',
+                                        outlineWidth: 0
+                                    }
+                                },
+                                {
+                                    mark: 'brush',
+                                    x: { linkingId: 'detail-1' },
+                                    strokeWidth: { value: 0 },
+                                    color: { value: 'gray' },
+                                    opacity: { value: 0.3 }
+                                },
+                                {
+                                    mark: 'brush',
+                                    x: { linkingId: 'detail-2' },
+                                    strokeWidth: { value: 0 },
+                                    color: { value: 'gray' },
+                                    opacity: { value: 0.3 }
+                                }
+                            ],
+                            row: { field: 'strand', type: 'nominal', domain: ['+', '-'] },
+                            color: {
+                                field: 'strand',
+                                type: 'nominal',
+                                domain: ['+', '-'],
+                                range: ['blue', 'red']
+                            },
+                            visibility: [
+                                {
+                                    operation: 'less-than',
+                                    measure: 'width',
+                                    threshold: '|xe-x|',
+                                    transitionPadding: 10,
+                                    target: 'mark'
+                                }
+                            ],
+                            opacity: { value: 0.4 },
+                            width: 400,
+                            height: 100
+                        },
+                        {
+                            title: 'LOH',
+                            style: { background: 'lightgray', backgroundOpacity: 0.2 },
+                            data: {
+                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
+                                headerNames: [
+                                    'id',
+                                    'chr',
+                                    'start',
+                                    'end',
+                                    'total_cn_normal',
+                                    'minor_cp_normal',
+                                    'total_cn_tumor',
+                                    'minor_cn_tumor'
+                                ],
+                                type: 'csv',
+                                chromosomeField: 'chr',
+                                genomicFields: ['start', 'end']
+                            },
+                            dataTransform: [{ type: 'filter', field: 'minor_cn_tumor', oneOf: ['0'] }],
+                            mark: 'rect',
+                            x: { field: 'start', type: 'genomic' },
+                            xe: { field: 'end', type: 'genomic' },
+                            color: { value: '#FB6A4B' },
+                            // stroke: { value: '#444444' },
+                            // strokeWidth: { value: 0.6 },
+                            width: 620,
+                            height: 20
+                        },
+                        {
+                            title: 'Gain',
+                            style: { background: 'lightgray', backgroundOpacity: 0.2 },
+                            data: {
+                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
+                                headerNames: [
+                                    'id',
+                                    'chr',
+                                    'start',
+                                    'end',
+                                    'total_cn_normal',
+                                    'minor_cp_normal',
+                                    'total_cn_tumor',
+                                    'minor_cn_tumor'
+                                ],
+                                type: 'csv',
+                                chromosomeField: 'chr',
+                                genomicFields: ['start', 'end']
+                            },
+                            dataTransform: [
+                                {
+                                    type: 'filter',
+                                    field: 'total_cn_tumor',
+                                    inRange: [4.5, 900]
+                                }
+                            ],
+                            mark: 'rect',
+                            x: { field: 'start', type: 'genomic' },
+                            xe: { field: 'end', type: 'genomic' },
+                            color: { value: '#73C475' },
+                            // stroke: { value: 'black' },
+                            // strokeWidth: { value: 0.6 },
+                            width: 500,
+                            height: 20
+                        },
+                        {
+                            title: 'Structural Variant',
+                            data: {
+                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/rearrangement.PD35930a.csv',
+                                type: 'csv',
+                                genomicFieldsToConvert: [
+                                    {
+                                        chromosomeField: 'chr1',
+                                        genomicFields: ['start1', 'end1']
+                                    },
+                                    {
+                                        chromosomeField: 'chr2',
+                                        genomicFields: ['start2', 'end2']
+                                    }
+                                ]
+                            },
+                            mark: 'withinLink',
+                            x: { field: 'start1', type: 'genomic' },
+                            xe: { field: 'end2', type: 'genomic' },
+                            color: {
+                                field: 'svclass',
+                                type: 'nominal',
+                                legend: true,
+                                domain: ['tandem-duplication', 'translocation', 'delection', 'inversion'],
+                                range: ['#569C4D', '#4C75A2', '#DA5456', '#EA8A2A']
+                            },
+                            stroke: {
+                                field: 'svclass',
+                                type: 'nominal',
+                                domain: ['tandem-duplication', 'translocation', 'delection', 'inversion'],
+                                range: ['#569C4D', '#4C75A2', '#DA5456', '#EA8A2A']
+                            },
+                            strokeWidth: { value: 1 },
+                            opacity: { value: 0.6 },
+                            style: { legendTitle: 'SV Class', bazierLink: true },
+                            width: 800,
+                            height: 400
+                        }
+                    ]
+                }
+                // {
+                //     linkingId: 'mid-scale',
+                //     xDomain: { chromosome: '1' },
+                //     xAxis: 'bottom',
+                //     layout: 'linear',
+                //     spacing: 0,
+                //     tracks: [
+                //         {
+                //             title: 'Genomic Feature',
+                //             alignment: 'overlay',
+                //             data: {
+                //                 url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/rearrangement.PD35930a.csv',
+                //                 type: 'csv',
+                //                 genomicFieldsToConvert: [
+                //                     {
+                //                         chromosomeField: 'chr1',
+                //                         genomicFields: ['start1', 'end1']
+                //                     },
+                //                     {
+                //                         chromosomeField: 'chr2',
+                //                         genomicFields: ['start2', 'end2']
+                //                     }
+                //                 ]
+                //             },
+                //             tracks: [
+                //                 { mark: 'withinLink' },
+                //                 {
+                //                     mark: 'brush',
+                //                     x: { linkingId: 'detail-1' },
+                //                     strokeWidth: { value: 0 },
+                //                     color: { value: 'gray' }
+                //                 },
+                //                 {
+                //                     mark: 'brush',
+                //                     x: { linkingId: 'detail-2' },
+                //                     strokeWidth: { value: 0 },
+                //                     color: { value: 'gray' }
+                //                 }
+                //             ],
+                //             x: { field: 'start1', type: 'genomic' },
+                //             xe: { field: 'end2', type: 'genomic' },
+                //             color: {
+                //                 field: 'svclass',
+                //                 type: 'nominal',
+                //                 legend: true,
+                //                 domain: ['translocation', 'delection', 'tandem-duplication', 'inversion']
+                //             },
+                //             stroke: {
+                //                 field: 'svclass',
+                //                 type: 'nominal',
+                //                 domain: ['translocation', 'delection', 'tandem-duplication', 'inversion']
+                //             },
+                //             style: {
+                //                 outline: 'lightgray',
+                //                 inlineLegend: true,
+                //                 bazierLink: true
+                //             },
+                //             strokeWidth: { value: 2.5 },
+                //             opacity: { value: 0.3 },
+                //             width: 400,
+                //             height: 250
+                //         },
+                //         {
+                //             title: 'LOH',
+                //             alignment: 'overlay',
+                //             data: {
+                //                 url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
+                //                 headerNames: [
+                //                     'id',
+                //                     'chr',
+                //                     'start',
+                //                     'end',
+                //                     'total_cn_normal',
+                //                     'minor_cp_normal',
+                //                     'total_cn_tumor',
+                //                     'minor_cn_tumor'
+                //                 ],
+                //                 type: 'csv',
+                //                 chromosomeField: 'chr',
+                //                 genomicFields: ['start', 'end']
+                //             },
+                //             dataTransform: [{ type: 'filter', field: 'minor_cn_tumor', oneOf: ['0'] }],
+                //             tracks: [
+                //                 { mark: 'rect' },
+                //                 {
+                //                     mark: 'brush',
+                //                     x: { linkingId: 'detail-1' },
+                //                     strokeWidth: { value: 0 },
+                //                     color: { value: 'gray' }
+                //                 },
+                //                 {
+                //                     mark: 'brush',
+                //                     x: { linkingId: 'detail-2' },
+                //                     strokeWidth: { value: 0 },
+                //                     color: { value: 'gray' }
+                //                 }
+                //             ],
+                //             x: { field: 'start', type: 'genomic' },
+                //             xe: { field: 'end', type: 'genomic' },
+                //             color: { value: '#FD7E85' },
+                //             stroke: { value: 'lightgray' },
+                //             strokeWidth: { value: 0.3 },
+                //             style: { outline: 'lightgray' },
+                //             width: 620,
+                //             height: 20
+                //         },
+                //         {
+                //             title: 'Gain',
+                //             alignment: 'overlay',
+                //             data: {
+                //                 url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
+                //                 headerNames: [
+                //                     'id',
+                //                     'chr',
+                //                     'start',
+                //                     'end',
+                //                     'total_cn_normal',
+                //                     'minor_cp_normal',
+                //                     'total_cn_tumor',
+                //                     'minor_cn_tumor'
+                //                 ],
+                //                 type: 'csv',
+                //                 chromosomeField: 'chr',
+                //                 genomicFields: ['start', 'end']
+                //             },
+                //             dataTransform: [
+                //                 {
+                //                     type: 'filter',
+                //                     field: 'total_cn_tumor',
+                //                     inRange: [4.5, 900]
+                //                 }
+                //             ],
+                //             tracks: [
+                //                 { mark: 'rect' },
+                //                 {
+                //                     mark: 'brush',
+                //                     x: { linkingId: 'detail-1' },
+                //                     strokeWidth: { value: 0 },
+                //                     color: { value: 'gray' }
+                //                 },
+                //                 {
+                //                     mark: 'brush',
+                //                     x: { linkingId: 'detail-2' },
+                //                     strokeWidth: { value: 0 },
+                //                     color: { value: 'gray' }
+                //                 }
+                //             ],
+                //             x: { field: 'start', type: 'genomic' },
+                //             xe: { field: 'end', type: 'genomic' },
+                //             color: { value: '#DFFBBF' },
+                //             stroke: { value: 'lightgray' },
+                //             strokeWidth: { value: 0.3 },
+                //             style: { outline: 'lightgray' },
+                //             width: 500,
+                //             height: 20
+                //         },
+                //         {
+                //             alignment: 'overlay',
+                //             title: 'hg38 | Genes',
+                //             data: {
+                //                 url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
+                //                 type: 'beddb',
+                //                 genomicFields: [
+                //                     { index: 1, name: 'start' },
+                //                     { index: 2, name: 'end' }
+                //                 ],
+                //                 valueFields: [
+                //                     { index: 5, name: 'strand', type: 'nominal' },
+                //                     { index: 3, name: 'name', type: 'nominal' }
+                //                 ],
+                //                 exonIntervalFields: [
+                //                     { index: 12, name: 'start' },
+                //                     { index: 13, name: 'end' }
+                //                 ]
+                //             },
+                //             tracks: [
+                //                 {
+                //                     dataTransform: [
+                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
+                //                         { type: 'filter', field: 'strand', oneOf: ['+'] }
+                //                     ],
+                //                     mark: 'triangleRight',
+                //                     x: { field: 'end', type: 'genomic' },
+                //                     size: { value: 15 }
+                //                 },
+                //                 {
+                //                     dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
+                //                     mark: 'text',
+                //                     text: { field: 'name', type: 'nominal' },
+                //                     x: { field: 'start', type: 'genomic' },
+                //                     xe: { field: 'end', type: 'genomic' },
+                //                     style: { dy: -15, outline: 'black', outlineWidth: 0 }
+                //                 },
+                //                 {
+                //                     dataTransform: [
+                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
+                //                         { type: 'filter', field: 'strand', oneOf: ['-'] }
+                //                     ],
+                //                     mark: 'triangleLeft',
+                //                     x: { field: 'start', type: 'genomic' },
+                //                     size: { value: 15 },
+                //                     style: { align: 'right', outline: 'black', outlineWidth: 0 }
+                //                 },
+                //                 {
+                //                     dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
+                //                     mark: 'rect',
+                //                     x: { field: 'start', type: 'genomic' },
+                //                     size: { value: 15 },
+                //                     xe: { field: 'end', type: 'genomic' }
+                //                 },
+                //                 {
+                //                     dataTransform: [
+                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
+                //                         { type: 'filter', field: 'strand', oneOf: ['+'] }
+                //                     ],
+                //                     mark: 'rule',
+                //                     x: { field: 'start', type: 'genomic' },
+                //                     strokeWidth: { value: 2 },
+                //                     xe: { field: 'end', type: 'genomic' },
+                //                     style: {
+                //                         linePattern: { type: 'triangleRight', size: 3.5 },
+                //                         outline: 'black',
+                //                         outlineWidth: 0
+                //                     }
+                //                 },
+                //                 {
+                //                     dataTransform: [
+                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
+                //                         { type: 'filter', field: 'strand', oneOf: ['-'] }
+                //                     ],
+                //                     mark: 'rule',
+                //                     x: { field: 'start', type: 'genomic' },
+                //                     strokeWidth: { value: 2 },
+                //                     xe: { field: 'end', type: 'genomic' },
+                //                     style: {
+                //                         linePattern: { type: 'triangleLeft', size: 3.5 },
+                //                         outline: 'black',
+                //                         outlineWidth: 0
+                //                     }
+                //                 },
+                //                 {
+                //                     mark: 'brush',
+                //                     x: { linkingId: 'detail-1' },
+                //                     strokeWidth: { value: 0 },
+                //                     color: { value: 'gray' },
+                //                     opacity: { value: 0.3 }
+                //                 },
+                //                 {
+                //                     mark: 'brush',
+                //                     x: { linkingId: 'detail-2' },
+                //                     strokeWidth: { value: 0 },
+                //                     color: { value: 'gray' },
+                //                     opacity: { value: 0.3 }
+                //                 }
+                //             ],
+                //             row: { field: 'strand', type: 'nominal', domain: ['+', '-'] },
+                //             color: {
+                //                 field: 'strand',
+                //                 type: 'nominal',
+                //                 domain: ['+', '-'],
+                //                 range: ['gray', 'gray']
+                //             },
+                //             visibility: [
+                //                 {
+                //                     operation: 'less-than',
+                //                     measure: 'width',
+                //                     threshold: '|xe-x|',
+                //                     transitionPadding: 10,
+                //                     target: 'mark'
+                //                 }
+                //             ],
+                //             opacity: { value: 0.8 },
+                //             style: { background: '#F5F5F5', outline: 'lightgray' },
+                //             width: 400,
+                //             height: 100
+                //         },
+                //         {
+                //             alignment: 'overlay',
+                //             data: {
+                //                 url:
+                //                     'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                //                 type: 'csv',
+                //                 chromosomeField: 'Chromosome',
+                //                 genomicFields: ['chromStart', 'chromEnd']
+                //             },
+                //             tracks: [
+                //                 { mark: 'rect' },
+                //                 {
+                //                     mark: 'brush',
+                //                     x: { linkingId: 'detail-1' },
+                //                     strokeWidth: { value: 0 },
+                //                     color: { value: 'gray' }
+                //                 },
+                //                 {
+                //                     mark: 'brush',
+                //                     x: { linkingId: 'detail-2' },
+                //                     strokeWidth: { value: 0 },
+                //                     color: { value: 'gray' }
+                //                 }
+                //             ],
+                //             color: {
+                //                 field: 'Stain',
+                //                 type: 'nominal',
+                //                 domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
+                //                 range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
+                //             },
+                //             x: { field: 'chromStart', type: 'genomic', axis: 'bottom' },
+                //             xe: { field: 'chromEnd', type: 'genomic' },
+                //             opacity: { value: 0.3 },
+                //             width: 1000,
+                //             height: 20
+                //         }
+                //     ]
+                // }
+            ]
+        }
+        // {
+        //     arrangement: 'horizontal',
+        //     spacing: 90,
+        //     views: [
+        //         {
+        //             xDomain: { chromosome: '1', interval: [100000000, 110000000] },
+        //             linkingId: 'detail-1',
+        //             tracks: [
+        //                 {
+        //                     title: 'Reads Detail View 1 (To Be Added)',
+        //                     data: {
+        //                         url:
+        //                             'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+        //                         type: 'csv',
+        //                         chromosomeField: 'Chromosome',
+        //                         genomicFields: ['chromStart', 'chromEnd']
+        //                     },
+        //                     mark: 'rect',
+        //                     color: {
+        //                         field: 'Stain',
+        //                         type: 'nominal',
+        //                         domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
+        //                         range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
+        //                     },
+        //                     x: { field: 'chromStart', type: 'genomic' },
+        //                     xe: { field: 'chromEnd', type: 'genomic' },
+        //                     opacity: { value: 0.3 },
+        //                     width: 452,
+        //                     height: 100
+        //                 }
+        //             ]
+        //         },
+        //         {
+        //             linkingId: 'detail-2',
+        //             xDomain: { chromosome: '1', interval: [240000000, 250000000] },
+        //             tracks: [
+        //                 {
+        //                     title: 'Reads Detail View 2 (To Be Added)',
+        //                     data: {
+        //                         url:
+        //                             'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+        //                         type: 'csv',
+        //                         chromosomeField: 'Chromosome',
+        //                         genomicFields: ['chromStart', 'chromEnd']
+        //                     },
+        //                     mark: 'rect',
+        //                     color: {
+        //                         field: 'Stain',
+        //                         type: 'nominal',
+        //                         domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
+        //                         range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
+        //                     },
+        //                     x: { field: 'chromStart', type: 'genomic' },
+        //                     xe: { field: 'chromEnd', type: 'genomic' },
+        //                     opacity: { value: 0.3 },
+        //                     width: 452,
+        //                     height: 100
+        //                 }
+        //             ]
+        //         }
+        //     ]
+        // }
+    ]
+};
+
 export function view(sample: string): GoslingSpec {
     return {
         layout: 'circular',
@@ -130,547 +1017,6 @@ export const EX_SPEC_CANCER_VARIANT: GoslingSpec = {
         {
             arrangement: 'horizontal',
             views: [{ ...view('PD31042a') } as any, { ...view('PD35930a') } as any]
-        }
-    ]
-};
-
-export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
-    title: 'Breast Cancer Variant (Staaf et al. 2019)',
-    subtitle: 'Genetic characteristics of RAD51C- and PALB2-altered TNBCs',
-    theme: { base: 'light', legend: { backgroundStroke: '#ffffff' } },
-    layout: 'linear',
-    arrangement: 'vertical',
-    centerRadius: 0.6,
-    assembly: 'hg19',
-    spacing: 40,
-    views: [
-        {
-            arrangement: 'vertical',
-            views: [
-                {
-                    layout: 'circular',
-                    spacing: 1,
-                    tracks: [
-                        {
-                            title: 'Patient Overview (PD35930a)',
-                            alignment: 'overlay',
-                            data: {
-                                url:
-                                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
-                                type: 'csv',
-                                chromosomeField: 'Chromosome',
-                                genomicFields: ['chromStart', 'chromEnd']
-                            },
-                            tracks: [
-                                { mark: 'rect' },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'mid-scale' },
-                                    strokeWidth: { value: 0 }
-                                }
-                            ],
-                            color: {
-                                field: 'Stain',
-                                type: 'nominal',
-                                domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
-                                range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
-                            },
-                            size: { value: 18 },
-                            x: { field: 'chromStart', type: 'genomic' },
-                            xe: { field: 'chromEnd', type: 'genomic' },
-                            opacity: { value: 0.3 },
-                            width: 500,
-                            height: 40
-                        },
-                        {
-                            alignment: 'overlay',
-                            data: {
-                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
-                                headerNames: [
-                                    'id',
-                                    'chr',
-                                    'start',
-                                    'end',
-                                    'total_cn_normal',
-                                    'minor_cp_normal',
-                                    'total_cn_tumor',
-                                    'minor_cn_tumor'
-                                ],
-                                type: 'csv',
-                                chromosomeField: 'chr',
-                                genomicFields: ['start', 'end']
-                            },
-                            dataTransform: [{ type: 'filter', field: 'minor_cn_tumor', oneOf: ['0'] }],
-                            tracks: [
-                                { mark: 'rect' },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'mid-scale' },
-                                    strokeWidth: { value: 0 }
-                                }
-                            ],
-                            x: { field: 'start', type: 'genomic' },
-                            xe: { field: 'end', type: 'genomic' },
-                            color: { value: '#FD7E85' },
-                            stroke: { value: 'lightgray' },
-                            strokeWidth: { value: 0.3 },
-                            width: 620,
-                            height: 20
-                        },
-                        {
-                            alignment: 'overlay',
-                            data: {
-                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
-                                headerNames: [
-                                    'id',
-                                    'chr',
-                                    'start',
-                                    'end',
-                                    'total_cn_normal',
-                                    'minor_cp_normal',
-                                    'total_cn_tumor',
-                                    'minor_cn_tumor'
-                                ],
-                                type: 'csv',
-                                chromosomeField: 'chr',
-                                genomicFields: ['start', 'end']
-                            },
-                            dataTransform: [
-                                {
-                                    type: 'filter',
-                                    field: 'total_cn_tumor',
-                                    inRange: [4.5, 900]
-                                }
-                            ],
-                            tracks: [
-                                { mark: 'rect' },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'mid-scale' },
-                                    strokeWidth: { value: 0 }
-                                }
-                            ],
-                            x: { field: 'start', type: 'genomic' },
-                            xe: { field: 'end', type: 'genomic' },
-                            color: { value: '#DFFBBF' },
-                            stroke: { value: 'lightgray' },
-                            strokeWidth: { value: 0.3 },
-                            width: 500,
-                            height: 20
-                        },
-                        {
-                            data: {
-                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/rearrangement.PD35930a.csv',
-                                type: 'csv',
-                                genomicFieldsToConvert: [
-                                    {
-                                        chromosomeField: 'chr1',
-                                        genomicFields: ['start1', 'end1']
-                                    },
-                                    {
-                                        chromosomeField: 'chr2',
-                                        genomicFields: ['start2', 'end2']
-                                    }
-                                ]
-                            },
-                            mark: 'withinLink',
-                            x: { field: 'start1', type: 'genomic' },
-                            xe: { field: 'end2', type: 'genomic' },
-                            color: {
-                                field: 'svclass',
-                                type: 'nominal',
-                                legend: true,
-                                domain: ['translocation', 'delection', 'tandem-duplication', 'inversion']
-                            },
-                            stroke: {
-                                field: 'svclass',
-                                type: 'nominal',
-                                domain: ['translocation', 'delection', 'tandem-duplication', 'inversion']
-                            },
-                            strokeWidth: { value: 1.5 },
-                            opacity: { value: 0.5 },
-                            width: 500,
-                            height: 80
-                        }
-                    ]
-                },
-                {
-                    linkingId: 'mid-scale',
-                    xDomain: { chromosome: '1' },
-                    xAxis: 'bottom',
-                    layout: 'linear',
-                    spacing: 0,
-                    tracks: [
-                        {
-                            title: 'Genomic Feature',
-                            alignment: 'overlay',
-                            data: {
-                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/rearrangement.PD35930a.csv',
-                                type: 'csv',
-                                genomicFieldsToConvert: [
-                                    {
-                                        chromosomeField: 'chr1',
-                                        genomicFields: ['start1', 'end1']
-                                    },
-                                    {
-                                        chromosomeField: 'chr2',
-                                        genomicFields: ['start2', 'end2']
-                                    }
-                                ]
-                            },
-                            tracks: [
-                                { mark: 'withinLink' },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'detail-1' },
-                                    strokeWidth: { value: 0 },
-                                    color: { value: 'gray' }
-                                },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'detail-2' },
-                                    strokeWidth: { value: 0 },
-                                    color: { value: 'gray' }
-                                }
-                            ],
-                            x: { field: 'start1', type: 'genomic', axis: 'none' },
-                            xe: { field: 'end2', type: 'genomic' },
-                            color: {
-                                field: 'svclass',
-                                type: 'nominal',
-                                legend: true,
-                                domain: ['translocation', 'delection', 'tandem-duplication', 'inversion']
-                            },
-                            stroke: {
-                                field: 'svclass',
-                                type: 'nominal',
-                                domain: ['translocation', 'delection', 'tandem-duplication', 'inversion']
-                            },
-                            style: {
-                                outline: 'lightgray',
-                                inlineLegend: true,
-                                bazierLink: true
-                            },
-                            strokeWidth: { value: 2.5 },
-                            opacity: { value: 0.3 },
-                            width: 400,
-                            height: 250
-                        },
-                        {
-                            title: 'LOH',
-                            alignment: 'overlay',
-                            data: {
-                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
-                                headerNames: [
-                                    'id',
-                                    'chr',
-                                    'start',
-                                    'end',
-                                    'total_cn_normal',
-                                    'minor_cp_normal',
-                                    'total_cn_tumor',
-                                    'minor_cn_tumor'
-                                ],
-                                type: 'csv',
-                                chromosomeField: 'chr',
-                                genomicFields: ['start', 'end']
-                            },
-                            dataTransform: [{ type: 'filter', field: 'minor_cn_tumor', oneOf: ['0'] }],
-                            tracks: [
-                                { mark: 'rect' },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'detail-1' },
-                                    strokeWidth: { value: 0 },
-                                    color: { value: 'gray' }
-                                },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'detail-2' },
-                                    strokeWidth: { value: 0 },
-                                    color: { value: 'gray' }
-                                }
-                            ],
-                            x: { field: 'start', type: 'genomic' },
-                            xe: { field: 'end', type: 'genomic' },
-                            color: { value: '#FD7E85' },
-                            stroke: { value: 'lightgray' },
-                            strokeWidth: { value: 0.3 },
-                            style: { outline: 'lightgray' },
-                            width: 620,
-                            height: 20
-                        },
-                        {
-                            title: 'Gain',
-                            alignment: 'overlay',
-                            data: {
-                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
-                                headerNames: [
-                                    'id',
-                                    'chr',
-                                    'start',
-                                    'end',
-                                    'total_cn_normal',
-                                    'minor_cp_normal',
-                                    'total_cn_tumor',
-                                    'minor_cn_tumor'
-                                ],
-                                type: 'csv',
-                                chromosomeField: 'chr',
-                                genomicFields: ['start', 'end']
-                            },
-                            dataTransform: [
-                                {
-                                    type: 'filter',
-                                    field: 'total_cn_tumor',
-                                    inRange: [4.5, 900]
-                                }
-                            ],
-                            tracks: [
-                                { mark: 'rect' },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'detail-1' },
-                                    strokeWidth: { value: 0 },
-                                    color: { value: 'gray' }
-                                },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'detail-2' },
-                                    strokeWidth: { value: 0 },
-                                    color: { value: 'gray' }
-                                }
-                            ],
-                            x: { field: 'start', type: 'genomic' },
-                            xe: { field: 'end', type: 'genomic' },
-                            color: { value: '#DFFBBF' },
-                            stroke: { value: 'lightgray' },
-                            strokeWidth: { value: 0.3 },
-                            style: { outline: 'lightgray' },
-                            width: 500,
-                            height: 20
-                        },
-                        {
-                            alignment: 'overlay',
-                            title: 'hg38 | Genes',
-                            data: {
-                                url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
-                                type: 'beddb',
-                                genomicFields: [
-                                    { index: 1, name: 'start' },
-                                    { index: 2, name: 'end' }
-                                ],
-                                valueFields: [
-                                    { index: 5, name: 'strand', type: 'nominal' },
-                                    { index: 3, name: 'name', type: 'nominal' }
-                                ],
-                                exonIntervalFields: [
-                                    { index: 12, name: 'start' },
-                                    { index: 13, name: 'end' }
-                                ]
-                            },
-                            tracks: [
-                                {
-                                    dataTransform: [
-                                        { type: 'filter', field: 'type', oneOf: ['gene'] },
-                                        { type: 'filter', field: 'strand', oneOf: ['+'] }
-                                    ],
-                                    mark: 'triangleRight',
-                                    x: { field: 'end', type: 'genomic' },
-                                    size: { value: 15 }
-                                },
-                                {
-                                    dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
-                                    mark: 'text',
-                                    text: { field: 'name', type: 'nominal' },
-                                    x: { field: 'start', type: 'genomic' },
-                                    xe: { field: 'end', type: 'genomic' },
-                                    style: { dy: -15, outline: 'black', outlineWidth: 0 }
-                                },
-                                {
-                                    dataTransform: [
-                                        { type: 'filter', field: 'type', oneOf: ['gene'] },
-                                        { type: 'filter', field: 'strand', oneOf: ['-'] }
-                                    ],
-                                    mark: 'triangleLeft',
-                                    x: { field: 'start', type: 'genomic' },
-                                    size: { value: 15 },
-                                    style: { align: 'right', outline: 'black', outlineWidth: 0 }
-                                },
-                                {
-                                    dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
-                                    mark: 'rect',
-                                    x: { field: 'start', type: 'genomic' },
-                                    size: { value: 15 },
-                                    xe: { field: 'end', type: 'genomic' }
-                                },
-                                {
-                                    dataTransform: [
-                                        { type: 'filter', field: 'type', oneOf: ['gene'] },
-                                        { type: 'filter', field: 'strand', oneOf: ['+'] }
-                                    ],
-                                    mark: 'rule',
-                                    x: { field: 'start', type: 'genomic' },
-                                    strokeWidth: { value: 2 },
-                                    xe: { field: 'end', type: 'genomic' },
-                                    style: {
-                                        linePattern: { type: 'triangleRight', size: 3.5 },
-                                        outline: 'black',
-                                        outlineWidth: 0
-                                    }
-                                },
-                                {
-                                    dataTransform: [
-                                        { type: 'filter', field: 'type', oneOf: ['gene'] },
-                                        { type: 'filter', field: 'strand', oneOf: ['-'] }
-                                    ],
-                                    mark: 'rule',
-                                    x: { field: 'start', type: 'genomic' },
-                                    strokeWidth: { value: 2 },
-                                    xe: { field: 'end', type: 'genomic' },
-                                    style: {
-                                        linePattern: { type: 'triangleLeft', size: 3.5 },
-                                        outline: 'black',
-                                        outlineWidth: 0
-                                    }
-                                },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'detail-1' },
-                                    strokeWidth: { value: 0 },
-                                    color: { value: 'gray' },
-                                    opacity: { value: 0.3 }
-                                },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'detail-2' },
-                                    strokeWidth: { value: 0 },
-                                    color: { value: 'gray' },
-                                    opacity: { value: 0.3 }
-                                }
-                            ],
-                            row: { field: 'strand', type: 'nominal', domain: ['+', '-'] },
-                            color: {
-                                field: 'strand',
-                                type: 'nominal',
-                                domain: ['+', '-'],
-                                range: ['gray', 'gray']
-                            },
-                            visibility: [
-                                {
-                                    operation: 'less-than',
-                                    measure: 'width',
-                                    threshold: '|xe-x|',
-                                    transitionPadding: 10,
-                                    target: 'mark'
-                                }
-                            ],
-                            opacity: { value: 0.8 },
-                            style: { background: '#F5F5F5', outline: 'lightgray' },
-                            width: 400,
-                            height: 100
-                        },
-                        {
-                            alignment: 'overlay',
-                            data: {
-                                url:
-                                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
-                                type: 'csv',
-                                chromosomeField: 'Chromosome',
-                                genomicFields: ['chromStart', 'chromEnd']
-                            },
-                            tracks: [
-                                { mark: 'rect' },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'detail-1' },
-                                    strokeWidth: { value: 0 },
-                                    color: { value: 'gray' }
-                                },
-                                {
-                                    mark: 'brush',
-                                    x: { linkingId: 'detail-2' },
-                                    strokeWidth: { value: 0 },
-                                    color: { value: 'gray' }
-                                }
-                            ],
-                            color: {
-                                field: 'Stain',
-                                type: 'nominal',
-                                domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
-                                range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
-                            },
-                            x: { field: 'chromStart', type: 'genomic', axis: 'bottom' },
-                            xe: { field: 'chromEnd', type: 'genomic' },
-                            opacity: { value: 0.3 },
-                            width: 1000,
-                            height: 20
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            arrangement: 'horizontal',
-            spacing: 90,
-            views: [
-                {
-                    xDomain: { chromosome: '1', interval: [100000000, 110000000] },
-                    linkingId: 'detail-1',
-                    tracks: [
-                        {
-                            title: 'Reads Detail View 1 (To Be Added)',
-                            data: {
-                                url:
-                                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
-                                type: 'csv',
-                                chromosomeField: 'Chromosome',
-                                genomicFields: ['chromStart', 'chromEnd']
-                            },
-                            mark: 'rect',
-                            color: {
-                                field: 'Stain',
-                                type: 'nominal',
-                                domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
-                                range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
-                            },
-                            x: { field: 'chromStart', type: 'genomic' },
-                            xe: { field: 'chromEnd', type: 'genomic' },
-                            opacity: { value: 0.3 },
-                            width: 452,
-                            height: 100
-                        }
-                    ]
-                },
-                {
-                    linkingId: 'detail-2',
-                    xDomain: { chromosome: '1', interval: [240000000, 250000000] },
-                    tracks: [
-                        {
-                            title: 'Reads Detail View 2 (To Be Added)',
-                            data: {
-                                url:
-                                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
-                                type: 'csv',
-                                chromosomeField: 'Chromosome',
-                                genomicFields: ['chromStart', 'chromEnd']
-                            },
-                            mark: 'rect',
-                            color: {
-                                field: 'Stain',
-                                type: 'nominal',
-                                domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
-                                range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
-                            },
-                            x: { field: 'chromStart', type: 'genomic' },
-                            xe: { field: 'chromEnd', type: 'genomic' },
-                            opacity: { value: 0.3 },
-                            width: 452,
-                            height: 100
-                        }
-                    ]
-                }
-            ]
         }
     ]
 };

--- a/src/gosling-brush/brush-track.ts
+++ b/src/gosling-brush/brush-track.ts
@@ -57,8 +57,13 @@ function BrushTrack(HGC: any, ...args: any[]): any {
                 .attr('d', this.brush)
                 .attr('fill', this.options.projectionFillColor)
                 .attr('stroke', this.options.projectionStrokeColor)
-                .attr('fill-opacity', this.options.projectionFillOpacity)
-                .attr('stroke-opacity', this.options.projectionStrokeOpacity)
+                // Let's hide left and right resizer
+                .attr('fill-opacity', (d: CircularBrushData) =>
+                    d.type === 'brush' ? this.options.projectionFillOpacity : 0
+                )
+                .attr('stroke-opacity', (d: CircularBrushData) =>
+                    d.type === 'brush' ? this.options.projectionStrokeOpacity : 0
+                )
                 .attr('stroke-width', this.options.strokeWidth)
                 .style('pointer-events', 'all')
                 .style('cursor', (d: CircularBrushData) => d.cursor)
@@ -77,8 +82,8 @@ function BrushTrack(HGC: any, ...args: any[]): any {
             return [
                 {
                     type: 'brush',
-                    startAngle: extent[0] + this.RR,
-                    endAngle: extent[1] - this.RR,
+                    startAngle: extent[0],
+                    endAngle: extent[1],
                     cursor: 'grab'
                 },
                 {

--- a/src/gosling-genomic-axis/axis-track.ts
+++ b/src/gosling-genomic-axis/axis-track.ts
@@ -42,7 +42,7 @@ function AxisTrack(HGC: any, ...args: any[]): any {
             this.isShowGlobalMousePosition = isShowGlobalMousePosition;
 
             this.textFontSize = 12;
-            this.textFontFamily = 'Arial';
+            this.textFontFamily = 'sans-serif'; //'Arial';
             this.textFontColor = '#808080';
             this.textStrokeColor = '#ffffff';
             this.pixiTextConfig = {

--- a/src/gosling-genomic-axis/index.ts
+++ b/src/gosling-genomic-axis/index.ts
@@ -1,3 +1,3 @@
-import AxisTrack from './axis-plugin-track';
+import AxisTrack from './axis-track';
 
 export { AxisTrack };

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -126,7 +126,12 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             this.textGraphics = [];
             this.textsBeingUsed = 0; // this variable is being used to improve the performance of text rendering
 
-            HGC.libraries.PIXI.GRAPHICS_CURVES.adaptive = false; // This improves the arc/link rendering performance
+            // This improves the arc/link rendering performance
+            HGC.libraries.PIXI.GRAPHICS_CURVES.adaptive = this.originalSpec.style?.enableSmoothPath ?? false;
+            if (HGC.libraries.PIXI.GRAPHICS_CURVES.adaptive) {
+                HGC.libraries.PIXI.GRAPHICS_CURVES.maxLength = 1;
+                HGC.libraries.PIXI.GRAPHICS_CURVES.maxSegments = 2048 * 10;
+            }
         }
 
         /* ----------------------------------- RENDERING CYCLE ----------------------------------- */


### PR DESCRIPTION
# Update
While continuously working on the SV visualization example, I made several updates:

1. Each arc brush in a track is shown as a single arc (previously, it was three, including left and right resizer,  #427).
2. Added a styling option to add a legend title for categorical colors. This can be more generalized in the future (e.g., showing a title of quantitative colors).
3. Now `backgroundColor` works in circular visualizations.
4. Allowed users to decide whether to use smooth lines w/ worse rendering performance (`style.enableSmoothPath`) (Toward #389).

# Screenshot

![gosling-visualization (2)](https://user-images.githubusercontent.com/9922882/124991236-62b39680-e00f-11eb-84e0-8f831cebab3d.png)

![Screen Shot 2021-07-08 at 5 31 22 PM](https://user-images.githubusercontent.com/9922882/124993417-57159f00-e012-11eb-9ee7-1cd0d2acb6da.png)


Fix #428 
Fix #427 