### PR TITLE
fix: draw circular background on the back, not in front of some tiles

### DIFF
--- a/src/core/mark/outline-circular.ts
+++ b/src/core/mark/outline-circular.ts
@@ -15,6 +15,7 @@ export function drawCircularOutlines(
     const spec = tm.spec();
 
     /* track size */
+    const [l, t] = trackInfo.position;
     const [trackWidth, trackHeight] = trackInfo.dimensions;
 
     /* circular parameters */
@@ -22,15 +23,15 @@ export function drawCircularOutlines(
     const trackOuterRadius = spec.outerRadius ?? 300; // TODO: should be smaller than Math.min(width, height)
     const startAngle = spec.startAngle ?? 0;
     const endAngle = spec.endAngle ?? 360;
-    const cx = trackWidth / 2.0;
-    const cy = trackHeight / 2.0;
+    const cx = l + trackWidth / 2.0;
+    const cy = t + trackHeight / 2.0;
 
     const posStartInner = cartesianToPolar(0, trackWidth, trackInnerRadius, cx, cy, startAngle, endAngle);
     const startRad = valueToRadian(0, trackWidth, startAngle, endAngle);
     const endRad = valueToRadian(trackWidth, trackWidth, startAngle, endAngle);
 
     /* render */
-    const g = tile.graphics;
+    const g = trackInfo.pBackground;
 
     if (!(spec.layout === 'circular' && spec.mark === 'withinLink')) {
         // circular link marks usually use entire inner space


### PR DESCRIPTION
# Introduction
This PR fixes the issue that, in circular layouts, some tiles are occluded by a background layer (see the screenshot below). This PR properly draw backgrounds on the back (using `pBackground` layer) to address the issue.

# Screenshots
## Before
![bofore](https://user-images.githubusercontent.com/9922882/127017809-59ef5428-544b-4184-ba4a-7c2e20333f08.png)

## After
![after](https://user-images.githubusercontent.com/9922882/127017801-a00797da-8699-451c-bcc1-b22e456d52b5.png)

