### PR TITLE
feat: separating `theme` from the main grammar

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "d3-shape": "^2.0.0",
         "file-loader": "^6.0.0",
         "generic-filehandle": "^2.0.3",
+        "gosling-theme": "^0.0.6",
         "higlass": "^1.11.7",
         "higlass-register": "^0.3.0",
         "higlass-text": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "format": "eslint src/ --fix && prettier 'src/**/*.css' --write",
         "schema": "ts-json-schema-generator -p src/index.ts -f tsconfig.json -t GoslingSpec --no-type-check --no-ref-encode > schema/gosling.schema.json",
         "schema-versioning": "mkdir -p schema/history/$npm_package_version && cp schema/gosling.schema.json schema/history/$npm_package_version/gosling$npm_package_version.schema.json && cp src/core/gosling.schema.ts schema/history/$npm_package_version/gosling$npm_package_version.schema.ts",
+        "theme-schema": "ts-json-schema-generator -p src/index.ts -f tsconfig.json -t Theme --no-type-check --no-ref-encode > schema/theme.schema.json",
         "predeploy": "yarn build-editor; echo \"gosling.js.org\" >> build/CNAME",
         "deploy": "gh-pages -d build"
     },
@@ -164,7 +165,7 @@
     },
     "husky": {
         "hooks": {
-            "pre-commit": "yarn changelog && yarn schema && yarn schema-versioning && yarn format && git add .",
+            "pre-commit": "yarn changelog && yarn schema && yarn schema-versioning && yarn theme-schema && yarn format && git add .",
             "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
         }
     }

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -35,27 +35,6 @@
       ],
       "type": "string"
     },
-    "AxisStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "baselineColor": {
-          "type": "string"
-        },
-        "gridColor": {
-          "type": "string"
-        },
-        "gridStrokeWidth": {
-          "type": "number"
-        },
-        "labelColor": {
-          "type": "string"
-        },
-        "tickColor": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
     "BAMData": {
       "additionalProperties": false,
       "properties": {
@@ -1378,27 +1357,6 @@
       ],
       "type": "string"
     },
-    "LegendStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "background": {
-          "type": "string"
-        },
-        "backgroundOpacity": {
-          "type": "number"
-        },
-        "backgroundStroke": {
-          "type": "string"
-        },
-        "labelColor": {
-          "type": "string"
-        },
-        "tickColor": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
     "LogBase": {
       "anyOf": [
         {
@@ -1547,46 +1505,6 @@
         "type",
         "server"
       ],
-      "type": "object"
-    },
-    "MarkStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "color": {
-          "type": "string"
-        },
-        "nominalColorRange": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "opacity": {
-          "type": "number"
-        },
-        "quantitativeSizeRange": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "type": "array"
-        },
-        "size": {
-          "type": "number"
-        },
-        "stroke": {
-          "type": "string"
-        },
-        "strokeWidth": {
-          "type": "number"
-        }
-      },
       "type": "object"
     },
     "MarkStyleInGlyph": {
@@ -2787,9 +2705,6 @@
         "subtitle": {
           "type": "string"
         },
-        "theme": {
-          "$ref": "#/definitions/Theme"
-        },
         "title": {
           "type": "string"
         },
@@ -2948,9 +2863,6 @@
             },
             "text": {
               "$ref": "#/definitions/Channel"
-            },
-            "theme": {
-              "$ref": "#/definitions/Theme"
             },
             "title": {
               "type": "string"
@@ -3475,9 +3387,6 @@
             "text": {
               "$ref": "#/definitions/Channel"
             },
-            "theme": {
-              "$ref": "#/definitions/Theme"
-            },
             "title": {
               "type": "string"
             },
@@ -3920,9 +3829,6 @@
             "subtitle": {
               "type": "string"
             },
-            "theme": {
-              "$ref": "#/definitions/Theme"
-            },
             "title": {
               "type": "string"
             },
@@ -3955,24 +3861,6 @@
           "type": "object"
         }
       ]
-    },
-    "RootStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "background": {
-          "type": "string"
-        },
-        "mousePositionColor": {
-          "type": "string"
-        },
-        "subtitleColor": {
-          "type": "string"
-        },
-        "titleColor": {
-          "type": "string"
-        }
-      },
-      "type": "object"
     },
     "SingleTrack": {
       "additionalProperties": false,
@@ -4917,132 +4805,6 @@
       },
       "type": "object"
     },
-    "Theme": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ThemeType"
-        },
-        {
-          "$ref": "#/definitions/ThemeDeep"
-        }
-      ]
-    },
-    "ThemeDeep": {
-      "additionalProperties": false,
-      "properties": {
-        "area": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "axis": {
-          "$ref": "#/definitions/AxisStyle"
-        },
-        "bar": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "base": {
-          "$ref": "#/definitions/ThemeType"
-        },
-        "brush": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "legend": {
-          "$ref": "#/definitions/LegendStyle"
-        },
-        "line": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "link": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "markCommon": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "point": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "rect": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "root": {
-          "$ref": "#/definitions/RootStyle"
-        },
-        "rule": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "text": {
-          "additionalProperties": false,
-          "properties": {
-            "color": {
-              "type": "string"
-            },
-            "nominalColorRange": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "opacity": {
-              "type": "number"
-            },
-            "quantitativeSizeRange": {
-              "items": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                }
-              ],
-              "maxItems": 2,
-              "minItems": 2,
-              "type": "array"
-            },
-            "size": {
-              "type": "number"
-            },
-            "stroke": {
-              "type": "string"
-            },
-            "strokeWidth": {
-              "type": "number"
-            },
-            "textAnchor": {
-              "enum": [
-                "start",
-                "middle",
-                "end"
-              ],
-              "type": "string"
-            },
-            "textFontWeight": {
-              "enum": [
-                "bold",
-                "normal"
-              ],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "track": {
-          "$ref": "#/definitions/TrackStyle"
-        },
-        "triangle": {
-          "$ref": "#/definitions/MarkStyle"
-        }
-      },
-      "required": [
-        "base"
-      ],
-      "type": "object"
-    },
-    "ThemeType": {
-      "enum": [
-        "light",
-        "dark"
-      ],
-      "type": "string"
-    },
     "Tooltip": {
       "additionalProperties": false,
       "properties": {
@@ -5077,24 +4839,6 @@
           "$ref": "#/definitions/DataTrack"
         }
       ]
-    },
-    "TrackStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "outline": {
-          "type": "string"
-        },
-        "outlineWidth": {
-          "type": "number"
-        },
-        "titleBackground": {
-          "type": "string"
-        },
-        "titleColor": {
-          "type": "string"
-        }
-      },
-      "type": "object"
     },
     "VectorData": {
       "additionalProperties": false,

--- a/schema/history/0.8.5/gosling0.8.5.schema.json
+++ b/schema/history/0.8.5/gosling0.8.5.schema.json
@@ -35,27 +35,6 @@
       ],
       "type": "string"
     },
-    "AxisStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "baselineColor": {
-          "type": "string"
-        },
-        "gridColor": {
-          "type": "string"
-        },
-        "gridStrokeWidth": {
-          "type": "number"
-        },
-        "labelColor": {
-          "type": "string"
-        },
-        "tickColor": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
     "BAMData": {
       "additionalProperties": false,
       "properties": {
@@ -1378,27 +1357,6 @@
       ],
       "type": "string"
     },
-    "LegendStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "background": {
-          "type": "string"
-        },
-        "backgroundOpacity": {
-          "type": "number"
-        },
-        "backgroundStroke": {
-          "type": "string"
-        },
-        "labelColor": {
-          "type": "string"
-        },
-        "tickColor": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
     "LogBase": {
       "anyOf": [
         {
@@ -1547,46 +1505,6 @@
         "type",
         "server"
       ],
-      "type": "object"
-    },
-    "MarkStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "color": {
-          "type": "string"
-        },
-        "nominalColorRange": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "opacity": {
-          "type": "number"
-        },
-        "quantitativeSizeRange": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "type": "array"
-        },
-        "size": {
-          "type": "number"
-        },
-        "stroke": {
-          "type": "string"
-        },
-        "strokeWidth": {
-          "type": "number"
-        }
-      },
       "type": "object"
     },
     "MarkStyleInGlyph": {
@@ -2787,9 +2705,6 @@
         "subtitle": {
           "type": "string"
         },
-        "theme": {
-          "$ref": "#/definitions/Theme"
-        },
         "title": {
           "type": "string"
         },
@@ -2948,9 +2863,6 @@
             },
             "text": {
               "$ref": "#/definitions/Channel"
-            },
-            "theme": {
-              "$ref": "#/definitions/Theme"
             },
             "title": {
               "type": "string"
@@ -3475,9 +3387,6 @@
             "text": {
               "$ref": "#/definitions/Channel"
             },
-            "theme": {
-              "$ref": "#/definitions/Theme"
-            },
             "title": {
               "type": "string"
             },
@@ -3920,9 +3829,6 @@
             "subtitle": {
               "type": "string"
             },
-            "theme": {
-              "$ref": "#/definitions/Theme"
-            },
             "title": {
               "type": "string"
             },
@@ -3955,24 +3861,6 @@
           "type": "object"
         }
       ]
-    },
-    "RootStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "background": {
-          "type": "string"
-        },
-        "mousePositionColor": {
-          "type": "string"
-        },
-        "subtitleColor": {
-          "type": "string"
-        },
-        "titleColor": {
-          "type": "string"
-        }
-      },
-      "type": "object"
     },
     "SingleTrack": {
       "additionalProperties": false,
@@ -4917,132 +4805,6 @@
       },
       "type": "object"
     },
