### PR TITLE
fix: ensure the entire height a multiple of 8

### DIFF
--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -252,6 +252,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                             ref={hgRef}
                             options={{
                                 bounded: true,
+                                pixelPreciseMarginPadding: false,
                                 containerPaddingX: 0,
                                 containerPaddingY: 0,
                                 viewMarginTop: 0,

--- a/src/core/utils/bounding-box.test.ts
+++ b/src/core/utils/bounding-box.test.ts
@@ -6,20 +6,20 @@ import { getTheme } from './theme';
 
 describe('Arrangement', () => {
     it('1 View, 1 Track', () => {
-        const spec = { tracks: [{ overlay: [], width: 10, height: 10 }] };
+        const spec = { tracks: [{ overlay: [], width: 40, height: 40 }] };
         const info = getRelativeTrackInfo(spec, getTheme());
         expect(info).toHaveLength(1);
 
         expect(info[0].track).toEqual(spec.tracks[0]);
-        expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
+        expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 40, height: 40 });
         expect(info[0].layout).toEqual({ x: 0, y: 0, w: 12, h: 12 });
     });
 
     it('1 View, 1 Track (N Overlaid Tracks)', () => {
         const spec1 = {
             tracks: [
-                { overlay: [], width: 10, height: 10 },
-                { overlay: [], width: 10, height: 10, overlayOnPreviousTrack: true }
+                { overlay: [], width: 40, height: 40 },
+                { overlay: [], width: 40, height: 40, overlayOnPreviousTrack: true }
             ]
         };
         expect(getRelativeTrackInfo(spec1, getTheme())).toHaveLength(2);
@@ -67,11 +67,11 @@ describe('Arrangement', () => {
 
         expect(info[0].track).toEqual(spec.tracks[0]);
         expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
-        expect(info[0].layout).toEqual({ x: 0, y: 0, w: 12, h: (10 / 20) * 12 });
+        expect(info[0].layout).toEqual({ x: 0, y: 0, w: 12, h: (10 / 24) * 12 }); // 4 is added since Gosling makes it a multiple of 8
 
         expect(info[1].track).toEqual(spec.tracks[1]);
         expect(info[1].boundingBox).toEqual({ x: 0, y: 10, width: 10, height: 10 });
-        expect(info[1].layout).toEqual({ x: 0, y: 6, w: 12, h: (10 / 20) * 12 });
+        expect(info[1].layout).toEqual({ x: 0, y: 5, w: 12, h: (10 / 24) * 12 }); // 4 is added since Gosling makes it a multiple of 8
     });
 
     it('Palallel Views', () => {
@@ -96,7 +96,7 @@ describe('Arrangement', () => {
         expect(info).toHaveLength(4);
 
         const size = getBoundingBox(info);
-        expect(size).toEqual({ width: 10, height: 40 + DEFAULT_VIEW_SPACING });
+        expect(size).toEqual({ width: 10, height: 40 + DEFAULT_VIEW_SPACING + 4 }); // TODO: a few px is added to make it a multiple of 8
 
         expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
         expect(info[1].boundingBox).toEqual({ x: 0, y: 10, width: 10, height: 10 });
@@ -126,7 +126,7 @@ describe('Arrangement', () => {
         expect(info).toHaveLength(4);
 
         const size = getBoundingBox(info);
-        expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 20 });
+        expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 20 + 4 }); // TODO: a few px is added to make it a multiple of 8
 
         expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
         expect(info[1].boundingBox).toEqual({ x: 0, y: 10, width: 10, height: 10 });
@@ -257,7 +257,7 @@ describe('Arrangement', () => {
             expect(info).toHaveLength(2);
 
             const size = getBoundingBox(info);
-            expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 10 });
+            expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 10 + 6 }); // TODO: a few px is added to make it a multiple of 8
 
             expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
             expect(info[1].boundingBox).toEqual({ x: 10 + DEFAULT_VIEW_SPACING, y: 0, width: 10, height: 10 });
@@ -289,7 +289,7 @@ describe('Arrangement', () => {
             const size = getBoundingBox(info);
             expect(size).toEqual({
                 width: 10 + DEFAULT_CIRCULAR_VIEW_PADDING * 2,
-                height: 10 + DEFAULT_CIRCULAR_VIEW_PADDING * 2
+                height: 10 + DEFAULT_CIRCULAR_VIEW_PADDING * 2 + 2 // TODO: a few px is added to make it a multiple of 8
             });
 
             expect(info[0].boundingBox).toEqual(info[1].boundingBox);

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -67,6 +67,12 @@ export function getBoundingBox(trackInfos: TrackInfo[]) {
             width = w;
         }
     });
+
+    // TODO: it should be multiples of `8` (refer to `pixelPreciseMarginPadding`)
+    if (height % 8 !== 0) {
+        height += height % 8;
+    }
+
     return { width, height };
 }
 

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -70,7 +70,7 @@ export function getBoundingBox(trackInfos: TrackInfo[]) {
 
     // TODO: it should be multiples of `8` (refer to `pixelPreciseMarginPadding`)
     if (height % 8 !== 0) {
-        height += height % 8;
+        height += 8 - (height % 8);
     }
 
     return { width, height };


### PR DESCRIPTION
This PR makes sure to use multiples of 8 for the entire height of the gosling.js visualization. This is necessary since (unless we figure out to use pixelPreciseMarginPadding) the overall layout breaks when the entire height is not a multiple of 8.