### PR TITLE
feat: support more parameters in `embed()` function

### DIFF
--- a/src/core/gosling-embed.tsx
+++ b/src/core/gosling-embed.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Theme } from '..';
 import { GoslingComponent } from './gosling-component';
 import { GoslingSpec } from './gosling.schema';
 
@@ -8,8 +9,30 @@ import { GoslingSpec } from './gosling.schema';
  * @param element
  * @param spec
  */
-export function embed(element: HTMLElement, spec: GoslingSpec) {
+export function embed(
+    element: HTMLElement,
+    spec: GoslingSpec,
+    options?: {
+        padding?: number;
+        margin?: number | string;
+        border?: string;
+        id?: string;
+        className?: string;
+        theme?: Theme;
+    }
+) {
     // const ref = React.createRef();
-    ReactDOM.render(<GoslingComponent spec={spec} />, element);
+    ReactDOM.render(
+        <GoslingComponent
+            spec={spec}
+            padding={options?.padding}
+            margin={options?.margin}
+            border={options?.border}
+            id={options?.id}
+            className={options?.className}
+            theme={options?.theme}
+        />,
+        element
+    );
     // return ref.current;
 }


### PR DESCRIPTION
The third parameter collects options for styling gosling visualizations:

```js
gosling.embed(
  document.getElementById('root'),
  spec,
  {
    padding: 0, 
    margin: 0, 
    id: 'gosling-wrapper',
    className: 'gosling-component',
    theme: 'dark'
  }
)
```