-    "Theme": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ThemeType"
-        },
-        {
-          "$ref": "#/definitions/ThemeDeep"
-        }
-      ]
-    },
-    "ThemeDeep": {
-      "additionalProperties": false,
-      "properties": {
-        "area": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "axis": {
-          "$ref": "#/definitions/AxisStyle"
-        },
-        "bar": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "base": {
-          "$ref": "#/definitions/ThemeType"
-        },
-        "brush": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "legend": {
-          "$ref": "#/definitions/LegendStyle"
-        },
-        "line": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "link": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "markCommon": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "point": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "rect": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "root": {
-          "$ref": "#/definitions/RootStyle"
-        },
-        "rule": {
-          "$ref": "#/definitions/MarkStyle"
-        },
-        "text": {
-          "additionalProperties": false,
-          "properties": {
-            "color": {
-              "type": "string"
-            },
-            "nominalColorRange": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "opacity": {
-              "type": "number"
-            },
-            "quantitativeSizeRange": {
-              "items": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                }
-              ],
-              "maxItems": 2,
-              "minItems": 2,
-              "type": "array"
-            },
-            "size": {
-              "type": "number"
-            },
-            "stroke": {
-              "type": "string"
-            },
-            "strokeWidth": {
-              "type": "number"
-            },
-            "textAnchor": {
-              "enum": [
-                "start",
-                "middle",
-                "end"
-              ],
-              "type": "string"
-            },
-            "textFontWeight": {
-              "enum": [
-                "bold",
-                "normal"
-              ],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "track": {
-          "$ref": "#/definitions/TrackStyle"
-        },
-        "triangle": {
-          "$ref": "#/definitions/MarkStyle"
-        }
-      },
-      "required": [
-        "base"
-      ],
-      "type": "object"
-    },
-    "ThemeType": {
-      "enum": [
-        "light",
-        "dark"
-      ],
-      "type": "string"
-    },
     "Tooltip": {
       "additionalProperties": false,
       "properties": {
@@ -5077,24 +4839,6 @@
           "$ref": "#/definitions/DataTrack"
         }
       ]
-    },
-    "TrackStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "outline": {
-          "type": "string"
-        },
-        "outlineWidth": {
-          "type": "number"
-        },
-        "titleBackground": {
-          "type": "string"
-        },
-        "titleColor": {
-          "type": "string"
-        }
-      },
-      "type": "object"
     },
     "VectorData": {
       "additionalProperties": false,

--- a/schema/history/0.8.5/gosling0.8.5.schema.ts
+++ b/schema/history/0.8.5/gosling0.8.5.schema.ts
@@ -1,5 +1,4 @@
 import { Chromosome } from './utils/chrom-size';
-import { Theme } from './utils/theme';
 
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
@@ -8,14 +7,12 @@ export type RootSpecWithSingleView = SingleView & {
     title?: string;
     subtitle?: string;
     description?: string;
-    theme?: Theme;
 };
 
 export interface RootSpecWithMultipleViews extends MultipleViews {
     title?: string;
     subtitle?: string;
     description?: string;
-    theme?: Theme;
 }
 
 /* ----------------------------- VIEW ----------------------------- */

--- a/schema/theme.schema.json
+++ b/schema/theme.schema.json
@@ -1,0 +1,250 @@
+{
+  "$ref": "#/definitions/Theme",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "AxisStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "baselineColor": {
+          "type": "string"
+        },
+        "gridColor": {
+          "type": "string"
+        },
+        "gridStrokeWidth": {
+          "type": "number"
+        },
+        "labelColor": {
+          "type": "string"
+        },
+        "tickColor": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "LegendStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "background": {
+          "type": "string"
+        },
+        "backgroundOpacity": {
+          "type": "number"
+        },
+        "backgroundStroke": {
+          "type": "string"
+        },
+        "labelColor": {
+          "type": "string"
+        },
+        "tickColor": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "MarkStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "nominalColorRange": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "opacity": {
+          "type": "number"
+        },
+        "quantitativeSizeRange": {
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "size": {
+          "type": "number"
+        },
+        "stroke": {
+          "type": "string"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "RootStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "background": {
+          "type": "string"
+        },
+        "mousePositionColor": {
+          "type": "string"
+        },
+        "subtitleColor": {
+          "type": "string"
+        },
+        "titleColor": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Theme": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ThemeType"
+        },
+        {
+          "$ref": "#/definitions/ThemeDeep"
+        }
+      ]
+    },
+    "ThemeDeep": {
+      "additionalProperties": false,
+      "properties": {
+        "area": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "axis": {
+          "$ref": "#/definitions/AxisStyle"
+        },
+        "bar": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "base": {
+          "$ref": "#/definitions/ThemeType"
+        },
+        "brush": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "legend": {
+          "$ref": "#/definitions/LegendStyle"
+        },
+        "line": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "link": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "markCommon": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "point": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "rect": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "root": {
+          "$ref": "#/definitions/RootStyle"
+        },
+        "rule": {
+          "$ref": "#/definitions/MarkStyle"
+        },
+        "text": {
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "type": "string"
+            },
+            "nominalColorRange": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "opacity": {
+              "type": "number"
+            },
+            "quantitativeSizeRange": {
+              "items": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            "size": {
+              "type": "number"
+            },
+            "stroke": {
+              "type": "string"
+            },
+            "strokeWidth": {
+              "type": "number"
+            },
+            "textAnchor": {
+              "enum": [
+                "start",
+                "middle",
+                "end"
+              ],
+              "type": "string"
+            },
+            "textFontWeight": {
+              "enum": [
+                "bold",
+                "normal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "track": {
+          "$ref": "#/definitions/TrackStyle"
+        },
+        "triangle": {
+          "$ref": "#/definitions/MarkStyle"
+        }
+      },
+      "required": [
+        "base"
+      ],
+      "type": "object"
+    },
+    "ThemeType": {
+      "enum": [
+        "light",
+        "dark"
+      ],
+      "type": "string"
+    },
+    "TrackStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "outline": {
+          "type": "string"
+        },
+        "outlineWidth": {
+          "type": "number"
+        },
+        "titleBackground": {
+          "type": "string"
+        },
+        "titleColor": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/schema/theme.schema.json
+++ b/schema/theme.schema.json
@@ -222,10 +222,6 @@
       "type": "object"
     },
     "ThemeType": {
-      "enum": [
-        "light",
-        "dark"
-      ],
       "type": "string"
     },
     "TrackStyle": {

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -3,17 +3,19 @@ import { compileLayout } from './layout/layout';
 import { HiGlassSpec } from './higlass.schema';
 import { traverseToFixSpecDownstream, overrideTemplates } from './utils/spec-preprocess';
 import { Size } from './utils/bounding-box';
+import { CompleteThemeDeep } from './utils/theme';
 
-export function compile(spec: GoslingSpec, setHg: (hg: HiGlassSpec, size: Size) => void) {
+export function compile(
+    spec: GoslingSpec,
+    setHg: (hg: HiGlassSpec, size: Size) => void,
+    theme: Required<CompleteThemeDeep>
+) {
     // Override default visual encoding (i.e., `DataTrack` => `BasicSingleTrack`)
     overrideTemplates(spec);
-
-    // Use default theme if not specified
-    if (!spec.theme) spec.theme = 'light';
 
     // Fix track specs by looking into the root-level spec
     traverseToFixSpecDownstream(spec);
 
     // Make HiGlass models for individual tracks
-    compileLayout(spec, setHg);
+    compileLayout(spec, setHg, theme);
 }

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -8,7 +8,7 @@ import * as gosling from '..';
 import { View as HgView } from './higlass.schema';
 import { traverseViewsInViewConfig } from '../core/utils/view-config';
 import { GET_CHROM_SIZES } from './utils/assembly';
-import { getTheme } from './utils/theme';
+import { getTheme, Theme } from './utils/theme';
 import { CommonEventData, EVENT_TYPE, MouseHoverCallback, UserDefinedEvents } from './api';
 import uuid from 'uuid';
 
@@ -25,6 +25,7 @@ interface GoslingCompProps {
     border?: string;
     id?: string;
     className?: string;
+    theme?: Theme;
 }
 
 // TODO: specify types other than "any"
@@ -35,6 +36,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
     const [size, setSize] = useState({ width: 200, height: 200 });
 
     // Styling
+    const theme: Theme = typeof props.theme !== 'undefined' ? props.theme : 'light';
     const padding = typeof props.padding !== 'undefined' ? props.padding : 60;
     const margin = typeof props.margin !== 'undefined' ? props.margin : 0;
     const border = typeof props.border !== 'undefined' ? props.border : 'none';
@@ -135,7 +137,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
 
                     const ctx = canvasWithBg.getContext('2d')!;
                     if (!transparentBackground) {
-                        ctx.fillStyle = getTheme(gs?.theme).root.background;
+                        ctx.fillStyle = getTheme(theme).root.background;
                         ctx.fillRect(0, 0, canvasWithBg.width, canvasWithBg.height);
                     }
                     ctx.drawImage(canvas, 0, 0);
@@ -173,7 +175,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
 
                     const ctx = canvasWithBg.getContext('2d')!;
                     if (!transparentBackground) {
-                        ctx.fillStyle = getTheme(gs?.theme).root.background;
+                        ctx.fillStyle = getTheme(theme).root.background;
                         ctx.fillRect(0, 0, canvasWithBg.width, canvasWithBg.height);
                     }
                     ctx.drawImage(canvas, 0, 0);
@@ -223,7 +225,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                         padding,
                         margin,
                         border,
-                        background: getTheme(gs?.theme).root.background,
+                        background: getTheme(theme).root.background,
                         width: size.width + padding * 2,
                         height: size.height + padding * 2,
                         textAlign: 'left'
@@ -235,7 +237,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                         style={{
                             position: 'relative',
                             display: 'block',
-                            background: getTheme(gs?.theme).root.background,
+                            background: getTheme(theme).root.background,
                             margin: 0,
                             padding: 0, // non-zero padding acts unexpectedly w/ HiGlassComponent
                             width: size.width,

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -8,7 +8,7 @@ import * as gosling from '..';
 import { View as HgView } from './higlass.schema';
 import { traverseViewsInViewConfig } from '../core/utils/view-config';
 import { GET_CHROM_SIZES } from './utils/assembly';
-import { getTheme, Theme } from './utils/theme';
+import { CompleteThemeDeep, getTheme, Theme } from './utils/theme';
 import { CommonEventData, EVENT_TYPE, MouseHoverCallback, UserDefinedEvents } from './api';
 import uuid from 'uuid';
 
@@ -36,7 +36,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
     const [size, setSize] = useState({ width: 200, height: 200 });
 
     // Styling
-    const theme: Theme = typeof props.theme !== 'undefined' ? props.theme : 'light';
+    const theme: Required<CompleteThemeDeep> = getTheme(typeof props.theme !== 'undefined' ? props.theme : 'light');
     const padding = typeof props.padding !== 'undefined' ? props.padding : 60;
     const margin = typeof props.margin !== 'undefined' ? props.margin : 0;
     const border = typeof props.border !== 'undefined' ? props.border : 'none';
@@ -137,7 +137,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
 
                     const ctx = canvasWithBg.getContext('2d')!;
                     if (!transparentBackground) {
-                        ctx.fillStyle = getTheme(theme).root.background;
+                        ctx.fillStyle = theme.root.background;
                         ctx.fillRect(0, 0, canvasWithBg.width, canvasWithBg.height);
                     }
                     ctx.drawImage(canvas, 0, 0);
@@ -175,7 +175,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
 
                     const ctx = canvasWithBg.getContext('2d')!;
                     if (!transparentBackground) {
-                        ctx.fillStyle = getTheme(theme).root.background;
+                        ctx.fillStyle = theme.root.background;
                         ctx.fillRect(0, 0, canvasWithBg.width, canvasWithBg.height);
                     }
                     ctx.drawImage(canvas, 0, 0);
@@ -203,14 +203,18 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                 return;
             }
 
-            gosling.compile(gs, (newHs: gosling.HiGlassSpec, newSize: { width: number; height: number }) => {
-                if (props.compiled) {
-                    // If a callback function is provided, return compiled information.
-                    props.compiled(gs, newHs);
-                }
-                setHs(newHs);
-                setSize(newSize);
-            });
+            gosling.compile(
+                gs,
+                (newHs: gosling.HiGlassSpec, newSize: { width: number; height: number }) => {
+                    if (props.compiled) {
+                        // If a callback function is provided, return compiled information.
+                        props.compiled(gs, newHs);
+                    }
+                    setHs(newHs);
+                    setSize(newSize);
+                },
+                theme
+            );
         }
     }, [gs]);
 
