### PR TITLE
feat: add more theme components like dashed grid, font styles, background colors

### DIFF
--- a/schema/theme.schema.json
+++ b/schema/theme.schema.json
@@ -11,10 +11,44 @@
         "gridColor": {
           "type": "string"
         },
+        "gridStrokeDash": {
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "gridStrokeType": {
+          "enum": [
+            "solid",
+            "dashed"
+          ],
+          "type": "string"
+        },
         "gridStrokeWidth": {
           "type": "number"
         },
         "labelColor": {
+          "type": "string"
+        },
+        "labelFontFamily": {
+          "type": "string"
+        },
+        "labelFontSize": {
+          "type": "number"
+        },
+        "labelFontWeight": {
+          "enum": [
+            "bold",
+            "normal",
+            "light"
+          ],
           "type": "string"
         },
         "tickColor": {
@@ -36,6 +70,27 @@
           "type": "string"
         },
         "labelColor": {
+          "type": "string"
+        },
+        "labelFontFamily": {
+          "type": "string"
+        },
+        "labelFontSize": {
+          "type": "number"
+        },
+        "labelFontWeight": {
+          "enum": [
+            "bold",
+            "normal",
+            "light"
+          ],
+          "type": "string"
+        },
+        "position": {
+          "enum": [
+            "top",
+            "right"
+          ],
           "type": "string"
         },
         "tickColor": {
@@ -93,10 +148,60 @@
         "mousePositionColor": {
           "type": "string"
         },
+        "subtitleAlign": {
+          "enum": [
+            "left",
+            "middle",
+            "right"
+          ],
+          "type": "string"
+        },
+        "subtitleBackgroundColor": {
+          "type": "string"
+        },
         "subtitleColor": {
           "type": "string"
         },
+        "subtitleFontFamily": {
+          "type": "string"
+        },
+        "subtitleFontSize": {
+          "type": "number"
+        },
+        "subtitleFontWeight": {
+          "enum": [
+            "bold",
+            "normal",
+            "light"
+          ],
+          "type": "string"
+        },
+        "titleAlign": {
+          "enum": [
+            "left",
+            "middle",
+            "right"
+          ],
+          "type": "string"
+        },
+        "titleBackgroundColor": {
+          "type": "string"
+        },
         "titleColor": {
+          "type": "string"
+        },
+        "titleFontFamily": {
+          "type": "string"
+        },
+        "titleFontSize": {
+          "type": "number"
+        },
+        "titleFontWeight": {
+          "enum": [
+            "bold",
+            "normal",
+            "light"
+          ],
           "type": "string"
         }
       },
@@ -227,17 +332,34 @@
     "TrackStyle": {
       "additionalProperties": false,
       "properties": {
+        "alternatingBackground": {
+          "type": "string"
+        },
+        "background": {
+          "type": "string"
+        },
         "outline": {
           "type": "string"
         },
         "outlineWidth": {
           "type": "number"
         },
+        "titleAlign": {
+          "enum": [
+            "left",
+            "middle",
+            "right"
+          ],
+          "type": "string"
+        },
         "titleBackground": {
           "type": "string"
         },
         "titleColor": {
           "type": "string"
+        },
+        "titleFontSize": {
+          "type": "number"
         }
       },
       "type": "object"

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -8,7 +8,7 @@ import { resolveSuperposedTracks } from './utils/overlay';
 import { getGenomicChannelKeyFromTrack, getGenomicChannelFromTrack } from './utils/validate';
 import { viridisColorMap } from './utils/colors';
 import { IsDataDeep, IsChannelDeep, IsDataDeepTileset } from './gosling.schema.guards';
-import { DEFAULT_SUBTITLE_HEIGHT, DEFAULT_TITLE_HEIGHT } from './layout/defaults';
+import { DEWFAULT_TITLE_PADDING_ON_TOP_AND_BOTTOM } from './layout/defaults';
 import { CompleteThemeDeep } from './utils/theme';
 
 /**
@@ -58,8 +58,12 @@ export function goslingToHiGlass(
                 mousePositionColor: theme.root.mousePositionColor,
                 /* Track title */
                 name: firstResolvedSpec.title,
-                fontSize: 12,
-                labelPosition: firstResolvedSpec.title ? 'topLeft' : 'none',
+                fontSize: theme.track.titleFontSize,
+                labelPosition: firstResolvedSpec.title
+                    ? theme.track.titleAlign === 'left'
+                        ? 'topLeft'
+                        : 'topRight'
+                    : 'none',
                 labelShowResolution: false,
                 labelColor: theme.track.titleColor,
                 labelBackgroundColor: theme.track.titleBackground,
@@ -164,21 +168,27 @@ export function goslingToHiGlass(
         if (typeof firstResolvedSpec.title === 'string') {
             hgModel.setTextTrack(
                 bb.width,
-                DEFAULT_TITLE_HEIGHT,
+                theme.root.titleFontSize + DEWFAULT_TITLE_PADDING_ON_TOP_AND_BOTTOM,
                 firstResolvedSpec.title,
                 theme.root.titleColor,
-                18,
-                'bold'
+                theme.root.titleFontSize ?? 18,
+                theme.root.titleFontWeight,
+                theme.root.titleAlign,
+                theme.root.titleBackgroundColor,
+                theme.root.titleFontFamily
             );
         }
         if (typeof firstResolvedSpec.subtitle === 'string') {
             hgModel.setTextTrack(
                 bb.width,
-                DEFAULT_SUBTITLE_HEIGHT,
+                theme.root.subtitleFontSize + DEWFAULT_TITLE_PADDING_ON_TOP_AND_BOTTOM,
                 firstResolvedSpec.subtitle,
                 theme.root.subtitleColor,
-                14,
-                'normal'
+                theme.root.subtitleFontSize ?? 14,
+                theme.root.subtitleFontWeight,
+                theme.root.subtitleAlign,
+                theme.root.subtitleBackgroundColor,
+                theme.root.subtitleFontFamily
             );
         }
     }

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -93,7 +93,10 @@ export class HiGlassModel {
         text: string,
         textColor = 'black',
         fontSize = 14,
-        fontWeight = 'normal'
+        fontWeight = 'normal',
+        align = 'left',
+        backgroundColor = 'transparent',
+        fontFamily = 'Arial'
     ) {
         if (this.getLastView()) {
             this.getLastView().tracks.top?.push({
@@ -101,13 +104,13 @@ export class HiGlassModel {
                 width,
                 height,
                 options: {
-                    backgroundColor: 'transparent',
+                    backgroundColor,
                     textColor,
                     fontSize,
                     fontWeight,
-                    fontFamily: 'sans-serif', // 'Arial',
+                    fontFamily,
                     offsetY: 0, // offset from the top of the track
-                    align: 'left',
+                    align,
                     text
                 }
             });
@@ -267,6 +270,9 @@ export class HiGlassModel {
                 assembly: this.getAssembly(),
                 stroke: 'transparent', // text outline
                 color: options.theme.axis.labelColor,
+                fontSize: options.theme.axis.labelFontSize,
+                fontFamily: options.theme.axis.labelFontFamily,
+                fontWeight: options.theme.axis.labelFontWeight,
                 tickColor: options.theme.axis.tickColor,
                 tickFormat: type === 'narrower' ? 'si' : 'plain',
                 tickPositions: type === 'regular' ? 'even' : 'ends',

--- a/src/core/layout/defaults.ts
+++ b/src/core/layout/defaults.ts
@@ -2,8 +2,9 @@ export const DEFAULT_VISUAL_PROPERTIES = {
     opacity: 1
 };
 
-export const DEFAULT_TITLE_HEIGHT = 20;
-export const DEFAULT_SUBTITLE_HEIGHT = 20;
+export const DEFAULT_TITLE_HEIGHT = 20; // deprecated
+export const DEFAULT_SUBTITLE_HEIGHT = 20; // deprecated
+export const DEWFAULT_TITLE_PADDING_ON_TOP_AND_BOTTOM = 6;
 
 // default track size
 export const DEFAULT_TRACK_HEIGHT_LINEAR = 180;

--- a/src/core/layout/layout.ts
+++ b/src/core/layout/layout.ts
@@ -10,7 +10,7 @@ export function compileLayout(
     theme: CompleteThemeDeep
 ) {
     // Generate arrangement data
-    const trackInfo = getRelativeTrackInfo(spec);
+    const trackInfo = getRelativeTrackInfo(spec, theme);
 
     // Render HiGlass tracks
     renderHiGlass(spec, trackInfo, setHg, theme);

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -4,25 +4,10 @@ import colorToHex from '../utils/color-to-hex';
 import { CompleteThemeDeep } from '../utils/theme';
 import { scaleLinear } from 'd3-scale';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
+import { getTextStyle } from '../utils/text-style';
 
 const EXTENT_TICK_SIZE = 8;
 const TICK_SIZE = 6;
-
-/**
- * Axis text styles
- */
-export const getAxisTextStyle = (fill = 'black') => {
-    return {
-        fontSize: '10px',
-        fontFamily: 'sans-serif', // 'Arial',
-        fontWeight: 'normal',
-        fill,
-        background: 'white',
-        lineJoin: 'round'
-        // stroke: '#ffffff',
-        // strokeThickness: 2
-    };
-};
 
 /**
  * Draw linear scale Y axis
@@ -122,12 +107,19 @@ export function drawLinearYAxis(
         graphics.moveTo(dx, dy + rowHeight);
         graphics.lineTo(tickEnd, dy + rowHeight);
 
+        const styleConfig = getTextStyle({
+            color: theme.axis.labelColor,
+            size: theme.axis.labelFontSize,
+            fontFamily: theme.axis.labelFontFamily,
+            fontWeight: theme.axis.labelFontWeight
+        });
+
         /* Labels */
         ticks.forEach(t => {
             const y = yScale(t);
             tickEnd = isLeft ? dx + TICK_SIZE * 2 : dx - TICK_SIZE * 2;
 
-            const textGraphic = new HGC.libraries.PIXI.Text(t, getAxisTextStyle(theme.axis.labelColor));
+            const textGraphic = new HGC.libraries.PIXI.Text(t, styleConfig);
             textGraphic.anchor.x = isLeft ? 0 : 1;
             textGraphic.anchor.y = y === 0 ? 0.9 : 0.5;
             textGraphic.position.x = tickEnd;
@@ -300,15 +292,20 @@ export function drawCircularYAxis(
             // The position of a tick in the polar system
             const pos = cartesianToPolar(SCALED_TICK_SIZE(currentR) * 2, tw, currentR, cx, cy, startAngle, endAngle);
 
-            // ! Maybe combine this part with `axis-plugin-track.ts`
-            const textGraphic = new HGC.libraries.PIXI.Text(t, getAxisTextStyle(theme.axis.labelColor));
+            const styleConfig = getTextStyle({
+                color: theme.axis.labelColor,
+                size: theme.axis.labelFontSize,
+                fontFamily: theme.axis.labelFontFamily,
+                fontWeight: theme.axis.labelFontWeight
+            });
+            const textGraphic = new HGC.libraries.PIXI.Text(t, styleConfig);
             textGraphic.anchor.x = isLeft ? 1 : 0;
             textGraphic.anchor.y = 0.5;
             textGraphic.position.x = pos.x;
             textGraphic.position.y = pos.y;
 
             textGraphic.resolution = 4;
-            const txtStyle = new HGC.libraries.PIXI.TextStyle(getAxisTextStyle());
+            const txtStyle = new HGC.libraries.PIXI.TextStyle(styleConfig);
             const metric = HGC.libraries.PIXI.TextMetrics.measureText(textGraphic.text, txtStyle);
 
             // Scale the width of text label so that its width is the same when converted into circular form

--- a/src/core/mark/background.ts
+++ b/src/core/mark/background.ts
@@ -1,8 +1,16 @@
 import { isUndefined } from 'lodash';
 import { GoslingTrackModel } from '../gosling-track-model';
+import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
+import { CompleteThemeDeep } from '../utils/theme';
 
-export function drawBackground(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel) {
+export function drawBackground(
+    HGC: any,
+    trackInfo: any,
+    tile: any,
+    tm: GoslingTrackModel,
+    theme: Required<CompleteThemeDeep>
+) {
     // size and position
     const [l, t] = trackInfo.position;
     const [w, h] = trackInfo.dimensions;
@@ -10,10 +18,10 @@ export function drawBackground(HGC: any, trackInfo: any, tile: any, tm: GoslingT
     // refer to https://github.com/higlass/higlass/blob/f82c0a4f7b2ab1c145091166b0457638934b15f3/app/scripts/PixiTrack.js#L129
     const g = trackInfo.pBackground;
 
-    if (tm.spec().style?.background) {
+    if (tm.spec().style?.background || theme.track.background !== 'transparent') {
         g.clear();
 
-        const bg = tm.spec().style?.background ?? 'white';
+        const bg = tm.spec().style?.background ?? theme.track.background;
         const alpha = isUndefined(tm.spec().style?.backgroundOpacity) ? 1 : tm.spec().style?.backgroundOpacity;
         // background
         g.lineStyle(
@@ -24,5 +32,42 @@ export function drawBackground(HGC: any, trackInfo: any, tile: any, tm: GoslingT
         );
         g.beginFill(colorToHex(bg), alpha);
         g.drawRect(l, t, w, h);
+    }
+
+    if (theme.track.alternatingBackground !== 'transparent') {
+        const spec = tm.spec();
+
+        if (!IsChannelDeep(spec.row) || spec.row.type !== 'nominal') {
+            // we do not use a `row` channel, so no need to draw alternating backgrounds
+            return;
+        }
+
+        /* row separation */
+        const rowCategories: string[] = (tm.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
+        if (rowCategories.length === 0) {
+            // We do not need to fill alternating colors for only one category
+            return;
+        }
+
+        /* render */
+        rowCategories.forEach((category, i) => {
+            if (i % 2 === 0) {
+                // we only draw even rows
+                return;
+            }
+            const rowPosition = tm.encodedValue('row', category);
+
+            const bg = tm.spec().style?.background ?? theme.track.alternatingBackground;
+            const alpha = isUndefined(tm.spec().style?.backgroundOpacity) ? 1 : tm.spec().style?.backgroundOpacity;
+            // background
+            g.lineStyle(
+                1,
+                colorToHex('white'),
+                0, // alpha
+                0 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+            );
+            g.beginFill(colorToHex(bg), alpha);
+            g.drawRect(trackInfo.position[0], trackInfo.position[1] + rowPosition, w, h / rowCategories.length);
+        });
     }
 }

--- a/src/core/mark/grid.ts
+++ b/src/core/mark/grid.ts
@@ -62,8 +62,9 @@ export function drawRowGrid(trackInfo: any, tm: GoslingTrackModel, theme: Requir
                 0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
             );
 
-            graphics.moveTo(trackX, trackY + rowPosition + rowHeight / 2.0);
-            graphics.lineTo(trackX + trackWidth, trackY + rowPosition + rowHeight / 2.0);
+            const y = trackY + rowPosition + rowHeight / 2.0;
+            graphics.moveTo(trackX, y);
+            graphics.lineTo(trackX + trackWidth, y);
         } else {
             const y = rowPosition + rowHeight / 2.0;
             const midR = trackOuterRadius - (y / trackHeight) * trackRingSize;
@@ -159,8 +160,17 @@ export function drawYGridQuantitative(trackInfo: any, tm: GoslingTrackModel, the
             );
             ticks.forEach(value => {
                 const y = trackY + rowPosition + rowHeight - scale(value);
-                graphics.moveTo(startX, y);
-                graphics.lineTo(endX, y);
+                if (theme.axis.gridStrokeType === 'solid') {
+                    graphics.moveTo(startX, y);
+                    graphics.lineTo(endX, y);
+                } else if (theme.axis.gridStrokeType === 'dashed') {
+                    const [line, gap] = theme.axis.gridStrokeDash ?? [1, 1];
+                    // eslint-disable-next-line
+                    for (let i = startX; i < endX; i += line + gap) {
+                        graphics.moveTo(i, y);
+                        graphics.lineTo(i + line, y);
+                    }
+                }
             });
         } else {
             ticks.forEach(value => {

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -142,9 +142,9 @@ export function drawPreEmbellishment(
     });
 
     if (CIRCULAR) {
-        drawCircularOutlines(HGC, trackInfo, tile, model);
+        drawCircularOutlines(HGC, trackInfo, tile, model, theme);
     } else {
-        drawBackground(HGC, trackInfo, tile, model);
+        drawBackground(HGC, trackInfo, tile, model, theme);
         drawChartOutlines(HGC, trackInfo, model, theme);
     }
     drawGrid(trackInfo, model, theme);

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -4,20 +4,7 @@ import colorToHex from '../utils/color-to-hex';
 import { CompleteThemeDeep } from '../utils/theme';
 import { Dimension } from '../utils/position';
 import { ScaleLinear } from 'd3-scale';
-
-export const getLegendTextStyle = (fill = 'black', fontWeight = 'normal') => {
-    return {
-        fontSize: '12px',
-        fontFamily: 'sans-serif', // 'Arial',
-        fontWeight,
-        fill,
-        background: 'white',
-        lineJoin: 'round'
-        // Other possible options:
-        // stroke: '#ffffff',
-        // strokeThickness: 2
-    };
-};
+import { getTextStyle } from '../utils/text-style';
 
 export function drawColorLegend(
     HGC: any,
@@ -135,6 +122,14 @@ export function drawColorLegendQuantitative(
         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
     );
 
+    // label text style
+    const labelTextStyle = getTextStyle({
+        color: theme.legend.labelColor,
+        size: theme.legend.labelFontSize,
+        fontWeight: theme.legend.labelFontWeight,
+        fontFamily: theme.legend.labelFontFamily
+    });
+
     const tickEnd = legendX + colorBarDim.left;
     ticks.forEach(value => {
         let y = legendY + colorBarDim.top + colorBarDim.height - ((value - startValue) / extent) * colorBarDim.height;
@@ -151,7 +146,7 @@ export function drawColorLegendQuantitative(
         graphics.lineTo(tickEnd, y);
 
         // labels
-        const textGraphic = new HGC.libraries.PIXI.Text(value, getLegendTextStyle(theme.legend.labelColor));
+        const textGraphic = new HGC.libraries.PIXI.Text(value, labelTextStyle);
         textGraphic.anchor.x = 1;
         textGraphic.anchor.y = 0.5;
         textGraphic.position.x = tickEnd - 6;
@@ -192,6 +187,14 @@ export function drawColorLegendCategories(
 
     const recipe: { x: number; y: number; color: string }[] = [];
 
+    // label text style
+    const labelTextStyle = getTextStyle({
+        color: theme.legend.labelColor,
+        size: theme.legend.labelFontSize,
+        fontWeight: theme.legend.labelFontWeight,
+        fontFamily: theme.legend.labelFontFamily
+    });
+
     if (spec.style?.inlineLegend) {
         // Show legend in a single horizontal line
 
@@ -206,7 +209,7 @@ export function drawColorLegendCategories(
                 }
 
                 const color = tm.encodedValue('color', category);
-                const textGraphic = new HGC.libraries.PIXI.Text(category, getLegendTextStyle(theme.legend.labelColor));
+                const textGraphic = new HGC.libraries.PIXI.Text(category, labelTextStyle);
                 textGraphic.anchor.x = 1;
                 textGraphic.anchor.y = 0;
                 textGraphic.position.x = trackInfo.position[0] + trackInfo.dimensions[0] - maxWidth - paddingX;
@@ -214,7 +217,7 @@ export function drawColorLegendCategories(
 
                 graphics.addChild(textGraphic);
 
-                const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(theme.legend.labelColor));
+                const textStyleObj = new HGC.libraries.PIXI.TextStyle(labelTextStyle);
                 const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
                 if (cumY < textMetrics.height + paddingY * 3) {
@@ -233,16 +236,16 @@ export function drawColorLegendCategories(
         // Show legend vertically
 
         if (spec.style?.legendTitle) {
-            const textGraphic = new HGC.libraries.PIXI.Text(
-                spec.style?.legendTitle,
-                getLegendTextStyle(theme.legend.labelColor, 'bold')
-            );
+            const textGraphic = new HGC.libraries.PIXI.Text(spec.style?.legendTitle, {
+                ...labelTextStyle,
+                fontWeight: 'bold'
+            });
             textGraphic.anchor.x = 1;
             textGraphic.anchor.y = 0;
             textGraphic.position.x = trackInfo.position[0] + trackInfo.dimensions[0] - paddingX;
             textGraphic.position.y = trackInfo.position[1] + cumY;
 
-            const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(theme.legend.labelColor, 'bold'));
+            const textStyleObj = new HGC.libraries.PIXI.TextStyle({ ...labelTextStyle, fontWeight: 'bold' });
             const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(spec.style?.legendTitle, textStyleObj);
 
             graphics.addChild(textGraphic);
@@ -258,7 +261,7 @@ export function drawColorLegendCategories(
 
             const color = tm.encodedValue('color', category);
 
-            const textGraphic = new HGC.libraries.PIXI.Text(category, getLegendTextStyle(theme.legend.labelColor));
+            const textGraphic = new HGC.libraries.PIXI.Text(category, labelTextStyle);
             textGraphic.anchor.x = 1;
             textGraphic.anchor.y = 0;
             textGraphic.position.x = trackInfo.position[0] + trackInfo.dimensions[0] - paddingX;
@@ -266,7 +269,7 @@ export function drawColorLegendCategories(
 
             graphics.addChild(textGraphic);
 
-            const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(theme.legend.labelColor));
+            const textStyleObj = new HGC.libraries.PIXI.TextStyle(labelTextStyle);
             const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
             if (maxWidth < textMetrics.width + paddingX * 3) {
@@ -345,10 +348,18 @@ export function drawRowLegend(
     const paddingX = 4;
     const paddingY = 2;
 
+    // label text style
+    const labelTextStyle = getTextStyle({
+        color: theme.legend.labelColor,
+        size: theme.legend.labelFontSize,
+        fontWeight: theme.legend.labelFontWeight,
+        fontFamily: theme.legend.labelFontFamily
+    });
+
     rowCategories.forEach(category => {
         const rowPosition = tm.encodedValue('row', category);
 
-        const textGraphic = new HGC.libraries.PIXI.Text(category, getLegendTextStyle(theme.legend.labelColor));
+        const textGraphic = new HGC.libraries.PIXI.Text(category, labelTextStyle);
         textGraphic.anchor.x = 0;
         textGraphic.anchor.y = 0;
         textGraphic.position.x = trackInfo.position[0] + paddingX;
@@ -356,7 +367,7 @@ export function drawRowLegend(
 
         graphics.addChild(textGraphic);
 
-        const textStyleObj = new HGC.libraries.PIXI.TextStyle(getLegendTextStyle(theme.legend.labelColor));
+        const textStyleObj = new HGC.libraries.PIXI.TextStyle(labelTextStyle);
         const textMetrics = HGC.libraries.PIXI.TextMetrics.measureText(category, textStyleObj);
 
         graphics.beginFill(colorToHex(theme.legend.background), theme.legend.backgroundOpacity);

--- a/src/core/mark/outline-circular.ts
+++ b/src/core/mark/outline-circular.ts
@@ -2,8 +2,15 @@ import { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
+import { CompleteThemeDeep } from '../utils/theme';
 
-export function drawCircularOutlines(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackModel) {
+export function drawCircularOutlines(
+    HGC: any,
+    trackInfo: any,
+    tile: any,
+    tm: GoslingTrackModel,
+    theme: Required<CompleteThemeDeep>
+) {
     /* track spec */
     const spec = tm.spec();
 
@@ -33,7 +40,10 @@ export function drawCircularOutlines(HGC: any, trackInfo: any, tile: any, tm: Go
             1, // 0.4, // alpha
             1 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
         );
-        g.beginFill(colorToHex(tm.spec().style?.background ?? 'lightgray'), tm.spec().style?.backgroundOpacity ?? 0.05);
+        g.beginFill(
+            colorToHex(tm.spec().style?.background ?? theme.track.background),
+            tm.spec().style?.backgroundOpacity ?? (theme.track.background === 'transparent' ? 0 : 1)
+        );
         g.moveTo(posStartInner.x, posStartInner.y);
         g.arc(cx, cy, trackInnerRadius, startRad, endRad, true);
         g.arc(cx, cy, trackOuterRadius, endRad, startRad, false);

--- a/src/core/mark/text.ts
+++ b/src/core/mark/text.ts
@@ -4,6 +4,7 @@ import { group } from 'd3-array';
 import { getValueUsingChannel, IsStackedMark } from '../gosling.schema.guards';
 import { cartesianToPolar } from '../utils/polar';
 
+// Merge with the one in the `utils/text-style.ts`
 export const TEXT_STYLE_GLOBAL = {
     fontSize: '12px',
     fontFamily: 'sans-serif', // 'Arial',

--- a/src/core/utils/bounding-box.test.ts
+++ b/src/core/utils/bounding-box.test.ts
@@ -2,11 +2,12 @@ import { GoslingSpec, Track } from '../gosling.schema';
 import { DEFAULT_CIRCULAR_VIEW_PADDING, DEFAULT_VIEW_SPACING } from '../layout/defaults';
 import { getBoundingBox, getRelativeTrackInfo } from './bounding-box';
 import { traverseToFixSpecDownstream } from './spec-preprocess';
+import { getTheme } from './theme';
 
 describe('Arrangement', () => {
     it('1 View, 1 Track', () => {
         const spec = { tracks: [{ overlay: [], width: 10, height: 10 }] };
-        const info = getRelativeTrackInfo(spec);
+        const info = getRelativeTrackInfo(spec, getTheme());
         expect(info).toHaveLength(1);
 
         expect(info[0].track).toEqual(spec.tracks[0]);
@@ -21,8 +22,8 @@ describe('Arrangement', () => {
                 { overlay: [], width: 10, height: 10, overlayOnPreviousTrack: true }
             ]
         };
-        expect(getRelativeTrackInfo(spec1)).toHaveLength(2);
-        expect(getRelativeTrackInfo(spec1)[1].boundingBox.y).toEqual(0);
+        expect(getRelativeTrackInfo(spec1, getTheme())).toHaveLength(2);
+        expect(getRelativeTrackInfo(spec1, getTheme())[1].boundingBox.y).toEqual(0);
     });
 
     it('1 View, 2 Tracks (N Overlaid Tracks)', () => {
@@ -46,8 +47,12 @@ describe('Arrangement', () => {
                 { overlay: [], width: 10, height: 10 }
             ]
         };
-        expect(getBoundingBox(getRelativeTrackInfo(spec1))).toEqual(getBoundingBox(getRelativeTrackInfo(spec2)));
-        expect(getBoundingBox(getRelativeTrackInfo(spec1))).toEqual(getBoundingBox(getRelativeTrackInfo(spec3)));
+        expect(getBoundingBox(getRelativeTrackInfo(spec1, getTheme()))).toEqual(
+            getBoundingBox(getRelativeTrackInfo(spec2, getTheme()))
+        );
+        expect(getBoundingBox(getRelativeTrackInfo(spec1, getTheme()))).toEqual(
+            getBoundingBox(getRelativeTrackInfo(spec3, getTheme()))
+        );
     });
 
     it('1 View, N Tracks', () => {
@@ -57,7 +62,7 @@ describe('Arrangement', () => {
                 { overlay: [], width: 10, height: 10 }
             ]
         };
-        const info = getRelativeTrackInfo(spec);
+        const info = getRelativeTrackInfo(spec, getTheme());
         expect(info).toHaveLength(2);
 
         expect(info[0].track).toEqual(spec.tracks[0]);
@@ -87,7 +92,7 @@ describe('Arrangement', () => {
                 }
             ]
         };
-        const info = getRelativeTrackInfo(spec);
+        const info = getRelativeTrackInfo(spec, getTheme());
         expect(info).toHaveLength(4);
 
         const size = getBoundingBox(info);
@@ -117,7 +122,7 @@ describe('Arrangement', () => {
                 }
             ]
         };
-        const info = getRelativeTrackInfo(spec);
+        const info = getRelativeTrackInfo(spec, getTheme());
         expect(info).toHaveLength(4);
 
         const size = getBoundingBox(info);
@@ -164,7 +169,7 @@ describe('Arrangement', () => {
                 }
             ]
         };
-        expect(getRelativeTrackInfo(spec1)).toEqual(getRelativeTrackInfo(spec2));
+        expect(getRelativeTrackInfo(spec1, getTheme())).toEqual(getRelativeTrackInfo(spec2, getTheme()));
     });
 
     it('Serial Views === HConcat Views in Linear Layout', () => {
@@ -202,7 +207,7 @@ describe('Arrangement', () => {
                 }
             ]
         };
-        expect(getRelativeTrackInfo(spec1)).toEqual(getRelativeTrackInfo(spec2));
+        expect(getRelativeTrackInfo(spec1, getTheme())).toEqual(getRelativeTrackInfo(spec2, getTheme()));
     });
 
     it('Complex Parallel Views in Linear Layout', () => {
@@ -221,7 +226,7 @@ describe('Arrangement', () => {
                     }
                 ]
             };
-            const info = getRelativeTrackInfo(spec);
+            const info = getRelativeTrackInfo(spec, getTheme());
             expect(info).toHaveLength(2);
 
             const size = getBoundingBox(info);
@@ -248,7 +253,7 @@ describe('Arrangement', () => {
                     }
                 ]
             };
-            const info = getRelativeTrackInfo(spec);
+            const info = getRelativeTrackInfo(spec, getTheme());
             expect(info).toHaveLength(2);
 
             const size = getBoundingBox(info);
@@ -278,7 +283,7 @@ describe('Arrangement', () => {
                 ]
             };
             traverseToFixSpecDownstream(spec);
-            const info = getRelativeTrackInfo(spec);
+            const info = getRelativeTrackInfo(spec, getTheme());
             expect(info).toHaveLength(2);
 
             const size = getBoundingBox(info);
@@ -309,7 +314,7 @@ describe('Arrangement', () => {
                 arrangement: 'parallel',
                 views: [{ tracks: [t] }, { tracks: [t] }]
             };
-            expect(getRelativeTrackInfo(spec1)).toEqual(getRelativeTrackInfo(spec2));
+            expect(getRelativeTrackInfo(spec1, getTheme())).toEqual(getRelativeTrackInfo(spec2, getTheme()));
         }
         {
             const t = { overlay: [], width: 10, height: 10 };
@@ -327,7 +332,7 @@ describe('Arrangement', () => {
                 arrangement: 'serial',
                 views: [{ tracks: [t] }, { tracks: [t] }]
             };
-            expect(getRelativeTrackInfo(spec1)).toEqual(getRelativeTrackInfo(spec2));
+            expect(getRelativeTrackInfo(spec1, getTheme())).toEqual(getRelativeTrackInfo(spec2, getTheme()));
         }
         {
             const t = { overlay: [], width: 10, height: 10 };
@@ -344,7 +349,7 @@ describe('Arrangement', () => {
                     }
                 ]
             };
-            const info = getRelativeTrackInfo(spec);
+            const info = getRelativeTrackInfo(spec, getTheme());
             expect(info).toHaveLength(3);
 
             const size = getBoundingBox(info);
@@ -373,7 +378,7 @@ describe('Arrangement', () => {
                     }
                 ]
             };
-            const info = getRelativeTrackInfo(spec);
+            const info = getRelativeTrackInfo(spec, getTheme());
             expect(info).toHaveLength(3);
 
             const size = getBoundingBox(info);

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -4,11 +4,11 @@ import { HIGLASS_AXIS_SIZE } from '../higlass-model';
 import {
     DEFAULT_CIRCULAR_VIEW_PADDING,
     DEFAULT_INNER_RADIUS_PROP,
-    DEFAULT_SUBTITLE_HEIGHT,
-    DEFAULT_TITLE_HEIGHT,
-    DEFAULT_VIEW_SPACING
+    DEFAULT_VIEW_SPACING,
+    DEWFAULT_TITLE_PADDING_ON_TOP_AND_BOTTOM
 } from '../layout/defaults';
 import { traverseTracksAndViews, traverseViewArrangements } from './spec-preprocess';
+import { CompleteThemeDeep } from './theme';
 
 export interface Size {
     width: number;
@@ -74,7 +74,7 @@ export function getBoundingBox(trackInfos: TrackInfo[]) {
  * Collect information of individual tracks including their size/position and specs
  * @param spec
  */
-export function getRelativeTrackInfo(spec: GoslingSpec): TrackInfo[] {
+export function getRelativeTrackInfo(spec: GoslingSpec, theme: CompleteThemeDeep): TrackInfo[] {
     let trackInfos: TrackInfo[] = [] as TrackInfo[];
 
     // Collect track information including spec, bounding boxes, and RGL' `layout`.
@@ -86,7 +86,9 @@ export function getRelativeTrackInfo(spec: GoslingSpec): TrackInfo[] {
     // Titles
     if (spec.title || spec.subtitle) {
         // If title and/or subtitle presents, offset the y position by title/subtitle size
-        const titleHeight = (spec.title ? DEFAULT_TITLE_HEIGHT : 0) + (spec.subtitle ? DEFAULT_SUBTITLE_HEIGHT : 0);
+        const titleHeight =
+            (spec.title ? theme.root.titleFontSize + DEWFAULT_TITLE_PADDING_ON_TOP_AND_BOTTOM : 0) +
+            (spec.subtitle ? theme.root.subtitleFontSize + DEWFAULT_TITLE_PADDING_ON_TOP_AND_BOTTOM : 0);
         const marginBottom = 4;
 
         size.height += titleHeight + marginBottom;

--- a/src/core/utils/spec-preprocess.test.ts
+++ b/src/core/utils/spec-preprocess.test.ts
@@ -1,17 +1,21 @@
 import { GoslingSpec, SingleView, Track } from '../gosling.schema';
 import { getBoundingBox, getRelativeTrackInfo } from './bounding-box';
 import { traverseToFixSpecDownstream, overrideTemplates, convertToFlatTracks } from './spec-preprocess';
+import { getTheme } from './theme';
 
 describe('Fix Spec Downstream', () => {
     it('Empty Views', () => {
-        const info = getRelativeTrackInfo({
-            arrangement: 'parallel',
-            views: [
-                {
-                    tracks: []
-                }
-            ]
-        });
+        const info = getRelativeTrackInfo(
+            {
+                arrangement: 'parallel',
+                views: [
+                    {
+                        tracks: []
+                    }
+                ]
+            },
+            getTheme()
+        );
         const size = getBoundingBox(info);
         expect(!isNaN(+size.width) && isFinite(size.width)).toEqual(true);
         expect(!isNaN(+size.height) && isFinite(size.height)).toEqual(true);

--- a/src/core/utils/text-style.ts
+++ b/src/core/utils/text-style.ts
@@ -1,0 +1,30 @@
+export type TextStyle = {
+    color?: string;
+    size?: number;
+    fontFamily?: string;
+    fontWeight?: 'bold' | 'normal' | 'light';
+    stroke?: string;
+    strokeThickness?: number;
+};
+
+export const DEFAULT_TEXT_STYLE: TextStyle = {
+    color: 'black',
+    size: 10,
+    fontFamily: 'Arial',
+    fontWeight: 'normal',
+    stroke: '#ffffff',
+    strokeThickness: 0
+};
+
+export function getTextStyle(style: TextStyle = DEFAULT_TEXT_STYLE) {
+    return {
+        fontSize: `${style.size ?? DEFAULT_TEXT_STYLE.size}px`,
+        fontFamily: style.fontFamily ?? DEFAULT_TEXT_STYLE.fontFamily,
+        fontWeight: style.fontWeight ?? DEFAULT_TEXT_STYLE.fontWeight,
+        fill: style.color ?? DEFAULT_TEXT_STYLE.color,
+        background: 'white',
+        lineJoin: 'round',
+        stroke: style.stroke ?? DEFAULT_TEXT_STYLE.stroke,
+        strokeThickness: style.strokeThickness ?? DEFAULT_TEXT_STYLE.strokeThickness
+    };
+}

--- a/src/core/utils/theme.ts
+++ b/src/core/utils/theme.ts
@@ -66,33 +66,56 @@ export interface CompleteThemeDeep {
 export interface RootStyle {
     background?: string;
     titleColor?: string;
+    titleFontSize?: number;
+    titleFontFamily?: string;
+    titleAlign?: 'left' | 'middle' | 'right';
+    titleFontWeight?: 'bold' | 'normal' | 'light';
+    titleBackgroundColor?: string;
     subtitleColor?: string;
+    subtitleFontSize?: number;
+    subtitleFontFamily?: string;
+    subtitleAlign?: 'left' | 'middle' | 'right';
+    subtitleFontWeight?: 'bold' | 'normal' | 'light';
+    subtitleBackgroundColor?: string;
     mousePositionColor?: string;
 }
 
 export interface TrackStyle {
+    background?: string;
+    alternatingBackground?: string; // used to fill all even rows
     titleColor?: string;
     titleBackground?: string;
+    titleFontSize?: number;
+    titleAlign?: 'left' | 'middle' | 'right';
     outline?: string;
     outlineWidth?: number;
     // ...
 }
 
 export interface LegendStyle {
+    position?: 'top' | 'right'; // TODO: support bottom and left, and even all corners (e.g., top-left, bottom-right, etc)
+    tickColor?: string;
     labelColor?: string;
+    labelFontSize?: number;
+    labelFontWeight?: 'bold' | 'normal' | 'light';
+    labelFontFamily?: string;
     background?: string;
     backgroundOpacity?: number;
     backgroundStroke?: string;
-    tickColor?: string;
     // ...
 }
 
 export interface AxisStyle {
     tickColor?: string;
     labelColor?: string;
+    labelFontSize?: number;
+    labelFontWeight?: 'bold' | 'normal' | 'light';
+    labelFontFamily?: string;
     baselineColor?: string;
     gridColor?: string;
     gridStrokeWidth?: number;
+    gridStrokeType?: 'solid' | 'dashed';
+    gridStrokeDash?: [number, number];
     // ...
 }
 
@@ -156,21 +179,39 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
         root: {
             background: 'white',
             titleColor: 'black',
+            titleBackgroundColor: 'transparent',
+            titleFontSize: 18,
+            titleFontFamily: 'Arial',
+            titleAlign: 'left',
+            titleFontWeight: 'bold',
             subtitleColor: 'gray',
+            subtitleBackgroundColor: 'transparent',
+            subtitleFontSize: 16,
+            subtitleFontFamily: 'Arial',
+            subtitleFontWeight: 'normal',
+            subtitleAlign: 'left',
             mousePositionColor: '#000000'
         },
 
         track: {
+            background: 'transparent',
+            alternatingBackground: 'transparent',
             titleColor: 'black',
             titleBackground: 'white',
+            titleFontSize: 24,
+            titleAlign: 'left',
             outline: 'black',
             outlineWidth: 1
         },
 
         legend: {
+            position: 'top',
             background: 'white',
             backgroundOpacity: 0.7,
             labelColor: 'black',
+            labelFontSize: 12,
+            labelFontWeight: 'normal',
+            labelFontFamily: 'Arial',
             backgroundStroke: '#DBDBDB',
             tickColor: 'black'
         },
@@ -178,9 +219,14 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
         axis: {
             tickColor: 'black',
             labelColor: 'black',
+            labelFontSize: 12,
+            labelFontWeight: 'normal',
+            labelFontFamily: 'Arial',
             baselineColor: 'black',
             gridColor: '#E3E3E3',
-            gridStrokeWidth: 1
+            gridStrokeWidth: 1,
+            gridStrokeType: 'solid',
+            gridStrokeDash: [4, 4]
         },
 
         markCommon: {
@@ -232,21 +278,39 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
         root: {
             background: 'black',
             titleColor: 'white',
+            titleBackgroundColor: 'transparent',
+            titleFontSize: 18,
+            titleFontFamily: 'Arial',
+            titleAlign: 'middle',
+            titleFontWeight: 'bold',
             subtitleColor: 'lightgray',
+            subtitleBackgroundColor: 'transparent',
+            subtitleFontSize: 16,
+            subtitleFontFamily: 'Arial',
+            subtitleAlign: 'middle',
+            subtitleFontWeight: 'normal',
             mousePositionColor: '#FFFFFF'
         },
 
         track: {
+            background: 'transparent',
+            alternatingBackground: 'transparent',
             titleColor: 'white',
             titleBackground: 'black',
+            titleFontSize: 18,
+            titleAlign: 'left',
             outline: 'white',
             outlineWidth: 1
         },
 
         legend: {
+            position: 'right',
             background: 'black',
             backgroundOpacity: 0.7,
             labelColor: 'white',
+            labelFontSize: 12,
+            labelFontWeight: 'normal',
+            labelFontFamily: 'Arial',
             backgroundStroke: '#DBDBDB',
             tickColor: 'white'
         },
@@ -254,9 +318,14 @@ export const THEMES: { [key in Themes]: Required<CompleteThemeDeep> } = {
         axis: {
             tickColor: 'white',
             labelColor: 'white',
+            labelFontSize: 10,
+            labelFontWeight: 'normal',
+            labelFontFamily: 'Arial',
             baselineColor: 'white',
             gridColor: 'gray',
-            gridStrokeWidth: 1
+            gridStrokeWidth: 1,
+            gridStrokeType: 'solid',
+            gridStrokeDash: [4, 4]
         },
 
         markCommon: {

--- a/src/gosling-genomic-axis/axis-track.ts
+++ b/src/gosling-genomic-axis/axis-track.ts
@@ -7,6 +7,7 @@ import { scaleLinear } from 'd3-scale';
 import { format, precisionPrefix, formatPrefix } from 'd3-format';
 import { GET_CHROM_SIZES } from '../core/utils/assembly';
 import { cartesianToPolar } from '../core/utils/polar';
+import { getTextStyle } from '../core/utils/text-style';
 
 const TICK_WIDTH = 200;
 const TICK_HEIGHT = 6;
@@ -43,16 +44,17 @@ function AxisTrack(HGC: any, ...args: any[]): any {
 
             this.textFontSize = 12;
             this.textFontFamily = 'sans-serif'; //'Arial';
+            this.textFontWeight = 'normal';
             this.textFontColor = '#808080';
             this.textStrokeColor = '#ffffff';
-            this.pixiTextConfig = {
-                fontSize: +this.options.fontSize ? `${+this.options.fontSize}px` : `${this.textFontSize}px`,
-                fontFamily: this.textFontFamily,
-                fill: this.options.color || this.textFontColor,
-                lineJoin: 'round',
+            this.pixiTextConfig = getTextStyle({
+                size: +this.options.fontSize || this.textFontSize,
+                fontFamily: this.options.fontFamily || this.textFontFamily,
+                fontWeight: this.options.fontWeight || this.textFontWeight,
+                color: this.options.color || this.textFontColor,
                 stroke: this.options.stroke || this.textStrokeColor,
                 strokeThickness: 2
-            };
+            });
             this.stroke = colorToHex(this.pixiTextConfig.stroke);
 
             // text objects to use if the tick style is "bounds", meaning


### PR DESCRIPTION
# About This PR
This PR adds additional theme components, such as font family, font weight, font alignment, dashed grid lines, alternating background, track's inner background, etc. To find the complete list of properties that have been added by this PR, please refer to `src/core/utils/theme.ts` in the "Files changed" tab.

# Example
## An Example Spec

(Be aware that the example below does not show the complete list of properties that had been added by this PR. For the complete list, please refer to `src/core/utils/theme.ts` as described above.)

```js
root: {
    ...,
    titleColor: 'black',
    titleBackgroundColor: '#F4F4F4',
    titleFontSize: 24,
    titleFontFamily: 'Roboto Condensed',
    titleAlign: 'middle',
    titleFontWeight: 'bold',
    subtitleColor: 'gray',
    subtitleBackgroundColor: '#F4F4F4',
    subtitleFontSize: 16,
    subtitleFontFamily: 'Arial',
    subtitleFontWeight: 'normal',
    subtitleAlign: 'middle'
},

track: {
    ..., 
    background: 'transparent',
    alternatingBackground: '#E1F2FB', // this is used for even numbers of rows, e.g., 2nd, 4th rows
    titleColor: 'black',
    titleBackground: 'white',
    titleFontSize: 24,
    titleAlign: 'left'
},

legend: {
    ...,
    position: 'top', // not functioning yet, but added in the spec
    labelFontSize: 12,
    labelFontWeight: 'normal',
    labelFontFamily: 'Arial'
},

axis: {
    ...,
    labelFontSize: 12,
    labelFontWeight: 'normal',
    labelFontFamily: 'Arial',
    gridStrokeWidth: 1,
    gridStrokeType: 'dashed',
    gridStrokeDash: [4, 4]
},
```

## Corresponding Screenshot
![gosling-visualization](https://user-images.githubusercontent.com/9922882/126239061-3ee1353d-acaa-474c-8071-2775cfa4164a.png)


Toward https://github.com/gosling-lang/gosling-theme/issues/9
Toward #117 