@@ -225,7 +229,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                         padding,
                         margin,
                         border,
-                        background: getTheme(theme).root.background,
+                        background: theme.root.background,
                         width: size.width + padding * 2,
                         height: size.height + padding * 2,
                         textAlign: 'left'
@@ -237,7 +241,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                         style={{
                             position: 'relative',
                             display: 'block',
-                            background: getTheme(theme).root.background,
+                            background: theme.root.background,
                             margin: 0,
                             padding: 0, // non-zero padding acts unexpectedly w/ HiGlassComponent
                             width: size.width,
@@ -259,7 +263,6 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                                 viewPaddingLeft: 0,
                                 viewPaddingRight: 0,
                                 sizeMode: 'bounded',
-                                // theme: gs?.theme, // TODO: do we need this?
                                 rangeSelectionOnAlt: true // this allows switching between `selection` and `zoom&pan` mode
                             }}
                             viewConfig={hs}

--- a/src/core/gosling-to-higlass.test.ts
+++ b/src/core/gosling-to-higlass.test.ts
@@ -3,6 +3,7 @@ import { SingleTrack } from './gosling.schema';
 import { HiGlassModel } from './higlass-model';
 import { EX_TRACK_SEMANTIC_ZOOM } from '../editor/example/semantic-zoom';
 import { convertToFlatTracks } from './utils/spec-preprocess';
+import { getTheme } from './utils/theme';
 
 describe('Should convert gosling spec to higlass view config.', () => {
     it('Should return a generated higlass view config correctly', () => {
@@ -21,7 +22,8 @@ describe('Should convert gosling spec to higlass view config.', () => {
                 y: 0,
                 w: 12,
                 h: 12
-            }
+            },
+            getTheme()
         ).spec();
         expect(Object.keys(higlass)).not.toHaveLength(0);
     });
@@ -43,7 +45,8 @@ describe('Should convert gosling spec to higlass view config.', () => {
                 y: 0,
                 w: 12,
                 h: 12
-            }
+            },
+            getTheme()
         ).spec();
         expect(higlass.views).toHaveLength(0);
     });

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -9,7 +9,7 @@ import { getGenomicChannelKeyFromTrack, getGenomicChannelFromTrack } from './uti
 import { viridisColorMap } from './utils/colors';
 import { IsDataDeep, IsChannelDeep, IsDataDeepTileset } from './gosling.schema.guards';
 import { DEFAULT_SUBTITLE_HEIGHT, DEFAULT_TITLE_HEIGHT } from './layout/defaults';
-import { getTheme, Theme } from './utils/theme';
+import { CompleteThemeDeep } from './utils/theme';
 
 /**
  * Convert a gosling track into a HiGlass view and add it into a higlass model.
@@ -19,7 +19,7 @@ export function goslingToHiGlass(
     gosTrack: Track,
     bb: BoundingBox,
     layout: RelativePosition,
-    theme: Theme = 'light'
+    theme: Required<CompleteThemeDeep>
 ): HiGlassModel {
     // TODO: check whether there are multiple track.data across superposed tracks
     // ...
@@ -55,14 +55,14 @@ export function goslingToHiGlass(
             options: {
                 /* Mouse hover position */
                 showMousePosition: firstResolvedSpec.layout === 'circular' ? false : true, // show mouse position only for linear tracks // TODO: or vertical
-                mousePositionColor: getTheme(theme).root.mousePositionColor,
+                mousePositionColor: theme.root.mousePositionColor,
                 /* Track title */
                 name: firstResolvedSpec.title,
                 fontSize: 12,
                 labelPosition: firstResolvedSpec.title ? 'topLeft' : 'none',
                 labelShowResolution: false,
-                labelColor: getTheme(theme).track.titleColor,
-                labelBackgroundColor: getTheme(theme).track.titleBackground,
+                labelColor: theme.track.titleColor,
+                labelBackgroundColor: theme.track.titleBackground,
                 labelTextOpacity: 1,
                 labelLeftMargin: 1,
                 labelTopMargin: 1,
@@ -166,7 +166,7 @@ export function goslingToHiGlass(
                 bb.width,
                 DEFAULT_TITLE_HEIGHT,
                 firstResolvedSpec.title,
-                getTheme(theme).root.titleColor,
+                theme.root.titleColor,
                 18,
                 'bold'
             );
@@ -176,7 +176,7 @@ export function goslingToHiGlass(
                 bb.width,
                 DEFAULT_SUBTITLE_HEIGHT,
                 firstResolvedSpec.subtitle,
-                getTheme(theme).root.subtitleColor,
+                theme.root.subtitleColor,
                 14,
                 'normal'
             );

--- a/src/core/gosling-track-model.test.ts
+++ b/src/core/gosling-track-model.test.ts
@@ -2,6 +2,7 @@ import { GoslingTrackModel } from './gosling-track-model';
 import { Track } from './gosling.schema';
 import isEqual from 'lodash/isEqual';
 import { IsChannelDeep, IsChannelValue } from './gosling.schema.guards';
+import { getTheme } from './utils/theme';
 
 const MINIMAL_TRACK_SPEC: Track = {
     data: { url: '', type: 'csv' },
@@ -13,7 +14,7 @@ const MINIMAL_TRACK_SPEC: Track = {
 
 describe('gosling track model should properly validate the original spec', () => {
     it('minimal spec with on genomic coordiate should be valid', () => {
-        const model = new GoslingTrackModel(MINIMAL_TRACK_SPEC, []);
+        const model = new GoslingTrackModel(MINIMAL_TRACK_SPEC, [], getTheme());
         expect(model.validateSpec().valid).toBe(true);
     });
 
@@ -22,7 +23,7 @@ describe('gosling track model should properly validate the original spec', () =>
             ...MINIMAL_TRACK_SPEC,
             row: { field: 'x', type: 'quantitative' }
         };
-        const model = new GoslingTrackModel(track, []);
+        const model = new GoslingTrackModel(track, [], getTheme());
         expect(model.validateSpec().valid).toBe(false);
     });
 
@@ -33,10 +34,10 @@ describe('gosling track model should properly validate the original spec', () =>
             width: 300,
             height: 300
         };
-        const model = new GoslingTrackModel(track, []);
+        const model = new GoslingTrackModel(track, [], getTheme());
         expect(model.validateSpec().valid).toBe(false);
 
-        const model2 = new GoslingTrackModel({ ...track, x: { field: 'x', type: 'genomic' } }, []);
+        const model2 = new GoslingTrackModel({ ...track, x: { field: 'x', type: 'genomic' } }, [], getTheme());
         expect(model2.validateSpec().valid).toBe(true);
     });
 
@@ -45,25 +46,25 @@ describe('gosling track model should properly validate the original spec', () =>
             ...MINIMAL_TRACK_SPEC,
             color: { field: 'f', type: 'genomic' }
         };
-        const model = new GoslingTrackModel(track, []);
+        const model = new GoslingTrackModel(track, [], getTheme());
         expect(model.validateSpec().valid).toBe(false);
 
         if (IsChannelDeep(track.color)) {
             track.color.type = 'nominal';
         }
-        const model2 = new GoslingTrackModel(track, []);
+        const model2 = new GoslingTrackModel(track, [], getTheme());
         expect(model2.validateSpec().valid).toBe(true);
     });
 });
 
 describe('default options should be added into the original spec', () => {
     it('original spec should be the same after making a gosling model', () => {
-        const model = new GoslingTrackModel(MINIMAL_TRACK_SPEC, []);
+        const model = new GoslingTrackModel(MINIMAL_TRACK_SPEC, [], getTheme());
         expect(isEqual(model.originalSpec(), MINIMAL_TRACK_SPEC)).toEqual(true);
     });
 
     it('default opacity should be added if it is missing in the spec', () => {
-        const model = new GoslingTrackModel(MINIMAL_TRACK_SPEC, []);
+        const model = new GoslingTrackModel(MINIMAL_TRACK_SPEC, [], getTheme());
         const spec = model.spec();
         expect(spec.opacity).not.toBeUndefined();
         expect(IsChannelValue(spec.opacity) ? spec.opacity.value : undefined).toBe(1);
@@ -74,7 +75,7 @@ describe('default options should be added into the original spec', () => {
             ...MINIMAL_TRACK_SPEC,
             color: { field: 'f', type: 'quantitative' }
         };
-        const model = new GoslingTrackModel(track, []);
+        const model = new GoslingTrackModel(track, [], getTheme());
         const spec = model.spec();
         const range = IsChannelDeep(spec.color) ? spec.color.range : [];
         expect(range).not.toBeUndefined();
@@ -93,7 +94,7 @@ describe('Gosling track model should be properly generated with data', () => {
             opacity: { value: 1 },
             height: 300
         };
-        const model = new GoslingTrackModel(track, [{ row: 'a' }, { row: 'b' }, { row: 'a' }]);
+        const model = new GoslingTrackModel(track, [{ row: 'a' }, { row: 'b' }, { row: 'a' }], getTheme());
         const spec = model.spec();
         const rowDomain = IsChannelDeep(spec.row) ? (spec.row.domain as string[]) : [];
 
@@ -120,11 +121,15 @@ describe('Gosling track model should be properly generated with data', () => {
             opacity: { field: 'yStr', type: 'quantitative' },
             height: 300
         };
-        const model = new GoslingTrackModel(track, [
-            { color: 1, row: 'a', y: 5, yStr: '5' },
-            { color: 2, row: 'b', y: 7, yStr: '7' },
-            { color: 3, row: 'a', y: 10, yStr: '10' }
-        ]);
+        const model = new GoslingTrackModel(
+            track,
+            [
+                { color: 1, row: 'a', y: 5, yStr: '5' },
+                { color: 2, row: 'b', y: 7, yStr: '7' },
+                { color: 3, row: 'a', y: 10, yStr: '10' }
+            ],
+            getTheme()
+        );
         const spec = model.spec();
         const colorDomain = IsChannelDeep(spec.color) ? (spec.color.domain as string[]) : [];
         const rowDomain = IsChannelDeep(spec.row) ? (spec.row.domain as string[]) : [];
@@ -163,7 +168,7 @@ describe('Gosling track model should be properly generated with data', () => {
             ...MINIMAL_TRACK_SPEC,
             y: { field: 'y', type: 'quantitative' }
         };
-        const model = new GoslingTrackModel(track, []);
+        const model = new GoslingTrackModel(track, [], getTheme());
         const spec = model.spec();
         const yDomain = IsChannelDeep(spec.y) ? (spec.y.domain as number[]) : [];
 
@@ -194,7 +199,7 @@ describe('Visual marks should be correctly encoded with data', () => {
             width: size.width,
             height: size.height
         };
-        const model = new GoslingTrackModel(track, data);
+        const model = new GoslingTrackModel(track, data, getTheme());
 
         // y channel not encoded, hence middle of the height
         expect(model.encodedValue('y', 0)).toBe(size.height / 2.0 / nSize);
@@ -226,7 +231,7 @@ describe('Visual marks should be correctly encoded with data', () => {
             width: size.width,
             height: size.height
         };
-        const model2 = new GoslingTrackModel(track2, data);
+        const model2 = new GoslingTrackModel(track2, data, getTheme());
 
         // y is encoded with quantitative values, hence linear scale values with zero baseline
         expect(model2.encodedValue('y', 0)).toBe(0);

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -33,7 +33,7 @@ import {
     IsRangeArray
 } from './gosling.schema.guards';
 import { CHANNEL_DEFAULTS } from './channel';
-import { getTheme, Theme } from './utils/theme';
+import { CompleteThemeDeep } from './utils/theme';
 
 export type ScaleType =
     | ScaleLinear<any, any>
@@ -45,7 +45,7 @@ export type ScaleType =
 export class GoslingTrackModel {
     private id: string;
 
-    private theme: Theme;
+    private theme: Required<CompleteThemeDeep>;
 
     /* spec */
     private specOriginal: SingleTrack; // original spec of users
@@ -60,7 +60,7 @@ export class GoslingTrackModel {
         [channel: string]: ScaleType;
     };
 
-    constructor(spec: SingleTrack, data: { [k: string]: number | string }[], theme: Theme = 'light') {
+    constructor(spec: SingleTrack, data: { [k: string]: number | string }[], theme: Required<CompleteThemeDeep>) {
         this.id = uuid.v1();
 
         this.theme = theme;
@@ -565,7 +565,7 @@ export class GoslingTrackModel {
                             break;
                         case 'size':
                             // TODO: make as an object
-                            if (spec.mark === 'line') value = getTheme(this.theme).line.size;
+                            if (spec.mark === 'line') value = this.theme.line.size;
                             else if (spec.mark === 'bar') value = undefined;
                             else if (spec.mark === 'rect') value = undefined;
                             else if (spec.mark === 'triangleRight') value = undefined;
@@ -579,24 +579,24 @@ export class GoslingTrackModel {
                                 IsChannelDeep(spec.xe)
                             )
                                 value = undefined;
-                            else value = getTheme(this.theme).point.size;
+                            else value = this.theme.point.size;
                             break;
                         case 'color':
-                            value = getTheme(this.theme).markCommon.color;
+                            value = this.theme.markCommon.color;
                             break;
                         case 'row':
                             value = 0;
                             break;
                         case 'stroke':
-                            value = getTheme(this.theme).markCommon.stroke;
+                            value = this.theme.markCommon.stroke;
                             break;
                         case 'strokeWidth':
-                            if (spec.mark === 'rule') value = getTheme(this.theme).rule.strokeWidth;
-                            else if (spec.mark === 'withinLink') value = getTheme(this.theme).link.strokeWidth;
-                            else value = getTheme(this.theme).markCommon.strokeWidth;
+                            if (spec.mark === 'rule') value = this.theme.rule.strokeWidth;
+                            else if (spec.mark === 'withinLink') value = this.theme.link.strokeWidth;
+                            else value = this.theme.markCommon.strokeWidth;
                             break;
                         case 'opacity':
-                            value = getTheme(this.theme).markCommon.opacity;
+                            value = this.theme.markCommon.opacity;
                             break;
                         case 'text':
                             value = '';
@@ -635,7 +635,7 @@ export class GoslingTrackModel {
                                 range = CHANNEL_DEFAULTS.QUANTITATIVE_COLOR as PREDEFINED_COLORS;
                                 break;
                             case 'size':
-                                range = getTheme(this.theme).markCommon.quantitativeSizeRange;
+                                range = this.theme.markCommon.quantitativeSizeRange;
                                 break;
                             case 'strokeWidth':
                                 range = [1, 3];
@@ -668,7 +668,7 @@ export class GoslingTrackModel {
                                 break;
                             case 'color':
                             case 'stroke':
-                                range = getTheme(this.theme).markCommon.nominalColorRange;
+                                range = this.theme.markCommon.nominalColorRange;
                                 break;
                             case 'row':
                                 range = [0, spec.height];

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -1,5 +1,4 @@
 import { Chromosome } from './utils/chrom-size';
-import { Theme } from './utils/theme';
 
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
@@ -8,14 +7,12 @@ export type RootSpecWithSingleView = SingleView & {
     title?: string;
     subtitle?: string;
     description?: string;
-    theme?: Theme;
 };
 
 export interface RootSpecWithMultipleViews extends MultipleViews {
     title?: string;
     subtitle?: string;
     description?: string;
-    theme?: Theme;
 }
 
 /* ----------------------------- VIEW ----------------------------- */

--- a/src/core/higlass-model.test.ts
+++ b/src/core/higlass-model.test.ts
@@ -1,6 +1,7 @@
 import uuid from 'uuid';
 import { HiGlassModel } from './higlass-model';
 import { GET_CHROM_SIZES } from './utils/assembly';
+import { getTheme } from './utils/theme';
 
 describe('Should produce higlass model correctly', () => {
     it('Should set default values correctly', () => {
@@ -23,7 +24,7 @@ describe('Should produce higlass model correctly', () => {
     it('Should add brush correctly', () => {
         const higlass = new HiGlassModel();
         higlass.addDefaultView(uuid.v1());
-        higlass.addBrush('linear', higlass.getLastView().uid ?? '', 'from');
+        higlass.addBrush('linear', higlass.getLastView().uid ?? '', getTheme(), 'from');
         expect(JSON.stringify(higlass.spec())).toContain('viewport-projection-horizontal');
     });
 

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -6,7 +6,7 @@ import { getNumericDomain } from './utils/scales';
 import { RelativePosition } from './utils/bounding-box';
 import { validateSpec } from './utils/validate';
 import { GET_CHROM_SIZES } from './utils/assembly';
-import { getTheme, Theme } from './utils/theme';
+import { CompleteThemeDeep } from './utils/theme';
 
 export const HIGLASS_AXIS_SIZE = 30;
 const getViewTemplate = (assembly?: string) => {
@@ -118,6 +118,7 @@ export class HiGlassModel {
     public addBrush(
         layout: 'circular' | 'linear',
         viewId: string,
+        theme: Required<CompleteThemeDeep>,
         fromViewUid?: string,
         style?: {
             color?: string;
@@ -128,8 +129,7 @@ export class HiGlassModel {
             endAngle?: number;
             innerRadius?: number;
             outerRadius?: number;
-        },
-        theme: Theme = 'light'
+        }
     ) {
         if (!fromViewUid) return;
 
@@ -140,11 +140,11 @@ export class HiGlassModel {
             uid: uuid.v4(),
             fromViewUid,
             options: {
-                projectionFillColor: style?.color ?? getTheme(theme).brush.color,
-                projectionStrokeColor: style?.stroke ?? getTheme(theme).brush.stroke,
-                projectionFillOpacity: style?.opacity ?? getTheme(theme).brush.opacity,
-                projectionStrokeOpacity: style?.opacity ?? getTheme(theme).brush.opacity,
-                strokeWidth: style?.strokeWidth ?? getTheme(theme).brush.strokeWidth,
+                projectionFillColor: style?.color ?? theme.brush.color,
+                projectionStrokeColor: style?.stroke ?? theme.brush.stroke,
+                projectionFillOpacity: style?.opacity ?? theme.brush.opacity,
+                projectionStrokeOpacity: style?.opacity ?? theme.brush.opacity,
+                strokeWidth: style?.strokeWidth ?? theme.brush.strokeWidth,
                 startAngle: style?.startAngle,
                 endAngle: style?.endAngle,
                 innerRadius: style?.innerRadius,
@@ -252,7 +252,7 @@ export class HiGlassModel {
             height?: number;
             startAngle?: number;
             endAngle?: number;
-            theme?: Theme;
+            theme: Required<CompleteThemeDeep>;
         }
     ) {
         if (!this.hg.views) return this;
@@ -266,8 +266,8 @@ export class HiGlassModel {
                 ...options,
                 assembly: this.getAssembly(),
                 stroke: 'transparent', // text outline
-                color: getTheme(options.theme).axis.labelColor,
-                tickColor: getTheme(options.theme).axis.tickColor,
+                color: options.theme.axis.labelColor,
+                tickColor: options.theme.axis.tickColor,
                 tickFormat: type === 'narrower' ? 'si' : 'plain',
                 tickPositions: type === 'regular' ? 'even' : 'ends',
                 reverseOrientation: position === 'bottom' || position === 'right' ? true : false

--- a/src/core/layout/higlass.ts
+++ b/src/core/layout/higlass.ts
@@ -4,11 +4,13 @@ import { HiGlassModel } from '../higlass-model';
 import { HiGlassSpec } from '../higlass.schema';
 import { getLinkingInfo } from '../utils/linking';
 import { GoslingSpec } from '../gosling.schema';
+import { CompleteThemeDeep } from '../utils/theme';
 
 export function renderHiGlass(
     spec: GoslingSpec,
     trackInfos: TrackInfo[],
-    setHg: (hg: HiGlassSpec, size: Size) => void
+    setHg: (hg: HiGlassSpec, size: Size) => void,
+    theme: CompleteThemeDeep
 ) {
     if (trackInfos.length === 0) {
         // no tracks to render
@@ -21,7 +23,7 @@ export function renderHiGlass(
     /* Update the HiGlass model by iterating tracks */
     trackInfos.forEach(tb => {
         const { track, boundingBox: bb, layout } = tb;
-        goslingToHiGlass(hgModel, track, bb, layout, spec.theme);
+        goslingToHiGlass(hgModel, track, bb, layout, theme);
     });
 
     /* Add linking information to the HiGlass model */
@@ -35,9 +37,9 @@ export function renderHiGlass(
             hgModel.addBrush(
                 info.layout,
                 info.viewId,
+                theme,
                 linkingInfos.find(d => !d.isBrush && d.linkId === info.linkId)?.viewId,
-                info.style,
-                spec.theme
+                info.style
             );
         });
 

--- a/src/core/layout/layout.ts
+++ b/src/core/layout/layout.ts
@@ -2,11 +2,16 @@ import { GoslingSpec } from '../gosling.schema';
 import { renderHiGlass } from './higlass';
 import { getRelativeTrackInfo, Size } from '../utils/bounding-box';
 import { HiGlassSpec } from '../higlass.schema';
+import { CompleteThemeDeep } from '../utils/theme';
 
-export function compileLayout(spec: GoslingSpec, setHg: (hg: HiGlassSpec, size: Size) => void) {
+export function compileLayout(
+    spec: GoslingSpec,
+    setHg: (hg: HiGlassSpec, size: Size) => void,
+    theme: CompleteThemeDeep
+) {
     // Generate arrangement data
     const trackInfo = getRelativeTrackInfo(spec);
 
     // Render HiGlass tracks
-    renderHiGlass(spec, trackInfo, setHg);
+    renderHiGlass(spec, trackInfo, setHg, theme);
 }

--- a/src/core/mark/axis.test.ts
+++ b/src/core/mark/axis.test.ts
@@ -1,6 +1,7 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { SingleTrack } from '../gosling.schema';
+import { getTheme } from '../utils/theme';
 import { drawLinearYAxis } from './axis';
 
 describe('Y Axis', () => {
@@ -19,7 +20,7 @@ describe('Y Axis', () => {
             { x: 11, y: 22 },
             { x: 111, y: 222 }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawLinearYAxis(
             {
                 libraries: {
@@ -34,7 +35,8 @@ describe('Y Axis', () => {
                 pBorder: g
             },
             null,
-            model
+            model,
+            getTheme()
         );
     });
 
@@ -57,7 +59,7 @@ describe('Y Axis', () => {
             { x: 11, y: 22 },
             { x: 111, y: 222 }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawLinearYAxis(
             {
                 libraries: {
@@ -72,7 +74,8 @@ describe('Y Axis', () => {
                 pBorder: g
             },
             null,
-            model
+            model,
+            getTheme()
         );
     });
 });

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -1,7 +1,7 @@
 import { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
-import { getTheme, Theme } from '../utils/theme';
+import { CompleteThemeDeep } from '../utils/theme';
 import { scaleLinear } from 'd3-scale';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 
@@ -27,7 +27,13 @@ export const getAxisTextStyle = (fill = 'black') => {
 /**
  * Draw linear scale Y axis
  */
-export function drawLinearYAxis(HGC: any, trackInfo: any, tile: any, gos: GoslingTrackModel, theme: Theme = 'light') {
+export function drawLinearYAxis(
+    HGC: any,
+    trackInfo: any,
+    tile: any,
+    gos: GoslingTrackModel,
+    theme: Required<CompleteThemeDeep>
+) {
     const spec = gos.spec();
     const CIRCULAR = spec.layout === 'circular';
     const yDomain = gos.getChannelDomainArray('y');
@@ -80,7 +86,7 @@ export function drawLinearYAxis(HGC: any, trackInfo: any, tile: any, gos: Goslin
         /* Axis Baseline */
         graphics.lineStyle(
             1,
-            colorToHex(getTheme(theme).axis.baselineColor),
+            colorToHex(theme.axis.baselineColor),
             1, // alpha
             0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
         );
@@ -98,7 +104,7 @@ export function drawLinearYAxis(HGC: any, trackInfo: any, tile: any, gos: Goslin
 
         graphics.lineStyle(
             1,
-            colorToHex(getTheme(theme).axis.tickColor),
+            colorToHex(theme.axis.tickColor),
             1, // alpha
             0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
         );
@@ -121,7 +127,7 @@ export function drawLinearYAxis(HGC: any, trackInfo: any, tile: any, gos: Goslin
             const y = yScale(t);
             tickEnd = isLeft ? dx + TICK_SIZE * 2 : dx - TICK_SIZE * 2;
 
-            const textGraphic = new HGC.libraries.PIXI.Text(t, getAxisTextStyle(getTheme(theme).axis.labelColor));
+            const textGraphic = new HGC.libraries.PIXI.Text(t, getAxisTextStyle(theme.axis.labelColor));
             textGraphic.anchor.x = isLeft ? 0 : 1;
             textGraphic.anchor.y = y === 0 ? 0.9 : 0.5;
             textGraphic.position.x = tickEnd;
@@ -135,7 +141,13 @@ export function drawLinearYAxis(HGC: any, trackInfo: any, tile: any, gos: Goslin
 /**
  * Draw linear scale Y axis
  */
-export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: GoslingTrackModel, theme: Theme = 'light') {
+export function drawCircularYAxis(
+    HGC: any,
+    trackInfo: any,
+    tile: any,
+    gos: GoslingTrackModel,
+    theme: Required<CompleteThemeDeep>
+) {
     const spec = gos.spec();
     const CIRCULAR = spec.layout === 'circular';
     const yDomain = gos.getChannelDomainArray('y');
@@ -199,7 +211,7 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
 
         graphics.lineStyle(
             1,
-            colorToHex(getTheme(theme).axis.baselineColor),
+            colorToHex(theme.axis.baselineColor),
             1, // alpha
             0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
         );
@@ -224,7 +236,7 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
         // Render ticks
         graphics.lineStyle(
             1,
-            colorToHex(getTheme(theme).axis.tickColor),
+            colorToHex(theme.axis.tickColor),
             1, // alpha
             0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
         );
@@ -289,7 +301,7 @@ export function drawCircularYAxis(HGC: any, trackInfo: any, tile: any, gos: Gosl
             const pos = cartesianToPolar(SCALED_TICK_SIZE(currentR) * 2, tw, currentR, cx, cy, startAngle, endAngle);
 
             // ! Maybe combine this part with `axis-plugin-track.ts`
-            const textGraphic = new HGC.libraries.PIXI.Text(t, getAxisTextStyle(getTheme(theme).axis.labelColor));
+            const textGraphic = new HGC.libraries.PIXI.Text(t, getAxisTextStyle(theme.axis.labelColor));
             textGraphic.anchor.x = isLeft ? 1 : 0;
             textGraphic.anchor.y = 0.5;
             textGraphic.position.x = pos.x;

--- a/src/core/mark/grid.test.ts
+++ b/src/core/mark/grid.test.ts
@@ -1,6 +1,7 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { SingleTrack } from '../gosling.schema';
+import { getTheme } from '../utils/theme';
 import { drawGrid } from './grid';
 
 describe('Grid', () => {
@@ -24,8 +25,8 @@ describe('Grid', () => {
             { x: 11, y: 22 },
             { x: 111, y: 222 }
         ];
-        const model = new GoslingTrackModel(t, d);
-        drawGrid(HGC, model);
+        const model = new GoslingTrackModel(t, d, getTheme());
+        drawGrid(HGC, model, getTheme());
     });
 
     it('Linear Row Grid', () => {
@@ -42,8 +43,8 @@ describe('Grid', () => {
             { x: 11, y: '22' },
             { x: 111, y: '222' }
         ];
-        const model = new GoslingTrackModel(t, d);
-        drawGrid(HGC, model);
+        const model = new GoslingTrackModel(t, d, getTheme());
+        drawGrid(HGC, model, getTheme());
     });
 
     it('Circular Y Grid', () => {
@@ -65,8 +66,8 @@ describe('Grid', () => {
             { x: 11, y: 22 },
             { x: 111, y: 222 }
         ];
-        const model = new GoslingTrackModel(t, d);
-        drawGrid(HGC, model);
+        const model = new GoslingTrackModel(t, d, getTheme());
+        drawGrid(HGC, model, getTheme());
     });
 
     it('Circular Row Grid', () => {
@@ -88,7 +89,7 @@ describe('Grid', () => {
             { x: 11, y: '22' },
             { x: 111, y: '222' }
         ];
-        const model = new GoslingTrackModel(t, d);
-        drawGrid(HGC, model);
+        const model = new GoslingTrackModel(t, d, getTheme());
+        drawGrid(HGC, model, getTheme());
     });
 });

--- a/src/core/mark/grid.ts
+++ b/src/core/mark/grid.ts
@@ -3,14 +3,14 @@ import { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
-import { getTheme, Theme } from '../utils/theme';
+import { CompleteThemeDeep } from '../utils/theme';
 
-export function drawGrid(trackInfo: any, tm: GoslingTrackModel, theme: Theme = 'light') {
+export function drawGrid(trackInfo: any, tm: GoslingTrackModel, theme: Required<CompleteThemeDeep>) {
     drawYGridQuantitative(trackInfo, tm, theme);
     drawRowGrid(trackInfo, tm, theme);
 }
 
-export function drawRowGrid(trackInfo: any, tm: GoslingTrackModel, theme: Theme = 'light') {
+export function drawRowGrid(trackInfo: any, tm: GoslingTrackModel, theme: Required<CompleteThemeDeep>) {
     const spec = tm.spec();
 
     if (!IsChannelDeep(spec.row) || spec.row.grid !== true) {
@@ -50,14 +50,14 @@ export function drawRowGrid(trackInfo: any, tm: GoslingTrackModel, theme: Theme 
     /* render */
     const graphics = trackInfo.pBackground;
 
-    const strokeWidth = getTheme(theme).axis.gridStrokeWidth;
+    const strokeWidth = theme.axis.gridStrokeWidth;
     rowCategories.forEach(rowCategory => {
         const rowPosition = tm.encodedValue('row', rowCategory);
 
         if (!circular) {
             graphics.lineStyle(
                 strokeWidth,
-                colorToHex(getTheme(theme).axis.gridColor),
+                colorToHex(theme.axis.gridColor),
                 1, // alpha
                 0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
             );
@@ -82,7 +82,7 @@ export function drawRowGrid(trackInfo: any, tm: GoslingTrackModel, theme: Theme 
                 0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
             );
 
-            graphics.beginFill(colorToHex(getTheme(theme).axis.gridColor), 1);
+            graphics.beginFill(colorToHex(theme.axis.gridColor), 1);
             graphics.moveTo(trackX + sPos.x, trackY + sPos.y);
             graphics.arc(trackX + cx, trackY + cy, nearR, startRad, endRad, true);
             graphics.arc(trackX + cx, trackY + cy, farR, endRad, startRad, false);
@@ -91,7 +91,7 @@ export function drawRowGrid(trackInfo: any, tm: GoslingTrackModel, theme: Theme 
     });
 }
 
-export function drawYGridQuantitative(trackInfo: any, tm: GoslingTrackModel, theme: Theme = 'light') {
+export function drawYGridQuantitative(trackInfo: any, tm: GoslingTrackModel, theme: Required<CompleteThemeDeep>) {
     const spec = tm.spec();
 
     if (!IsChannelDeep(spec.y) || spec.y.grid !== true) {
@@ -135,7 +135,7 @@ export function drawYGridQuantitative(trackInfo: any, tm: GoslingTrackModel, the
 
     /* render */
     const graphics = trackInfo.pBackground;
-    const strokeWidth = getTheme(theme).axis.gridStrokeWidth;
+    const strokeWidth = theme.axis.gridStrokeWidth;
 
     rowCategories.forEach(rowCategory => {
         const rowPosition = tm.encodedValue('row', rowCategory);
@@ -153,7 +153,7 @@ export function drawYGridQuantitative(trackInfo: any, tm: GoslingTrackModel, the
         if (!circular) {
             graphics.lineStyle(
                 strokeWidth,
-                colorToHex(getTheme(theme).axis.gridColor),
+                colorToHex(theme.axis.gridColor),
                 1, // alpha
                 0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
             );
@@ -181,7 +181,7 @@ export function drawYGridQuantitative(trackInfo: any, tm: GoslingTrackModel, the
                     0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
                 );
 
-                graphics.beginFill(colorToHex(getTheme(theme).axis.gridColor), 1);
+                graphics.beginFill(colorToHex(theme.axis.gridColor), 1);
                 graphics.moveTo(trackX + sPos.x, trackY + sPos.y);
                 graphics.arc(trackX + cx, trackY + cy, nearR, startRad, endRad, true);
                 graphics.arc(trackX + cx, trackY + cy, farR, endRad, startRad, false);

--- a/src/core/mark/index.test.ts
+++ b/src/core/mark/index.test.ts
@@ -1,9 +1,10 @@
 import { drawMark } from '.';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { SingleTrack } from '../gosling.schema';
+import { getTheme } from '../utils/theme';
 
 describe('Should draw marks correctly', () => {
     it('Should return early when some of parameters are not properly provided', () => {
-        drawMark(null, null, null, new GoslingTrackModel({} as SingleTrack, []));
+        drawMark(null, null, null, new GoslingTrackModel({} as SingleTrack, [], getTheme()));
     });
 });

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -15,7 +15,7 @@ import { drawColorLegend, drawRowLegend } from './legend';
 import { drawCircularYAxis, drawLinearYAxis } from './axis';
 import { drawCircularOutlines } from './outline-circular';
 import { drawBackground } from './background';
-import { Theme } from '../utils/theme';
+import { CompleteThemeDeep } from '../utils/theme';
 
 /**
  * Visual channels currently supported for visual encoding.
@@ -119,7 +119,7 @@ export function drawPreEmbellishment(
     trackInfo: any,
     tile: any,
     model: GoslingTrackModel,
-    theme: Theme = 'light'
+    theme: Required<CompleteThemeDeep>
 ) {
     if (!HGC || !trackInfo || !tile) {
         // We did not receive parameters correctly.
@@ -158,7 +158,7 @@ export function drawPostEmbellishment(
     trackInfo: any,
     tile: any,
     model: GoslingTrackModel,
-    theme: Theme = 'light'
+    theme: Required<CompleteThemeDeep>
 ) {
     if (!HGC || !trackInfo || !tile) {
         // We did not receive parameters correctly.

--- a/src/core/mark/legend.test.ts
+++ b/src/core/mark/legend.test.ts
@@ -1,6 +1,7 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { SingleTrack } from '../gosling.schema';
+import { getTheme } from '../utils/theme';
 import { drawColorLegend } from './legend';
 
 describe('Color Legend', () => {
@@ -19,7 +20,7 @@ describe('Color Legend', () => {
             { x: 11, y: 22 },
             { x: 111, y: 222 }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawColorLegend(
             {
                 libraries: {
@@ -36,7 +37,8 @@ describe('Color Legend', () => {
                 pBorder: g
             },
             null,
-            model
+            model,
+            getTheme()
         );
     });
 
@@ -59,7 +61,7 @@ describe('Color Legend', () => {
             { x: 11, v: '22' },
             { x: 111, v: '222' }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawColorLegend(
             {
                 libraries: {
@@ -76,7 +78,8 @@ describe('Color Legend', () => {
                 pBorder: g
             },
             null,
-            model
+            model,
+            getTheme()
         );
     });
 });

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -1,7 +1,7 @@
 import { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
-import { getTheme, Theme } from '../utils/theme';
+import { CompleteThemeDeep } from '../utils/theme';
 import { Dimension } from '../utils/position';
 import { ScaleLinear } from 'd3-scale';
 
@@ -19,7 +19,13 @@ export const getLegendTextStyle = (fill = 'black', fontWeight = 'normal') => {
     };
 };
 
-export function drawColorLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel, theme: Theme = 'light') {
+export function drawColorLegend(
+    HGC: any,
+    trackInfo: any,
+    tile: any,
+    tm: GoslingTrackModel,
+    theme: Required<CompleteThemeDeep>
+) {
     const spec = tm.spec();
 
     if (!IsChannelDeep(spec.color) || !spec.color.legend) {
@@ -42,7 +48,7 @@ export function drawColorLegendQuantitative(
     trackInfo: any,
     tile: any,
     tm: GoslingTrackModel,
-    theme: Theme = 'light'
+    theme: Required<CompleteThemeDeep>
 ) {
     const spec = tm.spec();
 
@@ -80,11 +86,11 @@ export function drawColorLegendQuantitative(
     const graphics = trackInfo.pBorder; // use pBorder not to be affected by zoomming
 
     // Background
-    graphics.beginFill(colorToHex(getTheme(theme).legend.background), getTheme(theme).legend.backgroundOpacity);
+    graphics.beginFill(colorToHex(theme.legend.background), theme.legend.backgroundOpacity);
     graphics.lineStyle(
         1,
-        colorToHex(getTheme(theme).legend.backgroundStroke),
-        getTheme(theme).legend.backgroundOpacity, // alpha
+        colorToHex(theme.legend.backgroundStroke),
+        theme.legend.backgroundOpacity, // alpha
         0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
     graphics.drawRect(legendX, legendY, legendWidth, legendHeight);
@@ -102,7 +108,7 @@ export function drawColorLegendQuantitative(
         );
         graphics.lineStyle(
             1,
-            colorToHex(getTheme(theme).legend.backgroundStroke),
+            colorToHex(theme.legend.backgroundStroke),
             0, // alpha
             0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
         );
@@ -124,7 +130,7 @@ export function drawColorLegendQuantitative(
     const TICK_STROKE_SIZE = 1;
     graphics.lineStyle(
         TICK_STROKE_SIZE,
-        colorToHex(getTheme(theme).legend.tickColor),
+        colorToHex(theme.legend.tickColor),
         1, // alpha
         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
@@ -145,7 +151,7 @@ export function drawColorLegendQuantitative(
         graphics.lineTo(tickEnd, y);
 
         // labels
-        const textGraphic = new HGC.libraries.PIXI.Text(value, getLegendTextStyle(getTheme(theme).legend.labelColor));
+        const textGraphic = new HGC.libraries.PIXI.Text(value, getLegendTextStyle(theme.legend.labelColor));
         textGraphic.anchor.x = 1;
         textGraphic.anchor.y = 0.5;
         textGraphic.position.x = tickEnd - 6;
@@ -160,7 +166,7 @@ export function drawColorLegendCategories(
     trackInfo: any,
     tile: any,
     tm: GoslingTrackModel,
-    theme: Theme = 'light'
+    theme: Required<CompleteThemeDeep>
 ) {
     /* track spec */
     const spec = tm.spec();
@@ -200,10 +206,7 @@ export function drawColorLegendCategories(
                 }
 
                 const color = tm.encodedValue('color', category);
-                const textGraphic = new HGC.libraries.PIXI.Text(
-                    category,
-                    getLegendTextStyle(getTheme(theme).legend.labelColor)
-                );
+                const textGraphic = new HGC.libraries.PIXI.Text(category, getLegendTextStyle(theme.legend.labelColor));
                 textGraphic.anchor.x = 1;
                 textGraphic.anchor.y = 0;
                 textGraphic.position.x = trackInfo.position[0] + trackInfo.dimensions[0] - maxWidth - paddingX;
@@ -211,9 +214,7 @@ export function drawColorLegendCategories(
 
                 graphics.addChild(textGraphic);
 
-                const textStyleObj = new HGC.libraries.PIXI.TextStyle(
-                    getLegendTextStyle(getTheme(theme).legend.labelColor)
-                );
+                const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(theme.legend.labelColor));
                 const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
                 if (cumY < textMetrics.height + paddingY * 3) {
@@ -234,16 +235,14 @@ export function drawColorLegendCategories(
         if (spec.style?.legendTitle) {
             const textGraphic = new HGC.libraries.PIXI.Text(
                 spec.style?.legendTitle,
-                getLegendTextStyle(getTheme(theme).legend.labelColor, 'bold')
+                getLegendTextStyle(theme.legend.labelColor, 'bold')
             );
             textGraphic.anchor.x = 1;
             textGraphic.anchor.y = 0;
             textGraphic.position.x = trackInfo.position[0] + trackInfo.dimensions[0] - paddingX;
             textGraphic.position.y = trackInfo.position[1] + cumY;
 
-            const textStyleObj = new HGC.libraries.PIXI.TextStyle(
-                getLegendTextStyle(getTheme(theme).legend.labelColor, 'bold')
-            );
+            const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(theme.legend.labelColor, 'bold'));
             const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(spec.style?.legendTitle, textStyleObj);
 
             graphics.addChild(textGraphic);
@@ -259,10 +258,7 @@ export function drawColorLegendCategories(
 
             const color = tm.encodedValue('color', category);
 
-            const textGraphic = new HGC.libraries.PIXI.Text(
-                category,
-                getLegendTextStyle(getTheme(theme).legend.labelColor)
-            );
+            const textGraphic = new HGC.libraries.PIXI.Text(category, getLegendTextStyle(theme.legend.labelColor));
             textGraphic.anchor.x = 1;
             textGraphic.anchor.y = 0;
             textGraphic.position.x = trackInfo.position[0] + trackInfo.dimensions[0] - paddingX;
@@ -270,9 +266,7 @@ export function drawColorLegendCategories(
 
             graphics.addChild(textGraphic);
 
-            const textStyleObj = new HGC.libraries.PIXI.TextStyle(
-                getLegendTextStyle(getTheme(theme).legend.labelColor)
-            );
+            const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(theme.legend.labelColor));
             const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
             if (maxWidth < textMetrics.width + paddingX * 3) {
@@ -289,11 +283,11 @@ export function drawColorLegendCategories(
         });
     }
 
-    graphics.beginFill(colorToHex(getTheme(theme).legend.background), getTheme(theme).legend.backgroundOpacity);
+    graphics.beginFill(colorToHex(theme.legend.background), theme.legend.backgroundOpacity);
     graphics.lineStyle(
         1,
-        colorToHex(getTheme(theme).legend.backgroundStroke),
-        getTheme(theme).legend.backgroundOpacity, // alpha
+        colorToHex(theme.legend.backgroundStroke),
+        theme.legend.backgroundOpacity, // alpha
         0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
     graphics.drawRect(
@@ -315,7 +309,13 @@ export function drawColorLegendCategories(
     });
 }
 
-export function drawRowLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel, theme: Theme = 'light') {
+export function drawRowLegend(
+    HGC: any,
+    trackInfo: any,
+    tile: any,
+    tm: GoslingTrackModel,
+    theme: Required<CompleteThemeDeep>
+) {
     /* track spec */
     const spec = tm.spec();
     if (
@@ -348,10 +348,7 @@ export function drawRowLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTr
     rowCategories.forEach(category => {
         const rowPosition = tm.encodedValue('row', category);
 
-        const textGraphic = new HGC.libraries.PIXI.Text(
-            category,
-            getLegendTextStyle(getTheme(theme).legend.labelColor)
-        );
+        const textGraphic = new HGC.libraries.PIXI.Text(category, getLegendTextStyle(theme.legend.labelColor));
         textGraphic.anchor.x = 0;
         textGraphic.anchor.y = 0;
         textGraphic.position.x = trackInfo.position[0] + paddingX;
@@ -359,13 +356,13 @@ export function drawRowLegend(HGC: any, trackInfo: any, tile: any, tm: GoslingTr
 
         graphics.addChild(textGraphic);
 
-        const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(getTheme(theme).legend.labelColor));
+        const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(theme.legend.labelColor));
         const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
-        graphics.beginFill(colorToHex(getTheme(theme).legend.background), getTheme(theme).legend.backgroundOpacity);
+        graphics.beginFill(colorToHex(theme.legend.background), theme.legend.backgroundOpacity);
         graphics.lineStyle(
             1,
-            colorToHex(getTheme(theme).legend.backgroundStroke),
+            colorToHex(theme.legend.backgroundStroke),
             0, // alpha
             0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
         );

--- a/src/core/mark/line.test.ts
+++ b/src/core/mark/line.test.ts
@@ -1,6 +1,7 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { SingleTrack } from '../gosling.schema';
+import { getTheme } from '../utils/theme';
 import { drawLine } from './line';
 
 describe('Rendering Point', () => {
@@ -19,7 +20,7 @@ describe('Rendering Point', () => {
             { x: 11, y: 22 },
             { x: 111, y: 222 }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawLine(g, model, []);
     });
 });

--- a/src/core/mark/link.test.ts
+++ b/src/core/mark/link.test.ts
@@ -1,6 +1,7 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { SingleTrack } from '../gosling.schema';
+import { getTheme } from '../utils/theme';
 import { drawLink } from './link';
 
 describe('Rendering link', () => {
@@ -21,7 +22,7 @@ describe('Rendering link', () => {
             { x: 11, x1: 22, xe: 33, x1e: 44 },
             { x: 111, x1: 222, xe: 333, x1e: 444 }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawLink(g, model);
     });
     it('Circular Band', () => {
@@ -41,7 +42,7 @@ describe('Rendering link', () => {
             { x: 11, x1: 22, xe: 33, x1e: 44 },
             { x: 111, x1: 222, xe: 333, x1e: 444 }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawLink(g, model);
     });
     it('Linear line', () => {
@@ -59,7 +60,7 @@ describe('Rendering link', () => {
             { x: 11, x1: 22, xe: 33, x1e: 44 },
             { x: 111, x1: 222, xe: 333, x1e: 444 }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawLink(g, model);
     });
     it('Circular line', () => {
@@ -77,7 +78,7 @@ describe('Rendering link', () => {
             { x: 11, x1: 22, xe: 33, x1e: 44 },
             { x: 111, x1: 222, xe: 333, x1e: 444 }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawLink(g, model);
     });
 });

--- a/src/core/mark/outline.ts
+++ b/src/core/mark/outline.ts
@@ -1,7 +1,7 @@
 import { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
-import { Theme, getTheme } from '../utils/theme';
+import { CompleteThemeDeep } from '../utils/theme';
 
 export const TITLE_STYLE = {
     fontSize: '12px',
@@ -12,7 +12,7 @@ export const TITLE_STYLE = {
     lineJoin: 'round'
 };
 
-export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackModel, theme: Theme = 'light') {
+export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackModel, theme: Required<CompleteThemeDeep>) {
     const g = trackInfo.pBorder; // use pBorder not to affected by zoomming
 
     // size and position
@@ -50,7 +50,7 @@ export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackMode
     g.lineStyle(
         tm.spec().style?.outlineWidth ?? 1,
         // TODO: outline not working
-        colorToHex(tm.spec().style?.outline ?? getTheme(theme).track.outline),
+        colorToHex(tm.spec().style?.outline ?? theme.track.outline),
         1, // alpha
         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
@@ -62,7 +62,7 @@ export function drawChartOutlines(HGC: any, trackInfo: any, tm: GoslingTrackMode
 
     g.lineStyle(
         1,
-        colorToHex(getTheme(theme).axis.baselineColor),
+        colorToHex(theme.axis.baselineColor),
         1, // alpha
         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );

--- a/src/core/mark/point.test.ts
+++ b/src/core/mark/point.test.ts
@@ -5,6 +5,7 @@ import { Track } from '../gosling.schema';
 import { HIGLASS_AXIS_SIZE } from '../higlass-model';
 import { SingleTrack } from '../gosling.schema';
 import { drawPoint } from './point';
+import { getTheme } from '../utils/theme';
 
 describe('Rendering Point', () => {
     const g = new PIXI.Graphics();
@@ -22,7 +23,7 @@ describe('Rendering Point', () => {
             { x: 11, y: 22 },
             { x: 111, y: 222 }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawPoint(null, g, model);
     });
 });
@@ -47,7 +48,7 @@ describe('Point marks should correctly encode visual channels', () => {
 
     it('x --> G', () => {
         const track: Track = { ...baseTrack, x: { field: 'G', type: 'genomic' } };
-        const model = new GoslingTrackModel(track, data);
+        const model = new GoslingTrackModel(track, data, getTheme());
 
         const cx = model.encodedPIXIProperty('x-center', data[1]);
         const cy = model.encodedPIXIProperty('y-center', data[1]);
@@ -64,7 +65,7 @@ describe('Point marks should correctly encode visual channels', () => {
                 x: { field: 'G', type: 'genomic' },
                 y: { field: 'Q', type: 'quantitative' }
             };
-            const model = new GoslingTrackModel(track, data);
+            const model = new GoslingTrackModel(track, data, getTheme());
 
             const cx = model.encodedPIXIProperty('x-center', data[1]);
             const cy = model.encodedPIXIProperty('y-center', data[1]);
@@ -80,7 +81,7 @@ describe('Point marks should correctly encode visual channels', () => {
                 x: { field: 'G', type: 'genomic', axis: 'top' },
                 y: { field: 'Q', type: 'quantitative' }
             };
-            const model = new GoslingTrackModel(track, data);
+            const model = new GoslingTrackModel(track, data, getTheme());
 
             const cx = model.encodedPIXIProperty('x-center', data[1]);
             const cy = model.encodedPIXIProperty('y-center', data[1]);
@@ -98,7 +99,7 @@ describe('Point marks should correctly encode visual channels', () => {
             xe: { field: 'G2', type: 'genomic' },
             y: { field: 'Q', type: 'quantitative' }
         };
-        const model = new GoslingTrackModel(track, data);
+        const model = new GoslingTrackModel(track, data, getTheme());
 
         const cx = model.encodedPIXIProperty('x-center', data[1]);
         const cy = model.encodedPIXIProperty('y-center', data[1]);
@@ -116,7 +117,7 @@ describe('Point marks should correctly encode visual channels', () => {
             y: { field: 'Q', type: 'quantitative' },
             row: { field: 'N', type: 'nominal' }
         };
-        const model = new GoslingTrackModel(track, data);
+        const model = new GoslingTrackModel(track, data, getTheme());
 
         const cx = model.encodedPIXIProperty('x-center', data[1]);
         const cy = model.encodedPIXIProperty('y-center', data[1]);
@@ -137,7 +138,7 @@ describe('Point marks should correctly encode visual channels', () => {
             size: { field: 'Q', type: 'quantitative' },
             row: { field: 'N', type: 'nominal' }
         };
-        const model = new GoslingTrackModel(track, data);
+        const model = new GoslingTrackModel(track, data, getTheme());
 
         const cx = model.encodedPIXIProperty('x-center', data[1]);
         const cy = model.encodedPIXIProperty('y-center', data[1]);

--- a/src/core/mark/triangle.test.ts
+++ b/src/core/mark/triangle.test.ts
@@ -1,6 +1,7 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { SingleTrack } from '../gosling.schema';
+import { getTheme } from '../utils/theme';
 import { drawTriangle } from './triangle';
 
 describe('Rendering triangle', () => {
@@ -20,7 +21,7 @@ describe('Rendering triangle', () => {
             { x: 11, xe: 11, y: 22 },
             { x: 111, xe: 111, y: 222 }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawTriangle(g, model);
     });
 
@@ -40,7 +41,7 @@ describe('Rendering triangle', () => {
             { x: 11, xe: 11, y: 22 },
             { x: 111, xe: 111, y: 222 }
         ];
-        const model = new GoslingTrackModel(t, d);
+        const model = new GoslingTrackModel(t, d, getTheme());
         drawTriangle(g, model);
     });
 });

--- a/src/core/utils/linking.test.ts
+++ b/src/core/utils/linking.test.ts
@@ -1,6 +1,7 @@
 import { goslingToHiGlass } from '../gosling-to-higlass';
 import { HiGlassModel } from '../higlass-model';
 import { getLinkingInfo } from './linking';
+import { getTheme } from './theme';
 
 describe('Should get linking information correctly', () => {
     it('Simple linking', () => {
@@ -32,7 +33,8 @@ describe('Should get linking information correctly', () => {
                 y: 0,
                 w: 12,
                 h: 12
-            }
+            },
+            getTheme()
         );
         const info = getLinkingInfo(higlass);
         expect(info).toHaveLength(2);

--- a/src/core/utils/scales.test.ts
+++ b/src/core/utils/scales.test.ts
@@ -1,6 +1,7 @@
 import { getNumericDomain, shareScaleAcrossTracks } from './scales';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
+import { getTheme } from './theme';
 
 describe('Genomic domain', () => {
     it('With Chromosome', () => {
@@ -21,7 +22,8 @@ describe('Should use shared scales', () => {
                 width: 300,
                 height: 300
             },
-            []
+            [],
+            getTheme()
         );
         const forceShare = true;
         shareScaleAcrossTracks(
@@ -37,7 +39,8 @@ describe('Should use shared scales', () => {
                         width: 300,
                         height: 300
                     },
-                    []
+                    [],
+                    getTheme()
                 ),
                 new GoslingTrackModel(
                     {
@@ -49,7 +52,8 @@ describe('Should use shared scales', () => {
                         width: 300,
                         height: 300
                     },
-                    []
+                    [],
+                    getTheme()
                 )
             ],
             forceShare
@@ -73,7 +77,8 @@ describe('Should use shared scales', () => {
                 width: 300,
                 height: 300
             },
-            []
+            [],
+            getTheme()
         );
         const forceShare = false;
         shareScaleAcrossTracks(
@@ -89,7 +94,8 @@ describe('Should use shared scales', () => {
                         width: 300,
                         height: 300
                     },
-                    []
+                    [],
+                    getTheme()
                 ),
                 new GoslingTrackModel(
                     {
@@ -101,7 +107,8 @@ describe('Should use shared scales', () => {
                         width: 300,
                         height: 300
                     },
-                    []
+                    [],
+                    getTheme()
                 )
             ],
             forceShare

--- a/src/core/utils/theme.ts
+++ b/src/core/utils/theme.ts
@@ -107,6 +107,7 @@ export interface MarkStyle {
 }
 
 export function getTheme(theme: Theme = 'light'): Required<CompleteThemeDeep> {
+    // TODO: import goslingTheme and check first whether theme is defined by goslingTheme
     if (theme === 'dark' || theme === 'light') {
         return THEMES[theme];
     } else {

--- a/src/core/utils/theme.ts
+++ b/src/core/utils/theme.ts
@@ -1,9 +1,11 @@
+// @ts-ignore
+import * as goslingTheme from 'gosling-theme';
 import { assign } from 'lodash';
 import { CHANNEL_DEFAULTS } from '../channel';
 
 /* ----------------------------- THEME ----------------------------- */
 export type Theme = ThemeType | ThemeDeep;
-export type ThemeType = 'light' | 'dark';
+export type ThemeType = 'light' | 'dark' | string;
 export enum Themes {
     light = 'light',
     dark = 'dark'
@@ -106,13 +108,25 @@ export interface MarkStyle {
     // ...
 }
 
+// TODO: Instead of calling this function everytime, create a JSON object and use it throughout the project.
 export function getTheme(theme: Theme = 'light'): Required<CompleteThemeDeep> {
-    // TODO: import goslingTheme and check first whether theme is defined by goslingTheme
-    if (theme === 'dark' || theme === 'light') {
-        return THEMES[theme];
+    if (typeof theme === 'string') {
+        if (Object.keys(goslingTheme.Themes).indexOf(theme)) {
+            return goslingTheme.getTheme(theme);
+        } else if (theme === 'dark' || theme === 'light') {
+            return THEMES[theme];
+        } else {
+            return THEMES['light'];
+        }
     } else {
         // Iterate all keys to override from base
-        const base = JSON.parse(JSON.stringify(THEMES[theme.base]));
+        let base = JSON.parse(JSON.stringify(THEMES['light']));
+        if (Object.keys(goslingTheme.Themes).indexOf(theme.base)) {
+            base = goslingTheme.getTheme(theme.base);
+        } else if (theme.base === 'light' || theme.base === 'dark') {
+            base = JSON.parse(JSON.stringify(THEMES[theme.base]));
+        }
+        // Override defaults from `base`
         Object.keys(base).forEach(k => {
             if ((theme as any)[k] && k !== 'base') {
                 base[k] = assign(JSON.parse(JSON.stringify(base[k])), JSON.parse(JSON.stringify((theme as any)[k])));

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -22,7 +22,6 @@ import * as qs from 'qs';
 import { JSONCrush, JSONUncrush } from '../core/utils/json-crush';
 import './editor.css';
 import { ICONS, ICON_INFO } from './icon';
-import { getTheme } from '../core/utils/theme';
 
 const INIT_DEMO_INDEX = examples.findIndex(d => d.forceShow) !== -1 ? examples.findIndex(d => d.forceShow) : 0;
 
@@ -189,7 +188,7 @@ function Editor(props: any) {
     const [isShowAbout, setIsShowAbout] = useState(false);
 
     // Editor theme
-    const [theme, setTheme] = useState<'light' | 'dark'>('light');
+    const [theme] = useState<'light' | 'dark'>('light');
 
     // Resizer `div`
     const descResizerRef = useRef<any>();
@@ -284,12 +283,12 @@ function Editor(props: any) {
     /**
      * Update theme of the editor based on the theme of Gosling visualizations
      */
-    useEffect(() => {
-        const gosTheme = getTheme(goslingSpec?.theme);
-        if (gosTheme.base !== theme) {
-            setTheme(gosTheme.base);
-        }
-    }, [goslingSpec]);
+    // useEffect(() => {
+    //     const gosTheme = getTheme(goslingSpec?.theme);
+    //     if (gosTheme.base !== theme) {
+    //         setTheme(gosTheme.base);
+    //     }
+    // }, [goslingSpec]);
 
     /**
      * Subscribe preview data that is being processed in the Gosling tracks.
@@ -674,6 +673,7 @@ function Editor(props: any) {
                                     <gosling.GoslingComponent
                                         ref={gosRef}
                                         spec={goslingSpec}
+                                        theme={'light'}
                                         padding={60}
                                         margin={0}
                                         border={'none'}

--- a/src/editor/example/cancer-variant.ts
+++ b/src/editor/example/cancer-variant.ts
@@ -3,7 +3,7 @@ import { GoslingSpec } from '../..';
 export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
     title: 'Breast Cancer Variant (Staaf et al. 2019)',
     subtitle: 'Genetic characteristics of RAD51C- and PALB2-altered TNBCs',
-    theme: { base: 'light', legend: { backgroundOpacity: 0, backgroundStroke: 'white' } },
+    // theme: { base: 'light', legend: { backgroundOpacity: 0, backgroundStroke: 'white' } },
     layout: 'linear',
     arrangement: 'vertical',
     centerRadius: 0.5,

--- a/src/editor/example/index.test.ts
+++ b/src/editor/example/index.test.ts
@@ -1,6 +1,7 @@
 import { GoslingTrackModel } from '../../core/gosling-track-model';
 import { resolveSuperposedTracks } from '../../core/utils/overlay';
 import { convertToFlatTracks } from '../../core/utils/spec-preprocess';
+import { getTheme } from '../../core/utils/theme';
 import { EX_TRACK_SEMANTIC_ZOOM } from './semantic-zoom';
 
 describe('Example specs should be valid', () => {
@@ -12,7 +13,7 @@ describe('Example specs should be valid', () => {
 
         const resolvedIdeograms = resolveSuperposedTracks(flatTracks[0]);
         resolvedIdeograms.forEach(spec => {
-            const ideogramMark = new GoslingTrackModel(spec, []);
+            const ideogramMark = new GoslingTrackModel(spec, [], getTheme());
             const validity = ideogramMark.validateSpec();
             if (!validity.valid) {
                 valid = false;
@@ -34,7 +35,7 @@ describe('Example specs should be valid', () => {
         convertToFlatTracks(EX_TRACK_SEMANTIC_ZOOM.cytoband).forEach(t => {
             const resolvedIdeograms = resolveSuperposedTracks({ ...t, width: 300, height: 300 });
             resolvedIdeograms.forEach(spec => {
-                const ideogramMark = new GoslingTrackModel(spec, []);
+                const ideogramMark = new GoslingTrackModel(spec, [], getTheme());
                 const validity = ideogramMark.validateSpec();
                 if (!validity.valid) {
                     valid = false;

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -1,6 +1,6 @@
 import { GoslingSpec } from '../../core/gosling.schema';
 import { EX_SPEC_LAYOUT_AND_ARRANGEMENT_1, EX_SPEC_LAYOUT_AND_ARRANGEMENT_2 } from './layout-and-arrangement';
-import { EX_SPEC_DARK_THEME, EX_SPEC_VISUAL_ENCODING, EX_SPEC_VISUAL_ENCODING_CIRCULAR } from './visual-encoding';
+import { EX_SPEC_VISUAL_ENCODING, EX_SPEC_VISUAL_ENCODING_CIRCULAR } from './visual-encoding';
 import { EX_SPEC_CANCER_VARIANT_PROTOTYPE } from './cancer-variant';
 import { EX_SPEC_MATRIX_HFFC6 } from './matrix-hffc6';
 import { EX_SPEC_LINKING } from './visual-linking';
@@ -145,11 +145,11 @@ export const examples: ReadonlyArray<{
         id: 'BAM_PILEUP',
         spec: EX_SPEC_PILEUP,
         underDevelopment: true
-    },
-    {
-        name: 'Dark Theme (Beta)',
-        id: 'DARK_THEME',
-        spec: EX_SPEC_DARK_THEME,
-        underDevelopment: true
     }
+    // {
+    //     name: 'Dark Theme (Beta)',
+    //     id: 'DARK_THEME',
+    //     spec: EX_SPEC_DARK_THEME,
+    //     underDevelopment: true
+    // }
 ].filter(d => !d.hidden);

--- a/src/editor/example/theme.ts
+++ b/src/editor/example/theme.ts
@@ -2,26 +2,26 @@ import { GoslingSpec } from '../../core/gosling.schema';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 export const EX_SPEC_CUSTOM_THEME: GoslingSpec = {
-    theme: {
-        base: 'light',
-        track: {
-            outline: 'black'
-        },
-        markCommon: {
-            color: 'black'
-        },
-        brush: {
-            color: 'red',
-            opacity: 1,
-            strokeWidth: 1,
-            stroke: 'red'
-        },
-        legend: {
-            background: '#2E4863',
-            backgroundOpacity: 1,
-            labelColor: 'white'
-        }
-    },
+    // theme: {
+    //     base: 'light',
+    //     track: {
+    //         outline: 'black'
+    //     },
+    //     markCommon: {
+    //         color: 'black'
+    //     },
+    //     brush: {
+    //         color: 'red',
+    //         opacity: 1,
+    //         strokeWidth: 1,
+    //         stroke: 'red'
+    //     },
+    //     legend: {
+    //         background: '#2E4863',
+    //         backgroundOpacity: 1,
+    //         labelColor: 'white'
+    //     }
+    // },
     title: 'Custom Theme',
     subtitle: 'Customize the style of Gosling visualizations',
     layout: 'linear',

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -529,15 +529,15 @@ export const EX_SPEC_VISUAL_ENCODING_CIRCULAR: GoslingSpec = {
 };
 
 export const EX_SPEC_DARK_THEME: GoslingSpec = {
-    theme: {
-        base: 'dark',
-        axis: { gridColor: '#333', baselineColor: 'transparent', tickColor: 'transparent' },
-        markCommon: {
-            color: 'gray',
-            nominalColorRange: ['white', 'gray'],
-            stroke: 'black'
-        }
-    },
+    // theme: {
+    //     base: 'dark',
+    //     axis: { gridColor: '#333', baselineColor: 'transparent', tickColor: 'transparent' },
+    //     markCommon: {
+    //         color: 'gray',
+    //         nominalColorRange: ['white', 'gray'],
+    //         stroke: 'black'
+    //     }
+    // },
     title: 'Dark Theme (Beta)',
     subtitle: 'Gosling allows to easily change the color theme using a `theme` property',
     layout: 'circular',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import pkg from '../package.json';
 import GoslingSchema from '../schema/gosling.schema.json';
+import ThemeSchema from '../schema/theme.schema.json';
 
 export type { GoslingSpec } from './core/gosling.schema';
 export type { HiGlassSpec } from './core/higlass.schema';
 export type { Theme } from './core/utils/theme';
 export { GoslingSchema };
+export { ThemeSchema };
 
 export const name = pkg.name;
 export const version = pkg.version;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import GoslingSchema from '../schema/gosling.schema.json';
 
 export type { GoslingSpec } from './core/gosling.schema';
 export type { HiGlassSpec } from './core/higlass.schema';
+export type { Theme } from './core/utils/theme';
 export { GoslingSchema };
 
 export const name = pkg.name;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9677,6 +9677,11 @@ good-listener@^1.2.2:
   dependencies:
     delegate "^3.1.2"
 
+gosling-theme@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/gosling-theme/-/gosling-theme-0.0.6.tgz#6130788dcc6846ec102e56ce2aa50ffd5e4f974c"
+  integrity sha512-qEnHzTj2yGS/gcb7QcWKfQx8462QAjBDEt7b+3sF+pHRM+nfQrQPwlIl90boIl8QiY/UolznoA8lX//8Yfrc2Q==
+
 graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"


### PR DESCRIPTION
# About this PR
## Updates
- [x] Gosling.js internally uses `goslingTheme` to apply styles of gosling visualizations.
- [x] `theme` specifications are separated from `spec`
- [x] The schema of `theme` is exported in both `.ts` and `.json`

## Before

```js
<GoslingComponent 
   spec={{..., theme: { base: 'light', ...}}
   ...
/>
```

## After
```js
<GoslingComponent 
   spec={{...}}
   theme={{ base: 'light', ...}}
   ...
/>
```