### PR TITLE
feat: support templates, enable precise and correct track/view sizing and triangle positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "mixwith": "^0.1.1",
         "pubsub-js": "^1.9.3",
         "raw-loader": "^4.0.2",
+        "react-grid-layout": "^1.2.5",
         "threads": "^1.6.4",
         "worker-loader": "^3.0.8"
     },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "homepage": "https://gosling-lang.github.io/gosling.js/",
     "main": "dist/gosling.js",
-    "types": "dist/index.d.ts",
+    "types": "dist/src/index.d.ts",
     "files": [
         "dist"
     ],

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -564,6 +564,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -934,6 +940,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -1626,6 +1638,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -1927,6 +1945,9 @@
                   }
                 ]
               },
+              "xOffset": {
+                "type": "number"
+              },
               "xe": {
                 "$ref": "#/definitions/Channel"
               },
@@ -1938,6 +1959,9 @@
               },
               "y1e": {
                 "$ref": "#/definitions/Channel"
+              },
+              "yOffset": {
+                "type": "number"
               },
               "ye": {
                 "$ref": "#/definitions/Channel"
@@ -2038,6 +2062,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -2049,6 +2076,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -2398,6 +2428,9 @@
                         }
                       ]
                     },
+                    "xOffset": {
+                      "type": "number"
+                    },
                     "xe": {
                       "$ref": "#/definitions/Channel"
                     },
@@ -2409,6 +2442,9 @@
                     },
                     "y1e": {
                       "$ref": "#/definitions/Channel"
+                    },
+                    "yOffset": {
+                      "type": "number"
                     },
                     "ye": {
                       "$ref": "#/definitions/Channel"
@@ -2512,6 +2548,9 @@
                   }
                 ]
               },
+              "xOffset": {
+                "type": "number"
+              },
               "xe": {
                 "$ref": "#/definitions/Channel"
               },
@@ -2523,6 +2562,9 @@
               },
               "y1e": {
                 "$ref": "#/definitions/Channel"
+              },
+              "yOffset": {
+                "type": "number"
               },
               "ye": {
                 "$ref": "#/definitions/Channel"
@@ -2566,6 +2608,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -2577,6 +2622,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -2722,6 +2770,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -3071,6 +3125,9 @@
                             }
                           ]
                         },
+                        "xOffset": {
+                          "type": "number"
+                        },
                         "xe": {
                           "$ref": "#/definitions/Channel"
                         },
@@ -3082,6 +3139,9 @@
                         },
                         "y1e": {
                           "$ref": "#/definitions/Channel"
+                        },
+                        "yOffset": {
+                          "type": "number"
                         },
                         "ye": {
                           "$ref": "#/definitions/Channel"
@@ -3185,6 +3245,9 @@
                       }
                     ]
                   },
+                  "xOffset": {
+                    "type": "number"
+                  },
                   "xe": {
                     "$ref": "#/definitions/Channel"
                   },
@@ -3196,6 +3259,9 @@
                   },
                   "y1e": {
                     "$ref": "#/definitions/Channel"
+                  },
+                  "yOffset": {
+                    "type": "number"
                   },
                   "ye": {
                     "$ref": "#/definitions/Channel"
@@ -3239,6 +3305,9 @@
                 }
               ]
             },
+            "xOffset": {
+              "type": "number"
+            },
             "xe": {
               "$ref": "#/definitions/Channel"
             },
@@ -3250,6 +3319,9 @@
             },
             "y1e": {
               "$ref": "#/definitions/Channel"
+            },
+            "yOffset": {
+              "type": "number"
             },
             "ye": {
               "$ref": "#/definitions/Channel"
@@ -3605,6 +3677,9 @@
                                 }
                               ]
                             },
+                            "xOffset": {
+                              "type": "number"
+                            },
                             "xe": {
                               "$ref": "#/definitions/Channel"
                             },
@@ -3616,6 +3691,9 @@
                             },
                             "y1e": {
                               "$ref": "#/definitions/Channel"
+                            },
+                            "yOffset": {
+                              "type": "number"
                             },
                             "ye": {
                               "$ref": "#/definitions/Channel"
@@ -3719,6 +3797,9 @@
                           }
                         ]
                       },
+                      "xOffset": {
+                        "type": "number"
+                      },
                       "xe": {
                         "$ref": "#/definitions/Channel"
                       },
@@ -3730,6 +3811,9 @@
                       },
                       "y1e": {
                         "$ref": "#/definitions/Channel"
+                      },
+                      "yOffset": {
+                        "type": "number"
                       },
                       "ye": {
                         "$ref": "#/definitions/Channel"
@@ -3778,6 +3862,9 @@
                 }
               ]
             },
+            "xOffset": {
+              "type": "number"
+            },
             "xe": {
               "$ref": "#/definitions/Channel"
             },
@@ -3789,6 +3876,9 @@
             },
             "y1e": {
               "$ref": "#/definitions/Channel"
+            },
+            "yOffset": {
+              "type": "number"
             },
             "ye": {
               "$ref": "#/definitions/Channel"
@@ -3857,6 +3947,12 @@
                   "$ref": "#/definitions/DomainChr"
                 }
               ]
+            },
+            "xOffset": {
+              "type": "number"
+            },
+            "yOffset": {
+              "type": "number"
             }
           },
           "required": [
@@ -4021,6 +4117,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -4032,6 +4131,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -4443,6 +4545,9 @@
                             }
                           ]
                         },
+                        "xOffset": {
+                          "type": "number"
+                        },
                         "xe": {
                           "$ref": "#/definitions/Channel"
                         },
@@ -4454,6 +4559,9 @@
                         },
                         "y1e": {
                           "$ref": "#/definitions/Channel"
+                        },
+                        "yOffset": {
+                          "type": "number"
                         },
                         "ye": {
                           "$ref": "#/definitions/Channel"
@@ -4557,6 +4665,9 @@
                       }
                     ]
                   },
+                  "xOffset": {
+                    "type": "number"
+                  },
                   "xe": {
                     "$ref": "#/definitions/Channel"
                   },
@@ -4568,6 +4679,9 @@
                   },
                   "y1e": {
                     "$ref": "#/definitions/Channel"
+                  },
+                  "yOffset": {
+                    "type": "number"
                   },
                   "ye": {
                     "$ref": "#/definitions/Channel"
@@ -4616,6 +4730,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -4627,6 +4744,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1451,9 +1451,6 @@
         },
         {
           "$ref": "#/definitions/MarkGlyph"
-        },
-        {
-          "$ref": "#/definitions/MarkWithStyle"
         }
       ]
     },
@@ -1546,26 +1543,6 @@
         "header"
       ],
       "type": "string"
-    },
-    "MarkWithStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "curvature": {
-          "enum": [
-            "straight",
-            "stepwise",
-            "curved"
-          ],
-          "type": "string"
-        },
-        "type": {
-          "$ref": "#/definitions/MarkType"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "type": "object"
     },
     "MatrixData": {
       "additionalProperties": false,
@@ -2241,6 +2218,12 @@
               "displacement": {
                 "$ref": "#/definitions/Displacement"
               },
+              "encoding": {
+                "additionalProperties": {
+                  "$ref": "#/definitions/Channel"
+                },
+                "type": "object"
+              },
               "endAngle": {
                 "type": "number"
               },
@@ -2478,6 +2461,9 @@
                 "$ref": "#/definitions/Style"
               },
               "subtitle": {
+                "type": "string"
+              },
+              "template": {
                 "type": "string"
               },
               "text": {
@@ -2905,6 +2891,12 @@
                   "displacement": {
                     "$ref": "#/definitions/Displacement"
                   },
+                  "encoding": {
+                    "additionalProperties": {
+                      "$ref": "#/definitions/Channel"
+                    },
+                    "type": "object"
+                  },
                   "endAngle": {
                     "type": "number"
                   },
@@ -3142,6 +3134,9 @@
                     "$ref": "#/definitions/Style"
                   },
                   "subtitle": {
+                    "type": "string"
+                  },
+                  "template": {
                     "type": "string"
                   },
                   "text": {
@@ -3430,6 +3425,12 @@
                       "displacement": {
                         "$ref": "#/definitions/Displacement"
                       },
+                      "encoding": {
+                        "additionalProperties": {
+                          "$ref": "#/definitions/Channel"
+                        },
+                        "type": "object"
+                      },
                       "endAngle": {
                         "type": "number"
                       },
@@ -3667,6 +3668,9 @@
                         "$ref": "#/definitions/Style"
                       },
                       "subtitle": {
+                        "type": "string"
+                      },
+                      "template": {
                         "type": "string"
                       },
                       "text": {
@@ -4259,6 +4263,12 @@
                   "displacement": {
                     "$ref": "#/definitions/Displacement"
                   },
+                  "encoding": {
+                    "additionalProperties": {
+                      "$ref": "#/definitions/Channel"
+                    },
+                    "type": "object"
+                  },
                   "endAngle": {
                     "type": "number"
                   },
@@ -4496,6 +4506,9 @@
                     "$ref": "#/definitions/Style"
                   },
                   "subtitle": {
+                    "type": "string"
+                  },
+                  "template": {
                     "type": "string"
                   },
                   "text": {
@@ -4805,6 +4818,37 @@
       },
       "type": "object"
     },
+    "TemplateTrack": {
+      "additionalProperties": false,
+      "description": "Template specification that will be internally converted into `SingleTrack` for rendering",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/DataDeep"
+        },
+        "encoding": {
+          "additionalProperties": {
+            "$ref": "#/definitions/Channel"
+          },
+          "type": "object"
+        },
+        "height": {
+          "type": "number"
+        },
+        "template": {
+          "type": "string"
+        },
+        "width": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "data",
+        "height",
+        "template",
+        "width"
+      ],
+      "type": "object"
+    },
     "Tooltip": {
       "additionalProperties": false,
       "properties": {
@@ -4837,6 +4881,9 @@
         },
         {
           "$ref": "#/definitions/DataTrack"
+        },
+        {
+          "$ref": "#/definitions/TemplateTrack"
         }
       ]
     },

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -479,6 +479,9 @@
       "additionalProperties": false,
       "description": "Partial specification of `BasicSingleTrack` to use default visual encoding predefined by data type.",
       "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
         "_renderingId": {
           "type": "string"
         },
@@ -1743,6 +1746,9 @@
       "additionalProperties": false,
       "description": "Superposing multiple tracks.",
       "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
         "_renderingId": {
           "type": "string"
         },
@@ -1808,6 +1814,9 @@
           "items": {
             "additionalProperties": false,
             "properties": {
+              "_invalidTrack": {
+                "type": "boolean"
+              },
               "_renderingId": {
                 "type": "string"
               },
@@ -2094,6 +2103,9 @@
     "OverlaidTracks": {
       "additionalProperties": false,
       "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
         "_renderingId": {
           "type": "string"
         },
@@ -2220,6 +2232,9 @@
           "items": {
             "additionalProperties": false,
             "properties": {
+              "_invalidTrack": {
+                "type": "boolean"
+              },
               "_renderingId": {
                 "type": "string"
               },
@@ -2291,6 +2306,9 @@
                 "items": {
                   "additionalProperties": false,
                   "properties": {
+                    "_invalidTrack": {
+                      "type": "boolean"
+                    },
                     "_renderingId": {
                       "type": "string"
                     },
@@ -2788,6 +2806,9 @@
         {
           "additionalProperties": false,
           "properties": {
+            "_invalidTrack": {
+              "type": "boolean"
+            },
             "_renderingId": {
               "type": "string"
             },
@@ -2917,6 +2938,9 @@
               "items": {
                 "additionalProperties": false,
                 "properties": {
+                  "_invalidTrack": {
+                    "type": "boolean"
+                  },
                   "_renderingId": {
                     "type": "string"
                   },
@@ -2988,6 +3012,9 @@
                     "items": {
                       "additionalProperties": false,
                       "properties": {
+                        "_invalidTrack": {
+                          "type": "boolean"
+                        },
                         "_renderingId": {
                           "type": "string"
                         },
@@ -3338,6 +3365,9 @@
         {
           "additionalProperties": false,
           "properties": {
+            "_invalidTrack": {
+              "type": "boolean"
+            },
             "_renderingId": {
               "type": "string"
             },
@@ -3469,6 +3499,9 @@
                   {
                     "additionalProperties": false,
                     "properties": {
+                      "_invalidTrack": {
+                        "type": "boolean"
+                      },
                       "_renderingId": {
                         "type": "string"
                       },
@@ -3540,6 +3573,9 @@
                         "items": {
                           "additionalProperties": false,
                           "properties": {
+                            "_invalidTrack": {
+                              "type": "boolean"
+                            },
                             "_renderingId": {
                               "type": "string"
                             },
@@ -3965,6 +4001,9 @@
     "SingleTrack": {
       "additionalProperties": false,
       "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
         "_renderingId": {
           "type": "string"
         },
@@ -4209,6 +4248,9 @@
     "StackedTracks": {
       "additionalProperties": false,
       "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
         "_renderingId": {
           "type": "string"
         },
@@ -4337,6 +4379,9 @@
               {
                 "additionalProperties": false,
                 "properties": {
+                  "_invalidTrack": {
+                    "type": "boolean"
+                  },
                   "_renderingId": {
                     "type": "string"
                   },
@@ -4408,6 +4453,9 @@
                     "items": {
                       "additionalProperties": false,
                       "properties": {
+                        "_invalidTrack": {
+                          "type": "boolean"
+                        },
                         "_renderingId": {
                           "type": "string"
                         },
@@ -4942,6 +4990,19 @@
       "additionalProperties": false,
       "description": "Template specification that will be internally converted into `SingleTrack` for rendering",
       "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
+        "_renderingId": {
+          "type": "string"
+        },
+        "assembly": {
+          "$ref": "#/definitions/Assembly"
+        },
+        "centerRadius": {
+          "description": "Proportion of the radius of the center white space.",
+          "type": "number"
+        },
         "data": {
           "$ref": "#/definitions/DataDeep"
         },
@@ -4951,13 +5012,86 @@
           },
           "type": "object"
         },
+        "endAngle": {
+          "type": "number"
+        },
         "height": {
           "type": "number"
+        },
+        "id": {
+          "type": "string"
+        },
+        "innerRadius": {
+          "type": "number"
+        },
+        "layout": {
+          "$ref": "#/definitions/Layout"
+        },
+        "linkingId": {
+          "type": "string"
+        },
+        "orientation": {
+          "$ref": "#/definitions/Orientation"
+        },
+        "outerRadius": {
+          "type": "number"
+        },
+        "overlayOnPreviousTrack": {
+          "type": "boolean"
+        },
+        "prerelease": {
+          "additionalProperties": false,
+          "properties": {
+            "testUsingNewRectRenderingForBAM": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "spacing": {
+          "type": "number"
+        },
+        "startAngle": {
+          "type": "number"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "style": {
+          "$ref": "#/definitions/Style"
+        },
+        "subtitle": {
+          "type": "string"
         },
         "template": {
           "type": "string"
         },
+        "title": {
+          "type": "string"
+        },
         "width": {
+          "type": "number"
+        },
+        "xAxis": {
+          "$ref": "#/definitions/AxisPosition"
+        },
+        "xDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
           "type": "number"
         }
       },

--- a/schema/history/0.8.12/gosling0.8.12.schema.json
+++ b/schema/history/0.8.12/gosling0.8.12.schema.json
@@ -564,6 +564,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -934,6 +940,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -1649,6 +1661,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -1950,6 +1968,9 @@
                   }
                 ]
               },
+              "xOffset": {
+                "type": "number"
+              },
               "xe": {
                 "$ref": "#/definitions/Channel"
               },
@@ -1961,6 +1982,9 @@
               },
               "y1e": {
                 "$ref": "#/definitions/Channel"
+              },
+              "yOffset": {
+                "type": "number"
               },
               "ye": {
                 "$ref": "#/definitions/Channel"
@@ -2061,6 +2085,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -2072,6 +2099,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -2415,6 +2445,9 @@
                         }
                       ]
                     },
+                    "xOffset": {
+                      "type": "number"
+                    },
                     "xe": {
                       "$ref": "#/definitions/Channel"
                     },
@@ -2426,6 +2459,9 @@
                     },
                     "y1e": {
                       "$ref": "#/definitions/Channel"
+                    },
+                    "yOffset": {
+                      "type": "number"
                     },
                     "ye": {
                       "$ref": "#/definitions/Channel"
@@ -2526,6 +2562,9 @@
                   }
                 ]
               },
+              "xOffset": {
+                "type": "number"
+              },
               "xe": {
                 "$ref": "#/definitions/Channel"
               },
@@ -2537,6 +2576,9 @@
               },
               "y1e": {
                 "$ref": "#/definitions/Channel"
+              },
+              "yOffset": {
+                "type": "number"
               },
               "ye": {
                 "$ref": "#/definitions/Channel"
@@ -2580,6 +2622,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -2591,6 +2636,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -2736,6 +2784,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -3079,6 +3133,9 @@
                             }
                           ]
                         },
+                        "xOffset": {
+                          "type": "number"
+                        },
                         "xe": {
                           "$ref": "#/definitions/Channel"
                         },
@@ -3090,6 +3147,9 @@
                         },
                         "y1e": {
                           "$ref": "#/definitions/Channel"
+                        },
+                        "yOffset": {
+                          "type": "number"
                         },
                         "ye": {
                           "$ref": "#/definitions/Channel"
@@ -3190,6 +3250,9 @@
                       }
                     ]
                   },
+                  "xOffset": {
+                    "type": "number"
+                  },
                   "xe": {
                     "$ref": "#/definitions/Channel"
                   },
@@ -3201,6 +3264,9 @@
                   },
                   "y1e": {
                     "$ref": "#/definitions/Channel"
+                  },
+                  "yOffset": {
+                    "type": "number"
                   },
                   "ye": {
                     "$ref": "#/definitions/Channel"
@@ -3244,6 +3310,9 @@
                 }
               ]
             },
+            "xOffset": {
+              "type": "number"
+            },
             "xe": {
               "$ref": "#/definitions/Channel"
             },
@@ -3255,6 +3324,9 @@
             },
             "y1e": {
               "$ref": "#/definitions/Channel"
+            },
+            "yOffset": {
+              "type": "number"
             },
             "ye": {
               "$ref": "#/definitions/Channel"
@@ -3604,6 +3676,9 @@
                                 }
                               ]
                             },
+                            "xOffset": {
+                              "type": "number"
+                            },
                             "xe": {
                               "$ref": "#/definitions/Channel"
                             },
@@ -3615,6 +3690,9 @@
                             },
                             "y1e": {
                               "$ref": "#/definitions/Channel"
+                            },
+                            "yOffset": {
+                              "type": "number"
                             },
                             "ye": {
                               "$ref": "#/definitions/Channel"
@@ -3715,6 +3793,9 @@
                           }
                         ]
                       },
+                      "xOffset": {
+                        "type": "number"
+                      },
                       "xe": {
                         "$ref": "#/definitions/Channel"
                       },
@@ -3726,6 +3807,9 @@
                       },
                       "y1e": {
                         "$ref": "#/definitions/Channel"
+                      },
+                      "yOffset": {
+                        "type": "number"
                       },
                       "ye": {
                         "$ref": "#/definitions/Channel"
@@ -3774,6 +3858,9 @@
                 }
               ]
             },
+            "xOffset": {
+              "type": "number"
+            },
             "xe": {
               "$ref": "#/definitions/Channel"
             },
@@ -3785,6 +3872,9 @@
             },
             "y1e": {
               "$ref": "#/definitions/Channel"
+            },
+            "yOffset": {
+              "type": "number"
             },
             "ye": {
               "$ref": "#/definitions/Channel"
@@ -3853,6 +3943,12 @@
                   "$ref": "#/definitions/DomainChr"
                 }
               ]
+            },
+            "xOffset": {
+              "type": "number"
+            },
+            "yOffset": {
+              "type": "number"
             }
           },
           "required": [
@@ -4017,6 +4113,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -4028,6 +4127,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -4433,6 +4535,9 @@
                             }
                           ]
                         },
+                        "xOffset": {
+                          "type": "number"
+                        },
                         "xe": {
                           "$ref": "#/definitions/Channel"
                         },
@@ -4444,6 +4549,9 @@
                         },
                         "y1e": {
                           "$ref": "#/definitions/Channel"
+                        },
+                        "yOffset": {
+                          "type": "number"
                         },
                         "ye": {
                           "$ref": "#/definitions/Channel"
@@ -4544,6 +4652,9 @@
                       }
                     ]
                   },
+                  "xOffset": {
+                    "type": "number"
+                  },
                   "xe": {
                     "$ref": "#/definitions/Channel"
                   },
@@ -4555,6 +4666,9 @@
                   },
                   "y1e": {
                     "$ref": "#/definitions/Channel"
+                  },
+                  "yOffset": {
+                    "type": "number"
                   },
                   "ye": {
                     "$ref": "#/definitions/Channel"
@@ -4603,6 +4717,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -4614,6 +4731,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"

--- a/schema/history/0.8.12/gosling0.8.12.schema.json
+++ b/schema/history/0.8.12/gosling0.8.12.schema.json
@@ -479,6 +479,9 @@
       "additionalProperties": false,
       "description": "Partial specification of `BasicSingleTrack` to use default visual encoding predefined by data type.",
       "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
         "_renderingId": {
           "type": "string"
         },
@@ -1463,9 +1466,6 @@
         },
         {
           "$ref": "#/definitions/MarkGlyph"
-        },
-        {
-          "$ref": "#/definitions/MarkWithStyle"
         }
       ]
     },
@@ -1558,26 +1558,6 @@
         "header"
       ],
       "type": "string"
-    },
-    "MarkWithStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "curvature": {
-          "enum": [
-            "straight",
-            "stepwise",
-            "curved"
-          ],
-          "type": "string"
-        },
-        "type": {
-          "$ref": "#/definitions/MarkType"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "type": "object"
     },
     "MatrixData": {
       "additionalProperties": false,
@@ -1766,6 +1746,9 @@
       "additionalProperties": false,
       "description": "Superposing multiple tracks.",
       "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
         "_renderingId": {
           "type": "string"
         },
@@ -1831,6 +1814,9 @@
           "items": {
             "additionalProperties": false,
             "properties": {
+              "_invalidTrack": {
+                "type": "boolean"
+              },
               "_renderingId": {
                 "type": "string"
               },
@@ -2117,6 +2103,9 @@
     "OverlaidTracks": {
       "additionalProperties": false,
       "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
         "_renderingId": {
           "type": "string"
         },
@@ -2243,6 +2232,9 @@
           "items": {
             "additionalProperties": false,
             "properties": {
+              "_invalidTrack": {
+                "type": "boolean"
+              },
               "_renderingId": {
                 "type": "string"
               },
@@ -2270,6 +2262,12 @@
               },
               "displacement": {
                 "$ref": "#/definitions/Displacement"
+              },
+              "encoding": {
+                "additionalProperties": {
+                  "$ref": "#/definitions/Channel"
+                },
+                "type": "object"
               },
               "endAngle": {
                 "type": "number"
@@ -2308,6 +2306,9 @@
                 "items": {
                   "additionalProperties": false,
                   "properties": {
+                    "_invalidTrack": {
+                      "type": "boolean"
+                    },
                     "_renderingId": {
                       "type": "string"
                     },
@@ -2514,6 +2515,9 @@
                 "$ref": "#/definitions/Style"
               },
               "subtitle": {
+                "type": "string"
+              },
+              "template": {
                 "type": "string"
               },
               "text": {
@@ -2802,6 +2806,9 @@
         {
           "additionalProperties": false,
           "properties": {
+            "_invalidTrack": {
+              "type": "boolean"
+            },
             "_renderingId": {
               "type": "string"
             },
@@ -2931,6 +2938,9 @@
               "items": {
                 "additionalProperties": false,
                 "properties": {
+                  "_invalidTrack": {
+                    "type": "boolean"
+                  },
                   "_renderingId": {
                     "type": "string"
                   },
@@ -2958,6 +2968,12 @@
                   },
                   "displacement": {
                     "$ref": "#/definitions/Displacement"
+                  },
+                  "encoding": {
+                    "additionalProperties": {
+                      "$ref": "#/definitions/Channel"
+                    },
+                    "type": "object"
                   },
                   "endAngle": {
                     "type": "number"
@@ -2996,6 +3012,9 @@
                     "items": {
                       "additionalProperties": false,
                       "properties": {
+                        "_invalidTrack": {
+                          "type": "boolean"
+                        },
                         "_renderingId": {
                           "type": "string"
                         },
@@ -3204,6 +3223,9 @@
                   "subtitle": {
                     "type": "string"
                   },
+                  "template": {
+                    "type": "string"
+                  },
                   "text": {
                     "$ref": "#/definitions/Channel"
                   },
@@ -3343,6 +3365,9 @@
         {
           "additionalProperties": false,
           "properties": {
+            "_invalidTrack": {
+              "type": "boolean"
+            },
             "_renderingId": {
               "type": "string"
             },
@@ -3474,6 +3499,9 @@
                   {
                     "additionalProperties": false,
                     "properties": {
+                      "_invalidTrack": {
+                        "type": "boolean"
+                      },
                       "_renderingId": {
                         "type": "string"
                       },
@@ -3501,6 +3529,12 @@
                       },
                       "displacement": {
                         "$ref": "#/definitions/Displacement"
+                      },
+                      "encoding": {
+                        "additionalProperties": {
+                          "$ref": "#/definitions/Channel"
+                        },
+                        "type": "object"
                       },
                       "endAngle": {
                         "type": "number"
@@ -3539,6 +3573,9 @@
                         "items": {
                           "additionalProperties": false,
                           "properties": {
+                            "_invalidTrack": {
+                              "type": "boolean"
+                            },
                             "_renderingId": {
                               "type": "string"
                             },
@@ -3745,6 +3782,9 @@
                         "$ref": "#/definitions/Style"
                       },
                       "subtitle": {
+                        "type": "string"
+                      },
+                      "template": {
                         "type": "string"
                       },
                       "text": {
@@ -3961,6 +4001,9 @@
     "SingleTrack": {
       "additionalProperties": false,
       "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
         "_renderingId": {
           "type": "string"
         },
@@ -4205,6 +4248,9 @@
     "StackedTracks": {
       "additionalProperties": false,
       "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
         "_renderingId": {
           "type": "string"
         },
@@ -4333,6 +4379,9 @@
               {
                 "additionalProperties": false,
                 "properties": {
+                  "_invalidTrack": {
+                    "type": "boolean"
+                  },
                   "_renderingId": {
                     "type": "string"
                   },
@@ -4360,6 +4409,12 @@
                   },
                   "displacement": {
                     "$ref": "#/definitions/Displacement"
+                  },
+                  "encoding": {
+                    "additionalProperties": {
+                      "$ref": "#/definitions/Channel"
+                    },
+                    "type": "object"
                   },
                   "endAngle": {
                     "type": "number"
@@ -4398,6 +4453,9 @@
                     "items": {
                       "additionalProperties": false,
                       "properties": {
+                        "_invalidTrack": {
+                          "type": "boolean"
+                        },
                         "_renderingId": {
                           "type": "string"
                         },
@@ -4604,6 +4662,9 @@
                     "$ref": "#/definitions/Style"
                   },
                   "subtitle": {
+                    "type": "string"
+                  },
+                  "template": {
                     "type": "string"
                   },
                   "text": {
@@ -4925,6 +4986,123 @@
       },
       "type": "object"
     },
+    "TemplateTrack": {
+      "additionalProperties": false,
+      "description": "Template specification that will be internally converted into `SingleTrack` for rendering",
+      "properties": {
+        "_invalidTrack": {
+          "type": "boolean"
+        },
+        "_renderingId": {
+          "type": "string"
+        },
+        "assembly": {
+          "$ref": "#/definitions/Assembly"
+        },
+        "centerRadius": {
+          "description": "Proportion of the radius of the center white space.",
+          "type": "number"
+        },
+        "data": {
+          "$ref": "#/definitions/DataDeep"
+        },
+        "encoding": {
+          "additionalProperties": {
+            "$ref": "#/definitions/Channel"
+          },
+          "type": "object"
+        },
+        "endAngle": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        },
+        "id": {
+          "type": "string"
+        },
+        "innerRadius": {
+          "type": "number"
+        },
+        "layout": {
+          "$ref": "#/definitions/Layout"
+        },
+        "linkingId": {
+          "type": "string"
+        },
+        "orientation": {
+          "$ref": "#/definitions/Orientation"
+        },
+        "outerRadius": {
+          "type": "number"
+        },
+        "overlayOnPreviousTrack": {
+          "type": "boolean"
+        },
+        "prerelease": {
+          "additionalProperties": false,
+          "properties": {
+            "testUsingNewRectRenderingForBAM": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "spacing": {
+          "type": "number"
+        },
+        "startAngle": {
+          "type": "number"
+        },
+        "static": {
+          "type": "boolean"
+        },
+        "style": {
+          "$ref": "#/definitions/Style"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "template": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "width": {
+          "type": "number"
+        },
+        "xAxis": {
+          "$ref": "#/definitions/AxisPosition"
+        },
+        "xDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "data",
+        "height",
+        "template",
+        "width"
+      ],
+      "type": "object"
+    },
     "Tooltip": {
       "additionalProperties": false,
       "properties": {
@@ -4957,6 +5135,9 @@
         },
         {
           "$ref": "#/definitions/DataTrack"
+        },
+        {
+          "$ref": "#/definitions/TemplateTrack"
         }
       ]
     },

--- a/schema/history/0.8.12/gosling0.8.12.schema.ts
+++ b/schema/history/0.8.12/gosling0.8.12.schema.ts
@@ -565,7 +565,7 @@ export interface TemplateTrack extends CommonRequiredTrackDef, CommonTrackDef {
  */
 export interface TemplateTrackDef {
     name: string;
-    customChannels: CustomChannelDef[];
+    channels: CustomChannelDef[];
     mapping: TemplateTrackMappingDef[];
 }
 
@@ -573,10 +573,13 @@ export interface TemplateTrackDef {
  * Definition of custom channels used in a track template.
  */
 export interface CustomChannelDef {
-    channel: string;
+    name: string;
     type: FieldType | 'value';
     required?: boolean;
 }
+
+// TODO: LogTransform already has `base`
+export type DataTransformWithBase = Partial<DataTransform> & { base?: string };
 
 /**
  * This is based on `SingleTrack` but the differeces are only the type of channels
@@ -588,7 +591,7 @@ export type TemplateTrackMappingDef = Omit<
     'data' | 'height' | 'width' | 'layout' | 'title' | 'subtitle'
 > & {
     // Data transformation
-    dataTransform?: DataTransform[];
+    dataTransform?: DataTransformWithBase[];
 
     tooltip?: Tooltip[];
 

--- a/schema/history/0.8.12/gosling0.8.12.schema.ts
+++ b/schema/history/0.8.12/gosling0.8.12.schema.ts
@@ -52,6 +52,10 @@ export interface CommonViewDef {
     spacing?: number;
     static?: boolean;
 
+    // offsets
+    xOffset?: number;
+    yOffset?: number;
+
     assembly?: Assembly;
 
     // TODO: Change to domain?

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -1,17 +1,22 @@
-import { GoslingSpec } from './gosling.schema';
+import { GoslingSpec, TemplateTrackDef } from './gosling.schema';
 import { compileLayout } from './layout/layout';
 import { HiGlassSpec } from './higlass.schema';
-import { traverseToFixSpecDownstream, overrideTemplates } from './utils/spec-preprocess';
+import { traverseToFixSpecDownstream, overrideDataTemplates } from './utils/spec-preprocess';
+import { replaceTrackTemplates } from './utils/template';
 import { Size } from './utils/bounding-box';
 import { CompleteThemeDeep } from './utils/theme';
 
 export function compile(
     spec: GoslingSpec,
     setHg: (hg: HiGlassSpec, size: Size) => void,
+    templates: TemplateTrackDef[],
     theme: Required<CompleteThemeDeep>
 ) {
     // Override default visual encoding (i.e., `DataTrack` => `BasicSingleTrack`)
-    overrideTemplates(spec);
+    overrideDataTemplates(spec);
+
+    // Replace track templates with raw gosling specs (i.e., `TemplateTrack` => `SingleTrack | OverlaidTrack`)
+    replaceTrackTemplates(spec, templates);
 
     // Fix track specs by looking into the root-level spec
     traverseToFixSpecDownstream(spec);

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -11,6 +11,7 @@ import { GET_CHROM_SIZES } from './utils/assembly';
 import { CompleteThemeDeep, getTheme, Theme } from './utils/theme';
 import { CommonEventData, EVENT_TYPE, MouseHoverCallback, UserDefinedEvents } from './api';
 import uuid from 'uuid';
+import { TemplateDef } from './gosling.schema'
 
 /**
  * Register plugin tracks and data fetchers to HiGlass. This is necessary for the first time before using Gosling.
@@ -26,6 +27,7 @@ interface GoslingCompProps {
     id?: string;
     className?: string;
     theme?: Theme;
+    templates?: TemplateDef[]; // TODO:
 }
 
 // TODO: specify types other than "any"

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -256,7 +256,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                             ref={hgRef}
                             options={{
                                 bounded: true,
-                                pixelPreciseMarginPadding: false,
+                                pixelPreciseMarginPadding: true, // this uses `rowHeight: 1` in react-grid-layout
                                 containerPaddingX: 0,
                                 containerPaddingY: 0,
                                 viewMarginTop: 0,

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -11,7 +11,8 @@ import { GET_CHROM_SIZES } from './utils/assembly';
 import { CompleteThemeDeep, getTheme, Theme } from './utils/theme';
 import { CommonEventData, EVENT_TYPE, MouseHoverCallback, UserDefinedEvents } from './api';
 import uuid from 'uuid';
-import { TemplateDef } from './gosling.schema'
+import { TemplateTrackDef } from './gosling.schema';
+import { GoslingTemplates } from '..';
 
 /**
  * Register plugin tracks and data fetchers to HiGlass. This is necessary for the first time before using Gosling.
@@ -27,7 +28,7 @@ interface GoslingCompProps {
     id?: string;
     className?: string;
     theme?: Theme;
-    templates?: TemplateDef[]; // TODO:
+    templates?: TemplateTrackDef[];
 }
 
 // TODO: specify types other than "any"
@@ -215,6 +216,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     setHs(newHs);
                     setSize(newSize);
                 },
+                [...GoslingTemplates], // TODO: allow user definitions
                 theme
             );
         }

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -194,7 +194,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                 }
             }
         };
-    }, [ref, hgRef, hs]);
+    }, [ref, hgRef, hs, theme]);
 
     useEffect(() => {
         if (gs) {
@@ -218,7 +218,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                 theme
             );
         }
-    }, [gs]);
+    }, [gs, theme]);
 
     const higlassComponent = useMemo(() => {
         return hs && size ? (
@@ -274,7 +274,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                 </div>
             </>
         ) : null;
-    }, [hs, size]);
+    }, [hs, size, theme]);
 
     return higlassComponent;
 });

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -579,6 +579,7 @@ export class GoslingTrackModel {
                                 IsChannelDeep(spec.xe)
                             )
                                 value = undefined;
+                            else if (spec.mark === 'text') value = 12;
                             else value = this.theme.point.size;
                             break;
                         case 'color':
@@ -588,11 +589,14 @@ export class GoslingTrackModel {
                             value = 0;
                             break;
                         case 'stroke':
-                            value = this.theme.markCommon.stroke;
+                            // !! TODO: These should be based on themes
+                            if (spec.mark === 'text') value = this.theme.text.stroke;
+                            else value = this.theme.markCommon.stroke;
                             break;
                         case 'strokeWidth':
                             if (spec.mark === 'rule') value = this.theme.rule.strokeWidth;
                             else if (spec.mark === 'withinLink') value = this.theme.link.strokeWidth;
+                            else if (spec.mark === 'text') value = this.theme.text.strokeWidth;
                             else value = this.theme.markCommon.strokeWidth;
                             break;
                         case 'opacity':

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -32,7 +32,8 @@ import {
     OverlaidTracks,
     StackedTracks,
     BAMData,
-    Range
+    Range,
+    TemplateTrack
 } from './gosling.schema';
 import { SUPPORTED_CHANNELS } from './mark';
 import { isArray } from 'lodash';
@@ -71,7 +72,7 @@ export function IsDataTrack(_: Track): _ is DataTrack {
     return !IsOverlaidTrack(_) && 'data' in _ && !('mark' in _);
 }
 
-export function IsTemplate(_: Partial<Track>): boolean {
+export function IsDataTemplate(_: Partial<Track>): boolean {
     return !!('data' in _ && 'overrideTemplate' in _ && _.overrideTemplate);
 }
 
@@ -117,6 +118,10 @@ export function IsSingleTrack(track: Track): track is SingleTrack {
 
 export function IsOverlaidTrack(track: Partial<Track>): track is OverlaidTrack {
     return 'overlay' in track;
+}
+
+export function IsTemplateTrack(track: Partial<Track>): track is TemplateTrack {
+    return 'template' in track;
 }
 
 /**

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -565,7 +565,7 @@ export interface TemplateTrack extends CommonRequiredTrackDef, CommonTrackDef {
  */
 export interface TemplateTrackDef {
     name: string;
-    customChannels: CustomChannelDef[];
+    channels: CustomChannelDef[];
     mapping: TemplateTrackMappingDef[];
 }
 
@@ -573,10 +573,13 @@ export interface TemplateTrackDef {
  * Definition of custom channels used in a track template.
  */
 export interface CustomChannelDef {
-    channel: string;
+    name: string;
     type: FieldType | 'value';
     required?: boolean;
 }
+
+// TODO: LogTransform already has `base`
+export type DataTransformWithBase = Partial<DataTransform> & { base?: string };
 
 /**
  * This is based on `SingleTrack` but the differeces are only the type of channels
@@ -588,7 +591,7 @@ export type TemplateTrackMappingDef = Omit<
     'data' | 'height' | 'width' | 'layout' | 'title' | 'subtitle'
 > & {
     // Data transformation
-    dataTransform?: DataTransform[];
+    dataTransform?: DataTransformWithBase[];
 
     tooltip?: Tooltip[];
 

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -52,6 +52,10 @@ export interface CommonViewDef {
     spacing?: number;
     static?: boolean;
 
+    // offsets
+    xOffset?: number;
+    yOffset?: number;
+
     assembly?: Assembly;
 
     // TODO: Change to domain?

--- a/src/core/layout/defaults.ts
+++ b/src/core/layout/defaults.ts
@@ -19,7 +19,7 @@ export const DEFAULT_VIEW_SPACING = 10;
 export const DEFAULT_INNER_RADIUS_PROP = 0.3;
 
 // padding around a circular view
-export const DEFAULT_CIRCULAR_VIEW_PADDING = 10;
+export const DEFAULT_CIRCULAR_VIEW_PADDING = 0; // TODO: this is not properly considered in determining the arrangement of views
 
 // default color when cannot parse
 export const DEFAULT_BACKUP_COLOR = 'gray';

--- a/src/core/layout/defaults.ts
+++ b/src/core/layout/defaults.ts
@@ -13,7 +13,7 @@ export const DEFAULT_TRACK_HEIGHT_CIRCULAR = 400;
 export const DEFAULT_TRACK_WIDTH_CIRCULAR = 400;
 
 // gab between views
-export const DEFAULT_VIEW_SPACING = 20;
+export const DEFAULT_VIEW_SPACING = 10;
 
 // empty space inside the visualization for circular layouts
 export const DEFAULT_INNER_RADIUS_PROP = 0.3;

--- a/src/core/layout/higlass.ts
+++ b/src/core/layout/higlass.ts
@@ -20,12 +20,6 @@ export function renderHiGlass(
     // HiGlass model
     const hgModel = new HiGlassModel();
 
-    // !! TODO: Can we remove this by allowing any number values?
-    // if(getBoundingBox(trackInfos).height % 8 !== 0) {
-    //     // We need to ensure that the height is the multiple of `8` (refer to `pixelPreciseMarginPadding`).
-    //     ensureHeightMultiplesOf8(trackInfos);
-    // }
-
     /* Update the HiGlass model by iterating tracks */
     trackInfos.forEach(tb => {
         const { track, boundingBox: bb, layout } = tb;
@@ -74,5 +68,5 @@ export function renderHiGlass(
             });
     });
 
-    setHg(hgModel.spec(), getBoundingBox(trackInfos, true));
+    setHg(hgModel.spec(), getBoundingBox(trackInfos));
 }

--- a/src/core/layout/higlass.ts
+++ b/src/core/layout/higlass.ts
@@ -20,6 +20,12 @@ export function renderHiGlass(
     // HiGlass model
     const hgModel = new HiGlassModel();
 
+    // !! TODO: Can we remove this by allowing any number values?
+    // if(getBoundingBox(trackInfos).height % 8 !== 0) {
+    //     // We need to ensure that the height is the multiple of `8` (refer to `pixelPreciseMarginPadding`).
+    //     ensureHeightMultiplesOf8(trackInfos);
+    // }
+
     /* Update the HiGlass model by iterating tracks */
     trackInfos.forEach(tb => {
         const { track, boundingBox: bb, layout } = tb;
@@ -68,5 +74,5 @@ export function renderHiGlass(
             });
     });
 
-    setHg(hgModel.spec(), getBoundingBox(trackInfos));
+    setHg(hgModel.spec(), getBoundingBox(trackInfos, true));
 }

--- a/src/core/mark/bar.ts
+++ b/src/core/mark/bar.ts
@@ -20,8 +20,7 @@ export function drawBar(trackInfo: any, tile: any, model: GoslingTrackModel) {
     const data = model.data();
 
     /* track size */
-    const trackWidth = spec.width;
-    const trackHeight = spec.height;
+    const [trackWidth, trackHeight] = trackInfo.dimensions;
     const tileSize = trackInfo.tilesetInfo.tile_size;
     const { tileX, tileWidth } = trackInfo.getTilePosAndDimensions(tile.gos.zoomLevel, tile.gos.tilePos, tileSize);
     const zoomLevel =

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -84,10 +84,6 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
             drawArea(HGC, trackInfo, tile, model);
             break;
         case 'rect':
-            if (model.spec().layout !== 'circular' && model.spec().prerelease?.testUsingNewRectRenderingForBAM) {
-                // In this case, we use different method for the rendering.
-                break;
-            }
             drawRect(HGC, trackInfo, tile, model);
             break;
         case 'triangleLeft':
@@ -130,6 +126,13 @@ export function drawPreEmbellishment(
         // We do not draw brush. Instead, higlass do.
         return;
     }
+
+    // This is only to render embellishments only once.
+    // TODO: Instead of rendering and removing for every tiles, render pBorder only once
+    trackInfo.pBackground.clear();
+    trackInfo.pBackground.removeChildren();
+    trackInfo.pBorder.clear();
+    trackInfo.pBorder.removeChildren();
 
     const CIRCULAR = model.spec().layout === 'circular';
 

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -89,7 +89,7 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
         case 'triangleLeft':
         case 'triangleRight':
         case 'triangleBottom':
-            drawTriangle(tile.graphics, model);
+            drawTriangle(tile.graphics, trackInfo, model);
             break;
         case 'text':
             drawText(HGC, trackInfo, tile, model);

--- a/src/core/mark/text.ts
+++ b/src/core/mark/text.ts
@@ -264,7 +264,7 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackMo
                     rowGraphics.addChild(rope);
                 } else {
                     textGraphic.position.x = cx;
-                    textGraphic.position.y = rowPosition + y;
+                    textGraphic.position.y = rowPosition + rowHeight - y;
                     rowGraphics.addChild(textGraphic);
                 }
             });

--- a/src/core/mark/text.ts
+++ b/src/core/mark/text.ts
@@ -40,16 +40,6 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackMo
     const rowCategories = (tm.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
     const rowHeight = trackHeight / rowCategories.length;
 
-    /* text styles */
-    const localTextStyle = {
-        ...TEXT_STYLE_GLOBAL,
-        fontSize: spec.style?.textFontSize ? `${spec.style?.textFontSize}px` : TEXT_STYLE_GLOBAL.fontSize,
-        stroke: spec.style?.textStroke ?? TEXT_STYLE_GLOBAL.stroke,
-        strokeThickness: spec.style?.textStrokeWidth ?? TEXT_STYLE_GLOBAL.strokeThickness,
-        fontWeight: spec.style?.textFontWeight ?? TEXT_STYLE_GLOBAL.fontWeight
-    };
-    const textStyleObj = new HGC.libraries.PIXI.TextStyle(localTextStyle);
-
     /* styles */
     const dx = spec.style?.dx ?? 0;
     const dy = spec.style?.dy ?? 0;
@@ -81,6 +71,9 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackMo
                 const xe = tm.encodedPIXIProperty('xe', d) + dx;
                 const cx = tm.encodedPIXIProperty('x-center', d) + dx;
                 const y = tm.encodedPIXIProperty('y', d) + dy;
+                const size = tm.encodedPIXIProperty('size', d);
+                const stroke = tm.encodedPIXIProperty('stroke', d);
+                const strokeWidth = tm.encodedPIXIProperty('strokeWidth', d);
                 const opacity = tm.encodedPIXIProperty('opacity', d);
 
                 if (cx < 0 || cx > trackWidth) {
@@ -92,6 +85,18 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackMo
                     // prevent from drawing too many text elements for the performance
                     return;
                 }
+
+                /* text styles */
+                const localTextStyle = {
+                    ...TEXT_STYLE_GLOBAL,
+                    fontSize:
+                        size ??
+                        (spec.style?.textFontSize ? `${spec.style?.textFontSize}px` : TEXT_STYLE_GLOBAL.fontSize),
+                    stroke: stroke ?? spec.style?.textStroke ?? TEXT_STYLE_GLOBAL.stroke,
+                    strokeThickness: strokeWidth ?? spec.style?.textStrokeWidth ?? TEXT_STYLE_GLOBAL.strokeThickness,
+                    fontWeight: spec.style?.textFontWeight ?? TEXT_STYLE_GLOBAL.fontWeight
+                };
+                const textStyleObj = new HGC.libraries.PIXI.TextStyle(localTextStyle);
 
                 let textGraphic;
                 if (trackInfo.textGraphics.length > trackInfo.textsBeingUsed) {
@@ -156,6 +161,9 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackMo
                 const color = tm.encodedPIXIProperty('color', d);
                 const cx = tm.encodedPIXIProperty('x-center', d) + dx;
                 const y = tm.encodedPIXIProperty('y', d) + dy;
+                const size = tm.encodedPIXIProperty('size', d);
+                const stroke = tm.encodedPIXIProperty('stroke', d);
+                const strokeWidth = tm.encodedPIXIProperty('strokeWidth', d);
                 const opacity = tm.encodedPIXIProperty('opacity', d);
 
                 if (cx < 0 || cx > trackWidth) {
@@ -167,6 +175,18 @@ export function drawText(HGC: any, trackInfo: any, tile: any, tm: GoslingTrackMo
                     // prevent from drawing too many text elements for the performance
                     return;
                 }
+
+                /* text styles */
+                const localTextStyle = {
+                    ...TEXT_STYLE_GLOBAL,
+                    fontSize:
+                        size ??
+                        (spec.style?.textFontSize ? `${spec.style?.textFontSize}px` : TEXT_STYLE_GLOBAL.fontSize),
+                    stroke: stroke ?? spec.style?.textStroke ?? TEXT_STYLE_GLOBAL.stroke,
+                    strokeThickness: strokeWidth ?? spec.style?.textStrokeWidth ?? TEXT_STYLE_GLOBAL.strokeThickness,
+                    fontWeight: spec.style?.textFontWeight ?? TEXT_STYLE_GLOBAL.fontWeight
+                };
+                const textStyleObj = new HGC.libraries.PIXI.TextStyle(localTextStyle);
 
                 let textGraphic;
                 if (trackInfo.textGraphics.length > trackInfo.textsBeingUsed) {

--- a/src/core/mark/triangle.test.ts
+++ b/src/core/mark/triangle.test.ts
@@ -22,7 +22,7 @@ describe('Rendering triangle', () => {
             { x: 111, xe: 111, y: 222 }
         ];
         const model = new GoslingTrackModel(t, d, getTheme());
-        drawTriangle(g, model);
+        drawTriangle(g, { dimensions: [100, 100] }, model);
     });
 
     it('Circular Triangle', () => {
@@ -42,6 +42,6 @@ describe('Rendering triangle', () => {
             { x: 111, xe: 111, y: 222 }
         ];
         const model = new GoslingTrackModel(t, d, getTheme());
-        drawTriangle(g, model);
+        drawTriangle(g, { dimensions: [100, 100] }, model);
     });
 });

--- a/src/core/mark/triangle.ts
+++ b/src/core/mark/triangle.ts
@@ -5,7 +5,7 @@ import { getValueUsingChannel } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
 import { cartesianToPolar } from '../utils/polar';
 
-export function drawTriangle(g: PIXI.Graphics, model: GoslingTrackModel) {
+export function drawTriangle(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackModel) {
     /* track spec */
     const spec = model.spec();
 
@@ -18,8 +18,7 @@ export function drawTriangle(g: PIXI.Graphics, model: GoslingTrackModel) {
     const data = model.data();
 
     /* track size */
-    const trackWidth = spec.width;
-    const trackHeight = spec.height;
+    const [trackWidth, trackHeight] = trackInfo.dimensions;
     const zoomLevel =
         (model.getChannelScale('x') as any).invert(trackWidth) - (model.getChannelScale('x') as any).invert(0);
 
@@ -53,10 +52,9 @@ export function drawTriangle(g: PIXI.Graphics, model: GoslingTrackModel) {
         ).forEach(d => {
             const x = model.encodedPIXIProperty('x', d);
             const xe = model.encodedPIXIProperty('xe', d);
-            const yValue = getValueUsingChannel(d, spec.y as Channel) as string | number;
             const markWidth = model.encodedPIXIProperty('size', d) ?? (xe === undefined ? triHeight : xe - x);
 
-            const y = model.encodedValue('y', yValue);
+            const y = model.encodedPIXIProperty('y', d);
             const strokeWidth = model.encodedPIXIProperty('strokeWidth', d);
             const stroke = model.encodedPIXIProperty('stroke', d);
             const color = model.encodedPIXIProperty('color', d);
@@ -67,7 +65,7 @@ export function drawTriangle(g: PIXI.Graphics, model: GoslingTrackModel) {
                 let x1 = xe ? xe : x + markWidth;
                 let xm = (x0 + x1) / 2.0;
 
-                const rm = trackOuterRadius - ((rowPosition + y) / trackHeight) * trackRingSize;
+                const rm = trackOuterRadius - ((rowPosition + rowHeight - y) / trackHeight) * trackRingSize;
                 const r0 = rm - triHeight / 2.0;
                 const r1 = rm + triHeight / 2.0;
 
@@ -119,9 +117,9 @@ export function drawTriangle(g: PIXI.Graphics, model: GoslingTrackModel) {
                 let x0 = x ? x : xe - markWidth;
                 let x1 = xe ? xe : x + markWidth;
                 let xm = x0 + (x1 - x0) / 2.0;
-                const ym = rowPosition + y;
-                const y0 = rowPosition + y - triHeight / 2.0;
-                const y1 = rowPosition + y + triHeight / 2.0;
+                const ym = rowPosition + rowHeight - y;
+                const y0 = rowPosition + rowHeight - y - triHeight / 2.0;
+                const y1 = rowPosition + rowHeight - y + triHeight / 2.0;
 
                 if (spec.style?.align === 'right' && !xe) {
                     x0 -= markWidth;

--- a/src/core/utils/bounding-box.test.ts
+++ b/src/core/utils/bounding-box.test.ts
@@ -12,7 +12,7 @@ describe('Arrangement', () => {
 
         expect(info[0].track).toEqual(spec.tracks[0]);
         expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 40, height: 40 });
-        expect(info[0].layout).toEqual({ x: 0, y: 0, w: 12, h: 12 });
+        expect(info[0].layout).toEqual({ x: 0, y: 0, w: 12, h: 40 });
     });
 
     it('1 View, 1 Track (N Overlaid Tracks)', () => {
@@ -67,11 +67,11 @@ describe('Arrangement', () => {
 
         expect(info[0].track).toEqual(spec.tracks[0]);
         expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
-        expect(info[0].layout).toEqual({ x: 0, y: 0, w: 12, h: (10 / 24) * 12 });
+        expect(info[0].layout).toEqual({ x: 0, y: 0, w: 12, h: 10 });
 
         expect(info[1].track).toEqual(spec.tracks[1]);
         expect(info[1].boundingBox).toEqual({ x: 0, y: 10, width: 10, height: 10 });
-        expect(info[1].layout).toEqual({ x: 0, y: 5, w: 12, h: (10 / 24) * 12 });
+        expect(info[1].layout).toEqual({ x: 0, y: 10, w: 12, h: 10 });
     });
 
     it('Palallel Views', () => {
@@ -96,7 +96,7 @@ describe('Arrangement', () => {
         expect(info).toHaveLength(4);
 
         const size = getBoundingBox(info);
-        expect(size).toEqual({ width: 10, height: 40 + DEFAULT_VIEW_SPACING + 4 });
+        expect(size).toEqual({ width: 10, height: 40 + DEFAULT_VIEW_SPACING });
 
         expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
         expect(info[1].boundingBox).toEqual({ x: 0, y: 10, width: 10, height: 10 });
@@ -126,7 +126,7 @@ describe('Arrangement', () => {
         expect(info).toHaveLength(4);
 
         const size = getBoundingBox(info);
-        expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 20 + 4 });
+        expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 20 });
 
         expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
         expect(info[1].boundingBox).toEqual({ x: 0, y: 10, width: 10, height: 10 });
@@ -257,7 +257,7 @@ describe('Arrangement', () => {
             expect(info).toHaveLength(2);
 
             const size = getBoundingBox(info);
-            expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 10 + 6 });
+            expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 10 });
 
             expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
             expect(info[1].boundingBox).toEqual({ x: 10 + DEFAULT_VIEW_SPACING, y: 0, width: 10, height: 10 });
@@ -289,7 +289,7 @@ describe('Arrangement', () => {
             const size = getBoundingBox(info);
             expect(size).toEqual({
                 width: 10 + DEFAULT_CIRCULAR_VIEW_PADDING * 2,
-                height: 10 + DEFAULT_CIRCULAR_VIEW_PADDING * 2 + 2
+                height: 10 + DEFAULT_CIRCULAR_VIEW_PADDING * 2
             });
 
             expect(info[0].boundingBox).toEqual(info[1].boundingBox);

--- a/src/core/utils/bounding-box.test.ts
+++ b/src/core/utils/bounding-box.test.ts
@@ -67,11 +67,11 @@ describe('Arrangement', () => {
 
         expect(info[0].track).toEqual(spec.tracks[0]);
         expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
-        expect(info[0].layout).toEqual({ x: 0, y: 0, w: 12, h: (10 / 24) * 12 }); // 4 is added since Gosling makes it a multiple of 8
+        expect(info[0].layout).toEqual({ x: 0, y: 0, w: 12, h: (10 / 24) * 12 });
 
         expect(info[1].track).toEqual(spec.tracks[1]);
         expect(info[1].boundingBox).toEqual({ x: 0, y: 10, width: 10, height: 10 });
-        expect(info[1].layout).toEqual({ x: 0, y: 5, w: 12, h: (10 / 24) * 12 }); // 4 is added since Gosling makes it a multiple of 8
+        expect(info[1].layout).toEqual({ x: 0, y: 5, w: 12, h: (10 / 24) * 12 });
     });
 
     it('Palallel Views', () => {
@@ -96,7 +96,7 @@ describe('Arrangement', () => {
         expect(info).toHaveLength(4);
 
         const size = getBoundingBox(info);
-        expect(size).toEqual({ width: 10, height: 40 + DEFAULT_VIEW_SPACING + 4 }); // TODO: a few px is added to make it a multiple of 8
+        expect(size).toEqual({ width: 10, height: 40 + DEFAULT_VIEW_SPACING + 4 });
 
         expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
         expect(info[1].boundingBox).toEqual({ x: 0, y: 10, width: 10, height: 10 });
@@ -126,7 +126,7 @@ describe('Arrangement', () => {
         expect(info).toHaveLength(4);
 
         const size = getBoundingBox(info);
-        expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 20 + 4 }); // TODO: a few px is added to make it a multiple of 8
+        expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 20 + 4 });
 
         expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
         expect(info[1].boundingBox).toEqual({ x: 0, y: 10, width: 10, height: 10 });
@@ -257,7 +257,7 @@ describe('Arrangement', () => {
             expect(info).toHaveLength(2);
 
             const size = getBoundingBox(info);
-            expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 10 + 6 }); // TODO: a few px is added to make it a multiple of 8
+            expect(size).toEqual({ width: 20 + DEFAULT_VIEW_SPACING, height: 10 + 6 });
 
             expect(info[0].boundingBox).toEqual({ x: 0, y: 0, width: 10, height: 10 });
             expect(info[1].boundingBox).toEqual({ x: 10 + DEFAULT_VIEW_SPACING, y: 0, width: 10, height: 10 });
@@ -289,7 +289,7 @@ describe('Arrangement', () => {
             const size = getBoundingBox(info);
             expect(size).toEqual({
                 width: 10 + DEFAULT_CIRCULAR_VIEW_PADDING * 2,
-                height: 10 + DEFAULT_CIRCULAR_VIEW_PADDING * 2 + 2 // TODO: a few px is added to make it a multiple of 8
+                height: 10 + DEFAULT_CIRCULAR_VIEW_PADDING * 2 + 2
             });
 
             expect(info[0].boundingBox).toEqual(info[1].boundingBox);

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -52,10 +52,8 @@ export interface TrackInfo {
 /**
  * Return the size of entire visualization.
  * @param trackInfos
- * @param ensureMultiplesOf8 this is to ensure that the height is the multiple of `8` (refer to `pixelPreciseMarginPadding`). This can be used right before rendering visualization using HiGlass.
- * https://github.com/higlass/higlass/blob/54f5aae61d3474f9e868621228270f0c90ef9343/app/scripts/HiGlassComponent.js#L2066
  */
-export function getBoundingBox(trackInfos: TrackInfo[], ensureMultiplesOf8 = false) {
+export function getBoundingBox(trackInfos: TrackInfo[]) {
     let width = 0;
     let height = 0;
 
@@ -70,24 +68,7 @@ export function getBoundingBox(trackInfos: TrackInfo[], ensureMultiplesOf8 = fal
         }
     });
 
-    // !! TODO: allow non-multiples of 8
-    if (ensureMultiplesOf8 && height % 8 !== 0) {
-        height += 8 - (height % 8);
-    }
-
     return { width, height };
-}
-
-export function ensureHeightMultiplesOf8(trackInfos: TrackInfo[]) {
-    const size = getBoundingBox(trackInfos, true);
-
-    // Calculate `layout`s for React Grid Layout (RGL).
-    trackInfos.forEach(_ => {
-        _.layout.x = (_.boundingBox.x / size.width) * 12;
-        _.layout.y = (_.boundingBox.y / size.height) * 12;
-        _.layout.w = (_.boundingBox.width / size.width) * 12;
-        _.layout.h = (_.boundingBox.height / size.height) * 12;
-    });
 }
 
 /**
@@ -137,10 +118,11 @@ export function getRelativeTrackInfo(spec: GoslingSpec, theme: CompleteThemeDeep
 
     // Calculate `layout`s for React Grid Layout (RGL).
     trackInfos.forEach(_ => {
-        _.layout.x = _.boundingBox.x; // / size.width) * 12;
-        _.layout.y = _.boundingBox.y; // / size.height) * 12 * 64;
-        _.layout.w = _.boundingBox.width; // / size.width) * 12;
-        _.layout.h = _.boundingBox.height; // / size.height) * 12 * 64;
+        _.layout.x = (_.boundingBox.x / size.width) * 12;
+        _.layout.w = (_.boundingBox.width / size.width) * 12;
+        // Because we set `pixelPreciseMarginPadding` `true`, we use actual values for `y` and `height`
+        _.layout.y = _.boundingBox.y;
+        _.layout.h = _.boundingBox.height;
     });
 
     // console.log(trackInfos);
@@ -333,7 +315,8 @@ function traverseAndCollectTrackInfo(
         cumHeight = TOTAL_RADIUS * 2;
     }
 
-    // cumHeight = (cumHeight + (8 - cumHeight % 8));
+    // DEBUG
+    // console.log(output);
 
     return { x: dx, y: dy, width: cumWidth, height: cumHeight };
 }

--- a/src/core/utils/spec-preprocess.test.ts
+++ b/src/core/utils/spec-preprocess.test.ts
@@ -1,6 +1,6 @@
 import { GoslingSpec, SingleView, Track } from '../gosling.schema';
 import { getBoundingBox, getRelativeTrackInfo } from './bounding-box';
-import { traverseToFixSpecDownstream, overrideTemplates, convertToFlatTracks } from './spec-preprocess';
+import { traverseToFixSpecDownstream, overrideDataTemplates, convertToFlatTracks } from './spec-preprocess';
 import { getTheme } from './theme';
 
 describe('Fix Spec Downstream', () => {
@@ -263,7 +263,7 @@ describe('Spec Preprocess', () => {
         const spec: GoslingSpec = {
             tracks: [{ data: { type: 'vector', url: '', column: 'c', value: 'v' }, overrideTemplate: true } as Track]
         };
-        overrideTemplates(spec);
+        overrideDataTemplates(spec);
         expect(spec.tracks[0]).toHaveProperty('mark');
     });
 
@@ -277,14 +277,14 @@ describe('Spec Preprocess', () => {
                     } as Track
                 ]
             };
-            overrideTemplates(spec);
+            overrideDataTemplates(spec);
             expect(spec.tracks[0]).toHaveProperty('mark');
         }
         {
             const spec: GoslingSpec = {
                 tracks: [{ data: { type: 'multivec', url: '', row: 'r', column: 'c', value: 'v' } } as Track]
             };
-            overrideTemplates(spec);
+            overrideDataTemplates(spec);
             expect(spec.tracks[0]).not.toHaveProperty('mark'); // overrideTemplate is not set, so do not override templates
         }
     });

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -281,7 +281,12 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
             }
 
             // This means this track is positioned on top of a view
-            if (i === 0 || tracks.slice(0, i).filter(d => !d.overlayOnPreviousTrack).length === 1) {
+            if (
+                i === 0 ||
+                (i !== 0 &&
+                    tracks.slice(0, i).filter(d => !d.overlayOnPreviousTrack).length === 1 &&
+                    track.overlayOnPreviousTrack === true)
+            ) {
                 /**
                  * Add axis to the first track, i.e., the track on the top
                  */

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -278,20 +278,24 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
             if (i === 0) {
                 // There is no track to overlay on
                 track.overlayOnPreviousTrack = false;
+            }
 
+            // This means this track is positioned on top of a view
+            if (i === 0 || tracks.slice(0, i).filter(d => !d.overlayOnPreviousTrack).length === 1) {
                 /**
-                 * Add axis to the first track
+                 * Add axis to the first track, i.e., the track on the top
                  */
                 if ((IsSingleTrack(track) || IsOverlaidTrack(track)) && IsChannelDeep(track.x) && !track.x.axis) {
                     track.x.axis = track.orientation === 'vertical' ? 'left' : 'top';
                 } else if (IsOverlaidTrack(track)) {
-                    let isNone = false; // If there is at least one 'none' axis, should not render axis.
+                    // let isNone = false; // If there is at least one 'none' axis, should not render axis.
                     track.overlay.forEach(o => {
-                        if (!isNone && IsChannelDeep(o.x) && !o.x.axis) {
+                        if (IsChannelDeep(o.x) && !o.x.axis) {
                             o.x.axis = 'top';
-                        } else if (IsChannelDeep(o.x) && o.x.axis === 'none') {
-                            isNone = true;
                         }
+                        //  else if (IsChannelDeep(o.x) && o.x.axis === 'none') {
+                        //     isNone = true;
+                        // }
                     });
                 }
             }

--- a/src/core/utils/template.ts
+++ b/src/core/utils/template.ts
@@ -21,35 +21,19 @@ export const GoslingTemplates: TemplateTrackDef[] = [
         channels: [
             { name: 'startPosition', type: 'genomic', required: true },
             { name: 'endPosition', type: 'genomic', required: true },
-            { name: 'strandColor', type: 'nominal', required: true }, // TODO: how to redefine bound colors?
+            { name: 'strandColor', type: 'nominal', required: true },
+            { name: 'strandRow', type: 'nominal', required: true },
+            { name: 'opacity', type: 'value', required: false },
             { name: 'geneHeight', type: 'value', required: false },
-            { name: 'geneLabel', type: 'nominal', required: true }, // TODO: can this be false and not show if undefined?
+            { name: 'geneLabel', type: 'nominal', required: true },
+            { name: 'geneLabelColor', type: 'nominal', required: true },
+            { name: 'geneLabelFontSize', type: 'value', required: false },
+            { name: 'geneLabelStroke', type: 'value', required: false },
+            { name: 'geneLabelStrokeThickness', type: 'value', required: false },
+            { name: 'geneLabelOpacity', type: 'value', required: false },
             { name: 'type', type: 'nominal', required: true } // either 'gene' or 'exon'
         ],
         mapping: [
-            {
-                dataTransform: [{ type: 'filter', base: 'type', oneOf: ['gene'] }],
-                mark: 'text',
-                text: { base: 'geneLabel', type: 'nominal' }, // TODO: add dy here
-                x: { base: 'startPosition', type: 'genomic' },
-                xe: { base: 'endPosition', type: 'genomic' },
-                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
-                color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
-                opacity: { value: 0.4 },
-                // stroke: { value: 'white' },
-                // strokeWidth: { value: 2 },
-                style: { textStrokeWidth: 2, textStroke: 'white' },
-                // style: { dy: -30 }, // TODO: how to redefine style from the users' side?
-                visibility: [
-                    {
-                        operation: 'less-than',
-                        measure: 'width',
-                        threshold: '|xe-x|',
-                        transitionPadding: 10,
-                        target: 'mark'
-                    }
-                ]
-            },
             {
                 dataTransform: [
                     { type: 'filter', base: 'type', oneOf: ['gene'] },
@@ -58,9 +42,9 @@ export const GoslingTemplates: TemplateTrackDef[] = [
                 mark: 'triangleLeft',
                 x: { base: 'startPosition', type: 'genomic' },
                 size: { base: 'geneHeight', value: 12 },
-                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
+                row: { base: 'strandRow', type: 'nominal', domain: ['+', '-'] },
                 color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
-                opacity: { value: 0.4 },
+                opacity: { base: 'opacity', value: 0.4 },
                 style: { align: 'right' }
             },
             {
@@ -71,9 +55,9 @@ export const GoslingTemplates: TemplateTrackDef[] = [
                 mark: 'triangleRight',
                 x: { base: 'endPosition', type: 'genomic' },
                 size: { base: 'geneHeight', value: 12 },
-                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
+                row: { base: 'strandRow', type: 'nominal', domain: ['+', '-'] },
                 color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
-                opacity: { value: 0.4 },
+                opacity: { base: 'opacity', value: 0.4 },
                 style: { align: 'left' }
             },
             {
@@ -82,9 +66,9 @@ export const GoslingTemplates: TemplateTrackDef[] = [
                 x: { base: 'startPosition', type: 'genomic' },
                 xe: { base: 'endPosition', type: 'genomic' },
                 size: { base: 'geneHeight', value: 12 },
-                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
+                row: { base: 'strandRow', type: 'nominal', domain: ['+', '-'] },
                 color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
-                opacity: { value: 0.4 }
+                opacity: { base: 'opacity', value: 0.4 }
             },
             {
                 dataTransform: [
@@ -94,9 +78,9 @@ export const GoslingTemplates: TemplateTrackDef[] = [
                 mark: 'rect',
                 x: { base: 'startPosition', type: 'genomic' },
                 xe: { base: 'endPosition', type: 'genomic' },
-                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
+                row: { base: 'strandRow', type: 'nominal', domain: ['+', '-'] },
                 color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
-                opacity: { value: 0.4 },
+                opacity: { base: 'opacity', value: 0.4 },
                 size: { value: 3 }
                 // style: {
                 //     linePattern: { type: 'triangleRight', size: 5 }
@@ -110,13 +94,36 @@ export const GoslingTemplates: TemplateTrackDef[] = [
                 mark: 'rect',
                 x: { base: 'startPosition', type: 'genomic' },
                 xe: { base: 'endPosition', type: 'genomic' },
-                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
+                row: { base: 'strandRow', type: 'nominal', domain: ['+', '-'] },
                 color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
-                opacity: { value: 0.4 },
+                opacity: { base: 'opacity', value: 0.4 },
                 size: { value: 3 }
                 // style: {
                 //     linePattern: { type: 'triangleLeft', size: 5 }
                 // }
+            },
+            {
+                dataTransform: [{ type: 'filter', base: 'type', oneOf: ['gene'] }],
+                mark: 'text',
+                text: { base: 'geneLabel', type: 'nominal' }, // TODO: add dy here
+                x: { base: 'startPosition', type: 'genomic' },
+                xe: { base: 'endPosition', type: 'genomic' },
+                row: { base: 'strandRow', type: 'nominal', domain: ['+', '-'] },
+                color: { base: 'geneLabelColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
+                opacity: { base: 'opacity', value: 1 },
+                size: { base: 'geneLabelFontSize', value: 18 },
+                stroke: { base: 'geneLabelStroke', value: 'white' },
+                strokeWidth: { base: 'geneLabelStrokeThickness', value: 2 },
+                // TODO: how to redefine style from the users' side? (e.g., dy: -30)
+                visibility: [
+                    {
+                        operation: 'less-than',
+                        measure: 'width',
+                        threshold: '|xe-x|',
+                        transitionPadding: 10,
+                        target: 'mark'
+                    }
+                ]
             }
         ]
     }
@@ -202,7 +209,7 @@ export function replaceTrackTemplates(spec: GoslingSpec, templates: TemplateTrac
                     .filter(k => k !== 'mark')
                     .forEach(channelKey => {
                         // Iterate all channels
-                        const channelMap = (singleTrackMappingDef as any)[channelKey];
+                        const channelMap = JSON.parse(JSON.stringify((singleTrackMappingDef as any)[channelKey]));
                         if ('base' in channelMap) {
                             delete channelMap.base;
                         }
@@ -213,7 +220,7 @@ export function replaceTrackTemplates(spec: GoslingSpec, templates: TemplateTrac
                     .filter(k => k !== 'mark')
                     .forEach(channelKey => {
                         // Iterate all channels
-                        const channelMap = (singleTrackMappingDef as any)[channelKey];
+                        const channelMap = JSON.parse(JSON.stringify((singleTrackMappingDef as any)[channelKey]));
                         if ('base' in channelMap) {
                             const baseChannelName = channelMap.base;
                             if (baseChannelName in encodingSpec) {

--- a/src/core/utils/template.ts
+++ b/src/core/utils/template.ts
@@ -126,6 +126,94 @@ export const GoslingTemplates: TemplateTrackDef[] = [
                 ]
             }
         ]
+    },
+    {
+        name: 'ideogram',
+        channels: [
+            { name: 'startPosition', type: 'genomic', required: true },
+            { name: 'endPosition', type: 'genomic', required: true },
+            { name: 'chrHeight', type: 'value', required: false }, // https://eweitz.github.io/ideogram/
+            { name: 'name', type: 'nominal', required: true },
+            { name: 'stainBackgroundColor', type: 'nominal', required: true },
+            { name: 'stainLabelColor', type: 'nominal', required: true },
+            { name: 'stainStroke', type: 'value', required: false },
+            { name: 'stainStrokeWidth', type: 'value', required: false }
+        ],
+        mapping: [
+            {
+                mark: 'rect',
+                dataTransform: [{ type: 'filter', base: 'stainBackgroundColor', oneOf: ['acen'], not: true }],
+                color: {
+                    base: 'stainBackgroundColor',
+                    type: 'nominal',
+                    domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
+                    range: ['white', 'lightgray', 'gray', 'gray', 'black', '#7B9CC8', '#DC4542']
+                },
+                size: { base: 'chrHeight', value: 18 },
+                x: { base: 'startPosition', type: 'genomic' },
+                xe: { base: 'endPosition', type: 'genomic' },
+                stroke: { base: 'stainStroke', value: 'gray' },
+                strokeWidth: { base: 'stainStrokeWidth', value: 0.3 }
+            },
+            {
+                mark: 'triangleRight',
+                dataTransform: [
+                    { type: 'filter', base: 'stainBackgroundColor', oneOf: ['acen'] },
+                    { type: 'filter', base: 'name', include: 'q' }
+                ],
+                color: {
+                    base: 'stainBackgroundColor',
+                    type: 'nominal',
+                    domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
+                    range: ['white', 'lightgray', 'gray', 'gray', 'black', '#7B9CC8', '#DC4542']
+                },
+                size: { base: 'chrHeight', value: 18 },
+                x: { base: 'startPosition', type: 'genomic' },
+                xe: { base: 'endPosition', type: 'genomic' },
+                stroke: { base: 'stainStroke', value: 'gray' },
+                strokeWidth: { base: 'stainStrokeWidth', value: 0.3 }
+            },
+            {
+                mark: 'triangleLeft',
+                dataTransform: [
+                    { type: 'filter', base: 'stainBackgroundColor', oneOf: ['acen'] },
+                    { type: 'filter', base: 'name', include: 'p' }
+                ],
+                color: {
+                    base: 'stainBackgroundColor',
+                    type: 'nominal',
+                    domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
+                    range: ['white', 'lightgray', 'gray', 'gray', 'black', '#7B9CC8', '#DC4542']
+                },
+                size: { base: 'chrHeight', value: 18 },
+                x: { base: 'startPosition', type: 'genomic' },
+                xe: { base: 'endPosition', type: 'genomic' },
+                stroke: { base: 'stainStroke', value: 'gray' },
+                strokeWidth: { base: 'stainStrokeWidth', value: 0.3 }
+            },
+            {
+                mark: 'text',
+                dataTransform: [{ type: 'filter', base: 'stainLabelColor', oneOf: ['acen'], not: true }],
+                color: {
+                    base: 'stainLabelColor',
+                    type: 'nominal',
+                    domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar'],
+                    range: ['black', 'black', 'black', 'black', 'white', 'black']
+                },
+                text: { base: 'name', type: 'nominal' },
+                x: { base: 'startPosition', type: 'genomic' },
+                xe: { base: 'endPosition', type: 'genomic' },
+                visibility: [
+                    {
+                        operation: 'less-than',
+                        measure: 'width',
+                        threshold: '|xe-x|',
+                        transitionPadding: 10,
+                        target: 'mark'
+                    }
+                ]
+            }
+        ]
     }
 ];
 
@@ -167,7 +255,12 @@ export function replaceTrackTemplates(spec: GoslingSpec, templates: TemplateTrac
         }
 
         /* conversion */
+        const viewBase = JSON.parse(JSON.stringify(t));
+        if ('encoding' in viewBase) {
+            delete viewBase.encoding;
+        }
         const convertedView: OverlaidTracks = {
+            ...viewBase,
             alignment: 'overlay',
             tracks: [],
             width: t.width ?? 100,

--- a/src/core/utils/template.ts
+++ b/src/core/utils/template.ts
@@ -1,4 +1,14 @@
-import { GoslingSpec, OverlaidTracks, TemplateTrackDef, TemplateTrackMappingDef, Track } from '../gosling.schema';
+import assign from 'lodash/assign';
+import {
+    CustomChannelDef,
+    DataTransform,
+    DataTransformWithBase,
+    GoslingSpec,
+    OverlaidTracks,
+    TemplateTrackDef,
+    TemplateTrackMappingDef,
+    Track
+} from '../gosling.schema';
 import { IsTemplateTrack } from '../gosling.schema.guards';
 import { traverseTracks } from './spec-preprocess';
 
@@ -7,9 +17,108 @@ import { traverseTracks } from './spec-preprocess';
  */
 export const GoslingTemplates: TemplateTrackDef[] = [
     {
-        name: 'empty',
-        customChannels: [],
-        mapping: []
+        name: 'gene',
+        channels: [
+            { name: 'startPosition', type: 'genomic', required: true },
+            { name: 'endPosition', type: 'genomic', required: true },
+            { name: 'strandColor', type: 'nominal', required: true }, // TODO: how to redefine bound colors?
+            { name: 'geneHeight', type: 'value', required: false },
+            { name: 'geneLabel', type: 'nominal', required: true }, // TODO: can this be false and not show if undefined?
+            { name: 'type', type: 'nominal', required: true } // either 'gene' or 'exon'
+        ],
+        mapping: [
+            {
+                dataTransform: [{ type: 'filter', base: 'type', oneOf: ['gene'] }],
+                mark: 'text',
+                text: { base: 'geneLabel', type: 'nominal' }, // TODO: add dy here
+                x: { base: 'startPosition', type: 'genomic' },
+                xe: { base: 'endPosition', type: 'genomic' },
+                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
+                color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
+                opacity: { value: 0.4 },
+                // stroke: { value: 'white' },
+                // strokeWidth: { value: 2 },
+                style: { textStrokeWidth: 2, textStroke: 'white' },
+                // style: { dy: -30 }, // TODO: how to redefine style from the users' side?
+                visibility: [
+                    {
+                        operation: 'less-than',
+                        measure: 'width',
+                        threshold: '|xe-x|',
+                        transitionPadding: 10,
+                        target: 'mark'
+                    }
+                ]
+            },
+            {
+                dataTransform: [
+                    { type: 'filter', base: 'type', oneOf: ['gene'] },
+                    { type: 'filter', base: 'strandColor', oneOf: ['-'] }
+                ],
+                mark: 'triangleLeft',
+                x: { base: 'startPosition', type: 'genomic' },
+                size: { base: 'geneHeight', value: 12 },
+                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
+                color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
+                opacity: { value: 0.4 },
+                style: { align: 'right' }
+            },
+            {
+                dataTransform: [
+                    { type: 'filter', base: 'type', oneOf: ['gene'] },
+                    { type: 'filter', base: 'strandColor', oneOf: ['+'] }
+                ],
+                mark: 'triangleRight',
+                x: { base: 'endPosition', type: 'genomic' },
+                size: { base: 'geneHeight', value: 12 },
+                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
+                color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
+                opacity: { value: 0.4 },
+                style: { align: 'left' }
+            },
+            {
+                dataTransform: [{ type: 'filter', base: 'type', oneOf: ['exon'] }],
+                mark: 'rect',
+                x: { base: 'startPosition', type: 'genomic' },
+                xe: { base: 'endPosition', type: 'genomic' },
+                size: { base: 'geneHeight', value: 12 },
+                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
+                color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
+                opacity: { value: 0.4 }
+            },
+            {
+                dataTransform: [
+                    { type: 'filter', base: 'type', oneOf: ['gene'] },
+                    { type: 'filter', base: 'strandColor', oneOf: ['+'] }
+                ],
+                mark: 'rect',
+                x: { base: 'startPosition', type: 'genomic' },
+                xe: { base: 'endPosition', type: 'genomic' },
+                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
+                color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
+                opacity: { value: 0.4 },
+                size: { value: 3 }
+                // style: {
+                //     linePattern: { type: 'triangleRight', size: 5 }
+                // }
+            },
+            {
+                dataTransform: [
+                    { type: 'filter', base: 'type', oneOf: ['gene'] },
+                    { type: 'filter', base: 'strandColor', oneOf: ['-'] }
+                ],
+                mark: 'rect',
+                x: { base: 'startPosition', type: 'genomic' },
+                xe: { base: 'endPosition', type: 'genomic' },
+                row: { base: 'strandColor', type: 'nominal', domain: ['+', '-'] },
+                color: { base: 'strandColor', type: 'nominal', domain: ['+', '-'], range: ['blue', 'red'] },
+                opacity: { value: 0.4 },
+                size: { value: 3 }
+                // style: {
+                //     linePattern: { type: 'triangleLeft', size: 5 }
+                // }
+            }
+        ]
     }
 ];
 
@@ -29,16 +138,18 @@ export function replaceTrackTemplates(spec: GoslingSpec, templates: TemplateTrac
 
         /* Validation */
         if (!templateDef) {
-            // We do not know about this template, so set a flag and remove it from the spec when compiling.
+            // No idea what this template is, so set a flag and remove it from the spec when compiling.
             t._invalidTrack = true;
+            console.warn(`There is no track template named '${name}'`);
             return;
         }
 
         let isValid = true;
-        templateDef.customChannels.forEach(d => {
-            if (d.required && !(d.channel in t)) {
+        templateDef.channels.forEach((d: CustomChannelDef) => {
+            if (d.required && (!t.encoding || !(d.name in t.encoding))) {
                 // Required channels are not defined
                 isValid = false;
+                console.warn(`A template spec ('${name}') does not contain a required channel, ${d.name}`);
             }
         });
 
@@ -55,10 +166,74 @@ export function replaceTrackTemplates(spec: GoslingSpec, templates: TemplateTrac
             width: t.width ?? 100,
             height: t.height ?? 100
         };
-        templateDef.mapping.forEach((m: TemplateTrackMappingDef) => {
+        templateDef.mapping.forEach((singleTrackMappingDef: TemplateTrackMappingDef) => {
+            // Set required properties
             const convertedTrack: Partial<Track> = {
-                mark: m.mark
+                data: t.data,
+                mark: singleTrackMappingDef.mark
             };
+
+            // Handle data transform
+            const { dataTransform } = singleTrackMappingDef;
+            if (dataTransform) {
+                const newDataTransform: DataTransform[] = [];
+                dataTransform.map((dataTramsformMap: DataTransformWithBase) => {
+                    const baseChannelName = dataTramsformMap.base;
+                    if (
+                        baseChannelName &&
+                        t.encoding &&
+                        baseChannelName in t.encoding &&
+                        'field' in t.encoding[baseChannelName]
+                    ) {
+                        delete dataTramsformMap.base;
+                        (dataTramsformMap as any).field = (t.encoding[baseChannelName] as any).field;
+                        newDataTransform.push(dataTramsformMap as DataTransform);
+                    } else {
+                        // TODO: JUST ADD?
+                    }
+                });
+            }
+
+            // Handle encoding
+            const encodingSpec = t.encoding;
+            if (!encodingSpec) {
+                // This means we do not need to override anything, so use default encodings
+                Object.keys(singleTrackMappingDef)
+                    .filter(k => k !== 'mark')
+                    .forEach(channelKey => {
+                        // Iterate all channels
+                        const channelMap = (singleTrackMappingDef as any)[channelKey];
+                        if ('base' in channelMap) {
+                            delete channelMap.base;
+                        }
+                        convertedTrack[channelKey as keyof TemplateTrackMappingDef] = channelMap;
+                    });
+            } else {
+                Object.keys(singleTrackMappingDef)
+                    .filter(k => k !== 'mark')
+                    .forEach(channelKey => {
+                        // Iterate all channels
+                        const channelMap = (singleTrackMappingDef as any)[channelKey];
+                        if ('base' in channelMap) {
+                            const baseChannelName = channelMap.base;
+                            if (baseChannelName in encodingSpec) {
+                                // This means we need to override a user's spec for this channel
+                                const base = JSON.parse(JSON.stringify(encodingSpec[baseChannelName]));
+                                delete channelMap.base;
+                                const newChannelSpec = assign(channelMap, JSON.parse(JSON.stringify(base)));
+                                convertedTrack[channelKey as keyof TemplateTrackMappingDef] = newChannelSpec;
+                            } else {
+                                // This means a user did not specify a optional custom channel, so just remove a `base` property.
+                                delete channelMap.base;
+                                convertedTrack[channelKey as keyof TemplateTrackMappingDef] = channelMap;
+                            }
+                        } else {
+                            // This means we use encoding that is constant.
+                            convertedTrack[channelKey as keyof TemplateTrackMappingDef] = channelMap;
+                        }
+                    });
+            }
+
             convertedView.tracks.push(convertedTrack);
         });
 

--- a/src/core/utils/template.ts
+++ b/src/core/utils/template.ts
@@ -1,0 +1,70 @@
+import { GoslingSpec, OverlaidTracks, TemplateTrackDef, TemplateTrackMappingDef, Track } from '../gosling.schema';
+import { IsTemplateTrack } from '../gosling.schema.guards';
+import { traverseTracks } from './spec-preprocess';
+
+/**
+ * Track templates officially supported by Gosling.js.
+ */
+export const GoslingTemplates: TemplateTrackDef[] = [
+    {
+        name: 'empty',
+        customChannels: [],
+        mapping: []
+    }
+];
+
+/**
+ * Replace track templetes to low-level gosling specs.
+ * @param spec
+ */
+export function replaceTrackTemplates(spec: GoslingSpec, templates: TemplateTrackDef[]) {
+    traverseTracks(spec, (t, i, ts) => {
+        if (!IsTemplateTrack(t)) {
+            // If this is not a template track, no point to replace templates.
+            return;
+        }
+
+        const { template: name } = t;
+        const templateDef = templates.find(d => d.name === name);
+
+        /* Validation */
+        if (!templateDef) {
+            // We do not know about this template, so set a flag and remove it from the spec when compiling.
+            t._invalidTrack = true;
+            return;
+        }
+
+        let isValid = true;
+        templateDef.customChannels.forEach(d => {
+            if (d.required && !(d.channel in t)) {
+                // Required channels are not defined
+                isValid = false;
+            }
+        });
+
+        if (!isValid) {
+            // The template spec is not valid for given template definition
+            t._invalidTrack = true;
+            return;
+        }
+
+        /* conversion */
+        const convertedView: OverlaidTracks = {
+            alignment: 'overlay',
+            tracks: [],
+            width: t.width ?? 100,
+            height: t.height ?? 100
+        };
+        templateDef.mapping.forEach((m: TemplateTrackMappingDef) => {
+            const convertedTrack: Partial<Track> = {
+                mark: m.mark
+            };
+            convertedView.tracks.push(convertedTrack);
+        });
+
+        ts[i] = convertedView;
+    });
+
+    // DEBUG
+    // console.log('After replaceTrackTemplates()', JSON.parse(JSON.stringify(spec)));
+}

--- a/src/core/utils/template.ts
+++ b/src/core/utils/template.ts
@@ -214,6 +214,51 @@ export const GoslingTemplates: TemplateTrackDef[] = [
                 ]
             }
         ]
+    },
+    {
+        name: 'sequence',
+        channels: [
+            { name: 'startPosition', type: 'genomic', required: true },
+            { name: 'endPosition', type: 'genomic', required: true },
+            { name: 'barLength', type: 'quantitative', required: true },
+            { name: 'baseBackground', type: 'nominal', required: true },
+            { name: 'baseLabelColor', type: 'nominal', required: true },
+            { name: 'baseLabelFontSize', type: 'value', required: false }
+        ],
+        mapping: [
+            {
+                mark: 'bar',
+                // x: { base: 'position', type: 'genomic' },
+                x: { base: 'startPosition', type: 'genomic' },
+                xe: { base: 'endPosition', type: 'genomic' },
+                y: { base: 'barLength', type: 'quantitative', axis: 'none' },
+                color: { base: 'baseBackground', type: 'nominal', domain: ['A', 'T', 'G', 'C'] }
+            },
+            {
+                dataTransform: [{ type: 'filter', base: 'barLength', oneOf: [0], not: true }],
+                mark: 'text',
+                x: { base: 'startPosition', type: 'genomic' },
+                xe: { base: 'endPosition', type: 'genomic' },
+                color: { base: 'baseLabelColor', type: 'nominal', domain: ['A', 'T', 'G', 'C'], range: ['white'] },
+                text: { base: 'baseBackground', type: 'nominal' },
+                size: { base: 'baseLabelFontSize', value: 18 },
+                visibility: [
+                    {
+                        operation: 'less-than',
+                        measure: 'width',
+                        threshold: '|xe-x|',
+                        transitionPadding: 30,
+                        target: 'mark'
+                    },
+                    {
+                        operation: 'LT',
+                        measure: 'zoomLevel',
+                        threshold: 10,
+                        target: 'track'
+                    }
+                ]
+            }
+        ]
     }
 ];
 

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -22,6 +22,8 @@ import * as qs from 'qs';
 import { JSONCrush, JSONUncrush } from '../core/utils/json-crush';
 import './editor.css';
 import { ICONS, ICON_INFO } from './icon';
+// @ts-ignore
+import { Themes } from 'gosling-theme';
 
 const INIT_DEMO_INDEX = examples.findIndex(d => d.forceShow) !== -1 ? examples.findIndex(d => d.forceShow) : 0;
 
@@ -145,6 +147,7 @@ function Editor(props: any) {
     const [refreshData, setRefreshData] = useState<boolean>(false);
 
     const [demo, setDemo] = useState(examples[urlExampleIndex === -1 ? INIT_DEMO_INDEX : urlExampleIndex]);
+    const [theme, setTheme] = useState('light');
     const [hg, setHg] = useState<HiGlassSpec>();
     const [code, setCode] = useState(defaultCode);
     const [goslingSpec, setGoslingSpec] = useState<gosling.GoslingSpec>();
@@ -153,6 +156,7 @@ function Editor(props: any) {
     const [selectedPreviewData, setSelectedPreviewData] = useState<number>(0);
     const [gistTitle, setGistTitle] = useState<string>();
     const [description, setDescription] = useState<string | null>();
+    const [expertMode, setExpertMode] = useState(false);
 
     // This parameter only matter when a markdown description was loaded from a gist but the user wants to hide it
     const [hideDescription, setHideDescription] = useState<boolean>(IS_SMALL_SCREEN || false);
@@ -186,9 +190,6 @@ function Editor(props: any) {
 
     // whether to show "about" information
     const [isShowAbout, setIsShowAbout] = useState(false);
-
-    // Editor theme
-    const [theme] = useState<string>('light'); // not used
 
     // Resizer `div`
     const descResizerRef = useRef<any>();
@@ -314,7 +315,7 @@ function Editor(props: any) {
         previewData.current = [];
         setSelectedPreviewData(0);
         runSpecUpdateVis();
-    }, [code, autoRun]);
+    }, [code, autoRun, theme]);
 
     // Uncommnet below to use HiGlass APIs
     // useEffect(() => {
@@ -436,6 +437,23 @@ function Editor(props: any) {
                         </option>
                     ))}
                 </select>
+                {expertMode ? (
+                    <select
+                        style={{ maxWidth: IS_SMALL_SCREEN ? window.innerWidth - 180 : 'none' }}
+                        onChange={e => {
+                            if (Object.keys(Themes).indexOf(e.target.value) !== -1) {
+                                setTheme(e.target.value);
+                            }
+                        }}
+                        defaultValue={theme}
+                    >
+                        {Object.keys(Themes).map((d: string) => (
+                            <option key={d} value={d}>
+                                {d}
+                            </option>
+                        ))}
+                    </select>
+                ) : null}
                 {demo.underDevelopment ? (
                     <span
                         style={{
@@ -584,6 +602,17 @@ function Editor(props: any) {
                             URL
                         </span>
                         <span
+                            title="Expert mode that turns on additional features, such as theme selection"
+                            className="side-panel-button"
+                            onClick={() => setExpertMode(!expertMode)}
+                        >
+                            {expertMode ? getIconSVG(ICONS.TOGGLE_ON, 23, 23, '#E18343') : getIconSVG(ICONS.TOGGLE_OFF)}
+                            <br />
+                            EXPERT
+                            <br />
+                            MODE
+                        </span>
+                        <span
                             title="Open GitHub repository"
                             className="side-panel-button"
                             onClick={() => window.open('https://github.com/gosling-lang/gosling.js', '_blank')}
@@ -673,7 +702,7 @@ function Editor(props: any) {
                                     <gosling.GoslingComponent
                                         ref={gosRef}
                                         spec={goslingSpec}
-                                        theme={'light'}
+                                        theme={theme}
                                         padding={60}
                                         margin={0}
                                         border={'none'}

--- a/src/editor/example/cancer-variant.ts
+++ b/src/editor/example/cancer-variant.ts
@@ -1,20 +1,25 @@
 import { GoslingSpec } from '../..';
+import { EX_SPEC_VIEW_PILEUP } from './pileup';
 
 export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
     title: 'Breast Cancer Variant (Staaf et al. 2019)',
     subtitle: 'Genetic characteristics of RAD51C- and PALB2-altered TNBCs',
-    // theme: { base: 'light', legend: { backgroundOpacity: 0, backgroundStroke: 'white' } },
     layout: 'linear',
     arrangement: 'vertical',
     centerRadius: 0.5,
     assembly: 'hg19',
     spacing: 40,
-    style: { outlineWidth: 1, outline: 'lightgray', enableSmoothPath: true },
+    style: {
+        outlineWidth: 1,
+        outline: 'lightgray',
+        enableSmoothPath: false
+    },
     views: [
         {
-            arrangement: 'horizontal',
+            arrangement: 'vertical',
             views: [
                 {
+                    xOffset: 400,
                     layout: 'circular',
                     spacing: 1,
                     tracks: [
@@ -62,18 +67,16 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                 genomicFields: ['ChrStart', 'ChrEnd']
                             },
                             dataTransform: [{ type: 'filter', field: 'Sample', oneOf: ['PD35930a'] }],
-                            tracks: [
-                                { mark: 'text' },
-                                {
-                                    mark: 'triangleBottom',
-                                    size: { value: 5 }
-                                }
-                            ],
+                            tracks: [{ mark: 'text' }, { mark: 'triangleBottom', size: { value: 5 } }],
                             x: { field: 'ChrStart', type: 'genomic' },
                             xe: { field: 'ChrEnd', type: 'genomic' },
                             text: { field: 'Gene', type: 'nominal' },
                             color: { value: 'black' },
-                            style: { textFontWeight: 'normal', dx: -10, outlineWidth: 0 },
+                            style: {
+                                textFontWeight: 'normal',
+                                dx: -10,
+                                outlineWidth: 0
+                            },
                             width: 500,
                             height: 40
                         },
@@ -110,8 +113,6 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
                             color: { value: '#FB6A4B' },
-                            // stroke: { value: '#444444' },
-                            // strokeWidth: { value: 0.6 },
                             width: 620,
                             height: 40
                         },
@@ -152,8 +153,6 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
                             color: { value: '#73C475' },
-                            // stroke: { value: 'black' },
-                            // strokeWidth: { value: 0.6 },
                             width: 500,
                             height: 40
                         },
@@ -202,6 +201,11 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                     layout: 'linear',
                     tracks: [
                         {
+                            style: {
+                                background: '#D7EBFF',
+                                outline: '#8DC1F2',
+                                outlineWidth: 5
+                            },
                             title: 'Ideogram',
                             alignment: 'overlay',
                             data: {
@@ -214,7 +218,14 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             tracks: [
                                 {
                                     mark: 'rect',
-                                    dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }]
+                                    dataTransform: [
+                                        {
+                                            type: 'filter',
+                                            field: 'Stain',
+                                            oneOf: ['acen'],
+                                            not: true
+                                        }
+                                    ]
                                 },
                                 {
                                     mark: 'triangleRight',
@@ -232,7 +243,14 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                 },
                                 {
                                     mark: 'text',
-                                    dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }],
+                                    dataTransform: [
+                                        {
+                                            type: 'filter',
+                                            field: 'Stain',
+                                            oneOf: ['acen'],
+                                            not: true
+                                        }
+                                    ],
                                     color: {
                                         field: 'Stain',
                                         type: 'nominal',
@@ -328,7 +346,11 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                     mark: 'triangleLeft',
                                     x: { field: 'start', type: 'genomic' },
                                     size: { value: 15 },
-                                    style: { align: 'right', outline: 'black', outlineWidth: 0 }
+                                    style: {
+                                        align: 'right',
+                                        outline: 'black',
+                                        outlineWidth: 0
+                                    }
                                 },
                                 {
                                     dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
@@ -382,12 +404,16 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                     opacity: { value: 0.3 }
                                 }
                             ],
-                            row: { field: 'strand', type: 'nominal', domain: ['+', '-'] },
+                            row: {
+                                field: 'strand',
+                                type: 'nominal',
+                                domain: ['+', '-']
+                            },
                             color: {
                                 field: 'strand',
                                 type: 'nominal',
                                 domain: ['+', '-'],
-                                range: ['blue', 'red']
+                                range: ['#97A8B2', '#D4C6BA'] //['blue', 'red']
                             },
                             visibility: [
                                 {
@@ -398,7 +424,7 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                     target: 'mark'
                                 }
                             ],
-                            opacity: { value: 0.4 },
+                            // opacity: { value: 0.4 },
                             width: 400,
                             height: 100
                         },
@@ -426,8 +452,6 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
                             color: { value: '#FB6A4B' },
-                            // stroke: { value: '#444444' },
-                            // strokeWidth: { value: 0.6 },
                             width: 620,
                             height: 20
                         },
@@ -461,8 +485,6 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
                             color: { value: '#73C475' },
-                            // stroke: { value: 'black' },
-                            // strokeWidth: { value: 0.6 },
                             width: 500,
                             height: 20
                         },
@@ -517,389 +539,25 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             opacity: { value: 0.6 },
                             size: { value: 4 },
                             style: { legendTitle: 'SV Class', bazierLink: true },
-                            width: 800,
-                            height: 400
+                            width: 1000,
+                            height: 200
                         }
                     ]
                 }
-                // {
-                //     linkingId: 'mid-scale',
-                //     xDomain: { chromosome: '1' },
-                //     xAxis: 'bottom',
-                //     layout: 'linear',
-                //     spacing: 0,
-                //     tracks: [
-                //         {
-                //             title: 'Genomic Feature',
-                //             alignment: 'overlay',
-                //             data: {
-                //                 url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/rearrangement.PD35930a.csv',
-                //                 type: 'csv',
-                //                 genomicFieldsToConvert: [
-                //                     {
-                //                         chromosomeField: 'chr1',
-                //                         genomicFields: ['start1', 'end1']
-                //                     },
-                //                     {
-                //                         chromosomeField: 'chr2',
-                //                         genomicFields: ['start2', 'end2']
-                //                     }
-                //                 ]
-                //             },
-                //             tracks: [
-                //                 { mark: 'withinLink' },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-1' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-2' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 }
-                //             ],
-                //             x: { field: 'start1', type: 'genomic' },
-                //             xe: { field: 'end2', type: 'genomic' },
-                //             color: {
-                //                 field: 'svclass',
-                //                 type: 'nominal',
-                //                 legend: true,
-                //                 domain: ['translocation', 'delection', 'tandem-duplication', 'inversion']
-                //             },
-                //             stroke: {
-                //                 field: 'svclass',
-                //                 type: 'nominal',
-                //                 domain: ['translocation', 'delection', 'tandem-duplication', 'inversion']
-                //             },
-                //             style: {
-                //                 outline: 'lightgray',
-                //                 inlineLegend: true,
-                //                 bazierLink: true
-                //             },
-                //             strokeWidth: { value: 2.5 },
-                //             opacity: { value: 0.3 },
-                //             width: 400,
-                //             height: 250
-                //         },
-                //         {
-                //             title: 'LOH',
-                //             alignment: 'overlay',
-                //             data: {
-                //                 url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
-                //                 headerNames: [
-                //                     'id',
-                //                     'chr',
-                //                     'start',
-                //                     'end',
-                //                     'total_cn_normal',
-                //                     'minor_cp_normal',
-                //                     'total_cn_tumor',
-                //                     'minor_cn_tumor'
-                //                 ],
-                //                 type: 'csv',
-                //                 chromosomeField: 'chr',
-                //                 genomicFields: ['start', 'end']
-                //             },
-                //             dataTransform: [{ type: 'filter', field: 'minor_cn_tumor', oneOf: ['0'] }],
-                //             tracks: [
-                //                 { mark: 'rect' },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-1' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-2' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 }
-                //             ],
-                //             x: { field: 'start', type: 'genomic' },
-                //             xe: { field: 'end', type: 'genomic' },
-                //             color: { value: '#FD7E85' },
-                //             stroke: { value: 'lightgray' },
-                //             strokeWidth: { value: 0.3 },
-                //             style: { outline: 'lightgray' },
-                //             width: 620,
-                //             height: 20
-                //         },
-                //         {
-                //             title: 'Gain',
-                //             alignment: 'overlay',
-                //             data: {
-                //                 url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
-                //                 headerNames: [
-                //                     'id',
-                //                     'chr',
-                //                     'start',
-                //                     'end',
-                //                     'total_cn_normal',
-                //                     'minor_cp_normal',
-                //                     'total_cn_tumor',
-                //                     'minor_cn_tumor'
-                //                 ],
-                //                 type: 'csv',
-                //                 chromosomeField: 'chr',
-                //                 genomicFields: ['start', 'end']
-                //             },
-                //             dataTransform: [
-                //                 {
-                //                     type: 'filter',
-                //                     field: 'total_cn_tumor',
-                //                     inRange: [4.5, 900]
-                //                 }
-                //             ],
-                //             tracks: [
-                //                 { mark: 'rect' },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-1' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-2' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 }
-                //             ],
-                //             x: { field: 'start', type: 'genomic' },
-                //             xe: { field: 'end', type: 'genomic' },
-                //             color: { value: '#DFFBBF' },
-                //             stroke: { value: 'lightgray' },
-                //             strokeWidth: { value: 0.3 },
-                //             style: { outline: 'lightgray' },
-                //             width: 500,
-                //             height: 20
-                //         },
-                //         {
-                //             alignment: 'overlay',
-                //             title: 'hg38 | Genes',
-                //             data: {
-                //                 url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
-                //                 type: 'beddb',
-                //                 genomicFields: [
-                //                     { index: 1, name: 'start' },
-                //                     { index: 2, name: 'end' }
-                //                 ],
-                //                 valueFields: [
-                //                     { index: 5, name: 'strand', type: 'nominal' },
-                //                     { index: 3, name: 'name', type: 'nominal' }
-                //                 ],
-                //                 exonIntervalFields: [
-                //                     { index: 12, name: 'start' },
-                //                     { index: 13, name: 'end' }
-                //                 ]
-                //             },
-                //             tracks: [
-                //                 {
-                //                     dataTransform: [
-                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
-                //                         { type: 'filter', field: 'strand', oneOf: ['+'] }
-                //                     ],
-                //                     mark: 'triangleRight',
-                //                     x: { field: 'end', type: 'genomic' },
-                //                     size: { value: 15 }
-                //                 },
-                //                 {
-                //                     dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
-                //                     mark: 'text',
-                //                     text: { field: 'name', type: 'nominal' },
-                //                     x: { field: 'start', type: 'genomic' },
-                //                     xe: { field: 'end', type: 'genomic' },
-                //                     style: { dy: -15, outline: 'black', outlineWidth: 0 }
-                //                 },
-                //                 {
-                //                     dataTransform: [
-                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
-                //                         { type: 'filter', field: 'strand', oneOf: ['-'] }
-                //                     ],
-                //                     mark: 'triangleLeft',
-                //                     x: { field: 'start', type: 'genomic' },
-                //                     size: { value: 15 },
-                //                     style: { align: 'right', outline: 'black', outlineWidth: 0 }
-                //                 },
-                //                 {
-                //                     dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
-                //                     mark: 'rect',
-                //                     x: { field: 'start', type: 'genomic' },
-                //                     size: { value: 15 },
-                //                     xe: { field: 'end', type: 'genomic' }
-                //                 },
-                //                 {
-                //                     dataTransform: [
-                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
-                //                         { type: 'filter', field: 'strand', oneOf: ['+'] }
-                //                     ],
-                //                     mark: 'rule',
-                //                     x: { field: 'start', type: 'genomic' },
-                //                     strokeWidth: { value: 2 },
-                //                     xe: { field: 'end', type: 'genomic' },
-                //                     style: {
-                //                         linePattern: { type: 'triangleRight', size: 3.5 },
-                //                         outline: 'black',
-                //                         outlineWidth: 0
-                //                     }
-                //                 },
-                //                 {
-                //                     dataTransform: [
-                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
-                //                         { type: 'filter', field: 'strand', oneOf: ['-'] }
-                //                     ],
-                //                     mark: 'rule',
-                //                     x: { field: 'start', type: 'genomic' },
-                //                     strokeWidth: { value: 2 },
-                //                     xe: { field: 'end', type: 'genomic' },
-                //                     style: {
-                //                         linePattern: { type: 'triangleLeft', size: 3.5 },
-                //                         outline: 'black',
-                //                         outlineWidth: 0
-                //                     }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-1' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' },
-                //                     opacity: { value: 0.3 }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-2' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' },
-                //                     opacity: { value: 0.3 }
-                //                 }
-                //             ],
-                //             row: { field: 'strand', type: 'nominal', domain: ['+', '-'] },
-                //             color: {
-                //                 field: 'strand',
-                //                 type: 'nominal',
-                //                 domain: ['+', '-'],
-                //                 range: ['gray', 'gray']
-                //             },
-                //             visibility: [
-                //                 {
-                //                     operation: 'less-than',
-                //                     measure: 'width',
-                //                     threshold: '|xe-x|',
-                //                     transitionPadding: 10,
-                //                     target: 'mark'
-                //                 }
-                //             ],
-                //             opacity: { value: 0.8 },
-                //             style: { background: '#F5F5F5', outline: 'lightgray' },
-                //             width: 400,
-                //             height: 100
-                //         },
-                //         {
-                //             alignment: 'overlay',
-                //             data: {
-                //                 url:
-                //                     'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
-                //                 type: 'csv',
-                //                 chromosomeField: 'Chromosome',
-                //                 genomicFields: ['chromStart', 'chromEnd']
-                //             },
-                //             tracks: [
-                //                 { mark: 'rect' },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-1' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-2' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 }
-                //             ],
-                //             color: {
-                //                 field: 'Stain',
-                //                 type: 'nominal',
-                //                 domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
-                //                 range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
-                //             },
-                //             x: { field: 'chromStart', type: 'genomic', axis: 'bottom' },
-                //             xe: { field: 'chromEnd', type: 'genomic' },
-                //             opacity: { value: 0.3 },
-                //             width: 1000,
-                //             height: 20
-                //         }
-                //     ]
-                // }
+            ]
+        },
+        {
+            arrangement: 'horizontal',
+            spacing: 100,
+            views: [
+                {
+                    ...EX_SPEC_VIEW_PILEUP(450, 310, { chromosome: '1', interval: [205000, 207000] })
+                },
+                {
+                    ...EX_SPEC_VIEW_PILEUP(450, 310, { chromosome: '1', interval: [490000, 496000] })
+                }
             ]
         }
-        // {
-        //     arrangement: 'horizontal',
-        //     spacing: 90,
-        //     views: [
-        //         {
-        //             xDomain: { chromosome: '1', interval: [100000000, 110000000] },
-        //             linkingId: 'detail-1',
-        //             tracks: [
-        //                 {
-        //                     title: 'Reads Detail View 1 (To Be Added)',
-        //                     data: {
-        //                         url:
-        //                             'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
-        //                         type: 'csv',
-        //                         chromosomeField: 'Chromosome',
-        //                         genomicFields: ['chromStart', 'chromEnd']
-        //                     },
-        //                     mark: 'rect',
-        //                     color: {
-        //                         field: 'Stain',
-        //                         type: 'nominal',
-        //                         domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
-        //                         range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
-        //                     },
-        //                     x: { field: 'chromStart', type: 'genomic' },
-        //                     xe: { field: 'chromEnd', type: 'genomic' },
-        //                     opacity: { value: 0.3 },
-        //                     width: 452,
-        //                     height: 100
-        //                 }
-        //             ]
-        //         },
-        //         {
-        //             linkingId: 'detail-2',
-        //             xDomain: { chromosome: '1', interval: [240000000, 250000000] },
-        //             tracks: [
-        //                 {
-        //                     title: 'Reads Detail View 2 (To Be Added)',
-        //                     data: {
-        //                         url:
-        //                             'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
-        //                         type: 'csv',
-        //                         chromosomeField: 'Chromosome',
-        //                         genomicFields: ['chromStart', 'chromEnd']
-        //                     },
-        //                     mark: 'rect',
-        //                     color: {
-        //                         field: 'Stain',
-        //                         type: 'nominal',
-        //                         domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
-        //                         range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
-        //                     },
-        //                     x: { field: 'chromStart', type: 'genomic' },
-        //                     xe: { field: 'chromEnd', type: 'genomic' },
-        //                     opacity: { value: 0.3 },
-        //                     width: 452,
-        //                     height: 100
-        //                 }
-        //             ]
-        //         }
-        //     ]
-        // }
     ]
 };
 

--- a/src/editor/example/circos.ts
+++ b/src/editor/example/circos.ts
@@ -1,5 +1,31 @@
 import { GoslingSpec } from '../../';
 
+export const EX_SPEC_CIRCULR_RANGE: GoslingSpec = {
+    // title: 'Circos',
+    // description: 'http://circos.ca/intro/genomic_data/',
+    layout: 'circular',
+    static: true,
+    spacing: 1,
+    centerRadius: 0.3,
+    alignment: 'stack',
+    tracks: [
+        {
+            data: {
+                type: 'vector',
+                url: 'https://resgen.io/api/v1/tileset_info/?d=VLFaiSVjTjW6mkbjRjWREA',
+                column: 'position',
+                value: 'peak'
+            },
+            mark: 'bar',
+            x: { field: 'position', type: 'genomic', axis: 'top' },
+            y: { field: 'peak', type: 'quantitative' },
+            color: { value: '#EEEDA1' },
+            width: 700,
+            height: 60
+        }
+    ]
+};
+
 export const EX_SPEC_CIRCOS: GoslingSpec = {
     title: 'Circos',
     description: 'http://circos.ca/intro/genomic_data/',

--- a/src/editor/example/corces.ts
+++ b/src/editor/example/corces.ts
@@ -199,6 +199,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                                 field: 'start',
                                 type: 'genomic'
                             },
+                            size: { value: 8 },
                             xe: { field: 'end', type: 'genomic' },
                             style: { textFontSize: 8, dy: -12 }
                         },
@@ -211,6 +212,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                             text: { field: 'name', type: 'nominal' },
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
+                            size: { value: 8 },
                             style: { textFontSize: 8, dy: 10 }
                         },
                         {
@@ -435,7 +437,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                 //     },
                 //     text: { field: 'base', type: 'nominal' },
                 //     stretch: true,
-                //     style: { outline: '#20102F', textStrokeWidth: 0 }
+                //     style: { outline: '#20102F' }
                 // }
             ]
         }

--- a/src/editor/example/debug.ts
+++ b/src/editor/example/debug.ts
@@ -1,90 +1,77 @@
-import { Range, Domain, GoslingSpec } from '../../core/gosling.schema';
+import { GoslingSpec } from '../../core/gosling.schema';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
-const colorDomain: Domain = [
-    'Metabolic',
-    'Protein',
-    'Kidney-related',
-    'Electrolyte',
-    'Liver-related',
-    'Other biochemical',
-    'Hematological',
-    'Blood pressure',
-    'Echocardiographic'
-];
-
-const colorRange: Range = [
-    '#E4812E',
-    '#8C60B6',
-    '#80594E',
-    '#6BBCCC',
-    '#BA2E2C',
-    '#7F7F7F',
-    '#5BA245',
-    '#F3DE67',
-    '#CE72BB'
-];
-
 export const EX_SPEC_DEBUG: GoslingSpec = {
-    title: 'Chart Templates',
-    subtitle: 'Using chart templates in Gosling.js helps you more easily create visualizations!',
+    title: 'Track Template In Gosling.js',
+    subtitle: 'Gosling.js enables track templates! This allows to create complex visualization more easily.',
     spacing: 0,
-    xDomain: { chromosome: '3', interval: [52168000, 52890000] },
-    tracks: [
+    // layout: 'circular', // TODO: support this!
+    views: [
         {
-            template: 'gene',
-            data: {
-                url: GOSLING_PUBLIC_DATA.geneAnnotation,
-                type: 'beddb',
-                genomicFields: [
-                    { index: 1, name: 'start' },
-                    { index: 2, name: 'end' }
-                ],
-                valueFields: [
-                    { index: 5, name: 'strand', type: 'nominal' },
-                    { index: 3, name: 'name', type: 'nominal' }
-                ],
-                exonIntervalFields: [
-                    { index: 12, name: 'start' },
-                    { index: 13, name: 'end' }
-                ]
-            },
-            encoding: {
-                startPosition: { field: 'start' },
-                endPosition: { field: 'end' },
-                strandColor: { field: 'strand', range: ['gray'] },
-                strandRow: { field: 'strand' },
-                opacity: { value: 0.4 },
-                geneHeight: { value: 30 },
-                geneLabel: { field: 'name' },
-                geneLabelFontSize: { value: 30 },
-                geneLabelColor: { field: 'strand', range: ['gray'] },
-                geneLabelStroke: { value: 'white' },
-                geneLabelStrokeThickness: { value: 4 },
-                geneLabelOpacity: { value: 1 },
-                type: { field: 'type' }
-            },
-            width: 800,
-            height: 300
+            xDomain: { chromosome: '3', interval: [52168000, 52890000] },
+            tracks: [
+                {
+                    template: 'gene',
+                    data: {
+                        url: GOSLING_PUBLIC_DATA.geneAnnotation,
+                        type: 'beddb',
+                        genomicFields: [
+                            { index: 1, name: 'start' },
+                            { index: 2, name: 'end' }
+                        ],
+                        valueFields: [
+                            { index: 5, name: 'strand', type: 'nominal' },
+                            { index: 3, name: 'name', type: 'nominal' }
+                        ],
+                        exonIntervalFields: [
+                            { index: 12, name: 'start' },
+                            { index: 13, name: 'end' }
+                        ]
+                    },
+                    encoding: {
+                        startPosition: { field: 'start' },
+                        endPosition: { field: 'end' },
+                        strandColor: { field: 'strand', range: ['gray'] },
+                        strandRow: { field: 'strand' },
+                        opacity: { value: 0.4 },
+                        geneHeight: { value: 30 },
+                        geneLabel: { field: 'name' },
+                        geneLabelFontSize: { value: 30 },
+                        geneLabelColor: { field: 'strand', range: ['gray'] },
+                        geneLabelStroke: { value: 'white' },
+                        geneLabelStrokeThickness: { value: 4 },
+                        geneLabelOpacity: { value: 1 },
+                        type: { field: 'type' }
+                    },
+                    width: 800,
+                    height: 300
+                }
+            ]
         },
         {
-            data: {
-                type: 'csv',
-                url: 'https://raw.githubusercontent.com/mkanai/fujiplot/master/input_example/input.txt',
-                chromosomeField: 'CHR',
-                genomicFields: ['BP'],
-                separator: '\t'
-            },
-            mark: 'point',
-            x: { field: 'BP', type: 'genomic' },
-            y: { field: 'TRAIT', type: 'nominal' },
-            row: { field: 'CATEGORY', type: 'nominal', domain: colorDomain },
-            color: { field: 'CATEGORY', type: 'nominal', domain: colorDomain, range: colorRange },
-            size: { value: 3 },
-            stroke: { value: 'black' },
-            strokeWidth: { value: 0.5 },
-            width: 800,
-            height: 300
+            xDomain: { chromosome: '1' },
+            tracks: [
+                {
+                    template: 'ideogram',
+                    data: {
+                        url:
+                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                        type: 'csv',
+                        chromosomeField: 'Chromosome',
+                        genomicFields: ['chromStart', 'chromEnd']
+                    },
+                    encoding: {
+                        startPosition: { field: 'chromStart' },
+                        endPosition: { field: 'chromEnd' },
+                        stainBackgroundColor: { field: 'Stain' },
+                        stainLabelColor: { field: 'Stain' },
+                        name: { field: 'Name' },
+                        stainStroke: { value: 'black' }
+                    },
+                    width: 800,
+                    height: 100
+                }
+            ]
         }
     ]
 };

--- a/src/editor/example/debug.ts
+++ b/src/editor/example/debug.ts
@@ -29,6 +29,7 @@ export const EX_SPEC_DEBUG: GoslingSpec = {
     title: 'Chart Templates',
     subtitle: 'Using chart templates in Gosling.js helps you more easily create visualizations!',
     spacing: 0,
+    xDomain: { chromosome: '3', interval: [52168000, 52890000] },
     tracks: [
         {
             template: 'gene',
@@ -51,9 +52,16 @@ export const EX_SPEC_DEBUG: GoslingSpec = {
             encoding: {
                 startPosition: { field: 'start' },
                 endPosition: { field: 'end' },
-                strandColor: { field: 'strand' },
+                strandColor: { field: 'strand', range: ['gray'] },
+                strandRow: { field: 'strand' },
+                opacity: { value: 0.4 },
                 geneHeight: { value: 30 },
                 geneLabel: { field: 'name' },
+                geneLabelFontSize: { value: 30 },
+                geneLabelColor: { field: 'strand', range: ['gray'] },
+                geneLabelStroke: { value: 'white' },
+                geneLabelStrokeThickness: { value: 4 },
+                geneLabelOpacity: { value: 1 },
                 type: { field: 'type' }
             },
             width: 800,

--- a/src/editor/example/debug.ts
+++ b/src/editor/example/debug.ts
@@ -24,8 +24,8 @@ const colorRange: Range = [
     '#CE72BB'
 ];
 
-export const geneTemplate: TemplateTrack = {
-    template: 'gene',
+export const templateSpec: TemplateTrack = {
+    template: 'empty',
     data: {
         type: 'csv',
         url: 'https://raw.githubusercontent.com/mkanai/fujiplot/master/input_example/input.txt',
@@ -35,14 +35,14 @@ export const geneTemplate: TemplateTrack = {
     },
     width: 800,
     height: 300
-}
+};
 
 export const EX_SPEC_DEBUG: GoslingSpec = {
     title: 'Chart Templates',
     subtitle: 'Using chart templates in Gosling.js helps you more easily create visualizations!',
     spacing: 0,
     tracks: [
-        geneTemplate,
+        templateSpec,
         {
             data: {
                 type: 'csv',

--- a/src/editor/example/debug.ts
+++ b/src/editor/example/debug.ts
@@ -1,4 +1,5 @@
-import { Range, Domain, GoslingSpec, TemplateTrack } from '../../core/gosling.schema';
+import { Range, Domain, GoslingSpec } from '../../core/gosling.schema';
+import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 const colorDomain: Domain = [
     'Metabolic',
@@ -24,25 +25,40 @@ const colorRange: Range = [
     '#CE72BB'
 ];
 
-export const templateSpec: TemplateTrack = {
-    template: 'empty',
-    data: {
-        type: 'csv',
-        url: 'https://raw.githubusercontent.com/mkanai/fujiplot/master/input_example/input.txt',
-        chromosomeField: 'CHR',
-        genomicFields: ['BP'],
-        separator: '\t'
-    },
-    width: 800,
-    height: 300
-};
-
 export const EX_SPEC_DEBUG: GoslingSpec = {
     title: 'Chart Templates',
     subtitle: 'Using chart templates in Gosling.js helps you more easily create visualizations!',
     spacing: 0,
     tracks: [
-        templateSpec,
+        {
+            template: 'gene',
+            data: {
+                url: GOSLING_PUBLIC_DATA.geneAnnotation,
+                type: 'beddb',
+                genomicFields: [
+                    { index: 1, name: 'start' },
+                    { index: 2, name: 'end' }
+                ],
+                valueFields: [
+                    { index: 5, name: 'strand', type: 'nominal' },
+                    { index: 3, name: 'name', type: 'nominal' }
+                ],
+                exonIntervalFields: [
+                    { index: 12, name: 'start' },
+                    { index: 13, name: 'end' }
+                ]
+            },
+            encoding: {
+                startPosition: { field: 'start' },
+                endPosition: { field: 'end' },
+                strandColor: { field: 'strand' },
+                geneHeight: { value: 30 },
+                geneLabel: { field: 'name' },
+                type: { field: 'type' }
+            },
+            width: 800,
+            height: 300
+        },
         {
             data: {
                 type: 'csv',

--- a/src/editor/example/debug.ts
+++ b/src/editor/example/debug.ts
@@ -1,4 +1,4 @@
-import { Range, Domain, GoslingSpec } from '../../core/gosling.schema';
+import { Range, Domain, GoslingSpec, TemplateTrack } from '../../core/gosling.schema';
 
 const colorDomain: Domain = [
     'Metabolic',
@@ -24,13 +24,25 @@ const colorRange: Range = [
     '#CE72BB'
 ];
 
-export const EX_SPEC_FUJI_PLOT: GoslingSpec = {
-    title: 'Fuji Plot',
-    subtitle: 'Kanai, M. et al., Nat. Genet. (2018)',
-    static: true,
-    layout: 'circular',
-    centerRadius: 0.05,
+export const geneTemplate: TemplateTrack = {
+    template: 'gene',
+    data: {
+        type: 'csv',
+        url: 'https://raw.githubusercontent.com/mkanai/fujiplot/master/input_example/input.txt',
+        chromosomeField: 'CHR',
+        genomicFields: ['BP'],
+        separator: '\t'
+    },
+    width: 800,
+    height: 300
+}
+
+export const EX_SPEC_DEBUG: GoslingSpec = {
+    title: 'Chart Templates',
+    subtitle: 'Using chart templates in Gosling.js helps you more easily create visualizations!',
+    spacing: 0,
     tracks: [
+        geneTemplate,
         {
             data: {
                 type: 'csv',
@@ -47,26 +59,8 @@ export const EX_SPEC_FUJI_PLOT: GoslingSpec = {
             size: { value: 3 },
             stroke: { value: 'black' },
             strokeWidth: { value: 0.5 },
-            style: { outlineWidth: 0.5 },
-            width: 550,
-            height: 200
-        },
-        {
-            data: {
-                type: 'csv',
-                url: 'https://raw.githubusercontent.com/mkanai/fujiplot/master/input_example/input.txt',
-                chromosomeField: 'CHR',
-                genomicFields: ['BP'],
-                separator: '\t'
-            },
-            mark: 'rect',
-            // stackY: true,
-            x: { field: 'BP', type: 'genomic' },
-            size: { value: 12 },
-            color: { field: 'CATEGORY', type: 'nominal', domain: colorDomain, range: colorRange, legend: true },
-            style: { outlineWidth: 0.5 },
-            width: 550,
-            height: 30
+            width: 800,
+            height: 300
         }
     ]
 };

--- a/src/editor/example/gene-annotation.ts
+++ b/src/editor/example/gene-annotation.ts
@@ -658,6 +658,7 @@ const CorcesEtAl: OverlaidTracks = {
                 domain
             },
             xe: { field: 'end', type: 'genomic' },
+            size: { value: 8 },
             style: { textFontSize: 8, dy: -12 }
         },
         {
@@ -669,6 +670,7 @@ const CorcesEtAl: OverlaidTracks = {
             text: { field: 'name', type: 'nominal' },
             x: { field: 'start', type: 'genomic' },
             xe: { field: 'end', type: 'genomic' },
+            size: { value: 8 },
             style: { textFontSize: 8, dy: 10 }
         },
         {

--- a/src/editor/example/gremlin.ts
+++ b/src/editor/example/gremlin.ts
@@ -48,10 +48,9 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                                     target: 'mark'
                                 }
                             ],
+                            size: { value: 6 },
                             style: {
                                 dy: 16,
-                                textFontSize: 6,
-                                textStrokeWidth: 0,
                                 outline: 'white'
                             }
                         },
@@ -68,10 +67,9 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                                     target: 'mark'
                                 }
                             ],
+                            size: { value: 6 },
                             style: {
                                 dy: -16,
-                                textFontSize: 6,
-                                textStrokeWidth: 0,
                                 outline: 'white'
                             }
                         },

--- a/src/editor/example/ideograms.ts
+++ b/src/editor/example/ideograms.ts
@@ -24,10 +24,7 @@ export const CytoBands: OverlaidTracks = {
                     transitionPadding: 10,
                     target: 'mark'
                 }
-            ],
-            style: {
-                textStrokeWidth: 0
-            }
+            ]
         },
         {
             mark: 'rect',

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -144,7 +144,8 @@ export const examples: ReadonlyArray<{
         name: 'Breast Cancer Variant (Staaf et al. 2019)',
         id: 'CANCER_VARIANT',
         spec: EX_SPEC_CANCER_VARIANT_PROTOTYPE,
-        underDevelopment: true
+        underDevelopment: true,
+        forceShow: true
     },
     {
         name: 'BAM file pileup tracks',

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -43,8 +43,7 @@ export const examples: ReadonlyArray<{
     {
         name: 'Basic Example: Circular Visual Encoding',
         id: 'VISUAL_ENCODING_CIRCULAR',
-        spec: EX_SPEC_VISUAL_ENCODING_CIRCULAR,
-        forceShow: true
+        spec: EX_SPEC_VISUAL_ENCODING_CIRCULAR
     },
     {
         name: 'Basic Example: Band Connection',

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -144,8 +144,7 @@ export const examples: ReadonlyArray<{
         name: 'Breast Cancer Variant (Staaf et al. 2019)',
         id: 'CANCER_VARIANT',
         spec: EX_SPEC_CANCER_VARIANT_PROTOTYPE,
-        underDevelopment: true,
-        forceShow: true
+        underDevelopment: true
     },
     {
         name: 'BAM file pileup tracks',

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -43,7 +43,8 @@ export const examples: ReadonlyArray<{
     {
         name: 'Basic Example: Circular Visual Encoding',
         id: 'VISUAL_ENCODING_CIRCULAR',
-        spec: EX_SPEC_VISUAL_ENCODING_CIRCULAR
+        spec: EX_SPEC_VISUAL_ENCODING_CIRCULAR,
+        forceShow: true
     },
     {
         name: 'Basic Example: Band Connection',
@@ -84,12 +85,12 @@ export const examples: ReadonlyArray<{
         spec: EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL
     },
     {
-        name: 'Scalable Sequence Track',
+        name: 'Multi-Scale Sequence Track',
         id: 'SEQUENCE',
         spec: EX_SPEC_SEQUENCE_TRACK
     },
     {
-        name: 'Clinvar Lollipop Plot',
+        name: 'Multi-Scale Clinvar Lollipop Plot',
         id: 'SEMANTIC_ZOOM',
         spec: EX_SPEC_CLINVAR_LOLLIPOP
     },
@@ -157,7 +158,6 @@ export const examples: ReadonlyArray<{
         name: 'Track Template',
         id: 'TEMPLATE',
         spec: EX_SPEC_TEMPLATE,
-        underDevelopment: true,
-        forceShow: true
+        underDevelopment: true
     }
 ].filter(d => !d.hidden);

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -17,6 +17,7 @@ import { EX_SPEC_CORCES_ET_AL } from './corces';
 import { EX_SPEC_CYTOBANDS } from './ideograms';
 import { EX_SPEC_PILEUP } from './pileup';
 import { EX_SPEC_BAND } from './vertical-band';
+import { EX_SPEC_TEMPLATE } from './track-template';
 import { EX_SPEC_DEBUG } from './debug';
 
 export const examples: ReadonlyArray<{
@@ -32,7 +33,7 @@ export const examples: ReadonlyArray<{
         name: 'DEBUG',
         spec: EX_SPEC_DEBUG,
         id: 'DEBUG',
-        hidden: false
+        hidden: true
     },
     {
         name: 'Basic Example: Visual Encoding',
@@ -151,11 +152,12 @@ export const examples: ReadonlyArray<{
         id: 'BAM_PILEUP',
         spec: EX_SPEC_PILEUP,
         underDevelopment: true
+    },
+    {
+        name: 'Track Template',
+        id: 'TEMPLATE',
+        spec: EX_SPEC_TEMPLATE,
+        underDevelopment: true,
+        forceShow: true
     }
-    // {
-    //     name: 'Dark Theme (Beta)',
-    //     id: 'DARK_THEME',
-    //     spec: EX_SPEC_DARK_THEME,
-    //     underDevelopment: true
-    // }
 ].filter(d => !d.hidden);

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -8,7 +8,7 @@ import { EX_SPEC_BASIC_SEMANTIC_ZOOM } from './basic-semantic-zoom';
 import { EX_SPEC_MARK_DISPLACEMENT } from './mark-displacement';
 import { EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL } from './circular-overview-linear-detail-views';
 import { EX_SPEC_SARS_COV_2 } from './sars-cov-2';
-import { EX_SPEC_CIRCOS } from './circos';
+import { EX_SPEC_CIRCOS, EX_SPEC_CIRCULR_RANGE } from './circos';
 import { EX_SPEC_GREMLIN } from './gremlin';
 import { EX_SPEC_GENE_ANNOTATION } from './gene-annotation';
 import { EX_SPEC_CLINVAR_LOLLIPOP, EX_SPEC_SEQUENCE_TRACK } from './semantic-zoom';
@@ -16,8 +16,8 @@ import { EX_SPEC_GIVE } from './give';
 import { EX_SPEC_CORCES_ET_AL } from './corces';
 import { EX_SPEC_CYTOBANDS } from './ideograms';
 import { EX_SPEC_PILEUP } from './pileup';
-import { EX_SPEC_FUJI_PLOT } from './fuji';
 import { EX_SPEC_BAND } from './vertical-band';
+import { EX_SPEC_DEBUG } from './debug';
 
 export const examples: ReadonlyArray<{
     name: string;
@@ -30,9 +30,9 @@ export const examples: ReadonlyArray<{
 }> = [
     {
         name: 'DEBUG',
-        spec: EX_SPEC_FUJI_PLOT,
-        id: 'FUJI_PLOT',
-        hidden: true
+        spec: EX_SPEC_DEBUG,
+        id: 'DEBUG',
+        hidden: false
     },
     {
         name: 'Basic Example: Visual Encoding',
@@ -111,6 +111,12 @@ export const examples: ReadonlyArray<{
         name: 'Circos',
         id: 'CIRCOS',
         spec: EX_SPEC_CIRCOS
+    },
+    {
+        name: 'Circular Range (Inspired By Weather Radials)',
+        id: 'Circular Range',
+        spec: EX_SPEC_CIRCULR_RANGE,
+        hidden: true
     },
     {
         name: 'SARS-CoV-2',

--- a/src/editor/example/mark-displacement.ts
+++ b/src/editor/example/mark-displacement.ts
@@ -49,26 +49,30 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
                         }
                     ],
                     tracks: [
-                        { mark: 'point', size: { value: 4 }, color: { value: '#029F73' } },
+                        {
+                            mark: 'point',
+                            size: { value: 4 },
+                            color: { value: '#029F73' },
+                            stroke: { value: 'black' },
+                            strokeWidth: { value: 1 }
+                        },
                         {
                             mark: 'text',
                             color: { field: '3', type: 'nominal', domain: ['A', 'T', 'G', 'C'], legend: true },
                             text: { field: '3', type: 'nominal' },
-                            y: { value: 40 }
+                            y: { value: 48 }
                         },
                         {
                             mark: 'text',
                             color: { field: '4', type: 'nominal', domain: ['A', 'T', 'G', 'C'] },
                             text: { field: '4', type: 'nominal' },
-                            y: { value: 10 }
+                            y: { value: 18 }
                         },
-                        { mark: 'text', color: { value: 'gray' }, text: { value: '↓' }, y: { value: 25 } }
+                        { mark: 'text', color: { value: 'gray' }, text: { value: '↓' }, y: { value: 33 } }
                     ],
                     x: { field: 'aStart', type: 'genomic' },
                     xe: { field: 'aEnd', type: 'genomic' },
                     y: { value: 5 },
-                    stroke: { value: 'black' },
-                    strokeWidth: { value: 1 },
                     opacity: { value: 0.8 },
                     style: { inlineLegend: true },
                     width: 700,

--- a/src/editor/example/matrix.ts
+++ b/src/editor/example/matrix.ts
@@ -122,10 +122,7 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                                     transitionPadding: 10,
                                     target: 'mark'
                                 }
-                            ],
-                            style: {
-                                textStrokeWidth: 0
-                            }
+                            ]
                         },
                         {
                             mark: 'rect',

--- a/src/editor/example/pileup.ts
+++ b/src/editor/example/pileup.ts
@@ -148,7 +148,7 @@ export function EX_SPEC_VIEW_PILEUP(
             {
                 title: 'Sequence',
                 ...EX_TRACK_SEMANTIC_ZOOM.sequence,
-                style: { inlineLegend: true, textStrokeWidth: 0, outline: 'white' },
+                style: { inlineLegend: true, outline: 'white' },
                 width,
                 height: 40
             },

--- a/src/editor/example/pileup.ts
+++ b/src/editor/example/pileup.ts
@@ -1,109 +1,239 @@
-import { GoslingSpec } from '../../core/gosling.schema';
+import { Domain, DomainGene, GoslingSpec, View } from '../../core/gosling.schema';
 import { EX_TRACK_SEMANTIC_ZOOM } from './semantic-zoom';
+
+export function EX_SPEC_VIEW_PILEUP(
+    width: number,
+    height: number,
+    xDomain: Exclude<Domain, string[] | number[] | DomainGene>,
+    strandColor?: [number, number]
+): View {
+    return {
+        static: false,
+        layout: 'linear',
+        centerRadius: 0.05,
+        xDomain: xDomain,
+        spacing: 0.01,
+        tracks: [
+            {
+                title: 'Coverage',
+                // prerelease: { testUsingNewRectRenderingForBAM: true },
+                data: {
+                    type: 'bam',
+                    // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
+                    url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam'
+                },
+                dataTransform: [{ type: 'coverage', startField: 'from', endField: 'to' }],
+                mark: 'bar',
+                x: { field: 'from', type: 'genomic' },
+                xe: { field: 'to', type: 'genomic' },
+                y: { field: 'coverage', type: 'quantitative', axis: 'right', grid: true },
+                color: { value: 'lightgray' },
+                stroke: { value: 'gray' },
+                width,
+                height: 80
+            },
+            {
+                alignment: 'overlay',
+                title: 'hg38 | Genes',
+                data: {
+                    url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
+                    type: 'beddb',
+                    genomicFields: [
+                        { index: 1, name: 'start' },
+                        { index: 2, name: 'end' }
+                    ],
+                    valueFields: [
+                        { index: 5, name: 'strand', type: 'nominal' },
+                        { index: 3, name: 'name', type: 'nominal' }
+                    ],
+                    exonIntervalFields: [
+                        { index: 12, name: 'start' },
+                        { index: 13, name: 'end' }
+                    ]
+                },
+                tracks: [
+                    {
+                        dataTransform: [
+                            { type: 'filter', field: 'type', oneOf: ['gene'] },
+                            { type: 'filter', field: 'strand', oneOf: ['+'] }
+                        ],
+                        mark: 'triangleRight',
+                        x: { field: 'end', type: 'genomic' },
+                        size: { value: 15 }
+                    },
+                    {
+                        dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
+                        mark: 'text',
+                        text: { field: 'name', type: 'nominal' },
+                        x: { field: 'start', type: 'genomic' },
+                        xe: { field: 'end', type: 'genomic' },
+                        style: { dy: -15, outline: 'black', outlineWidth: 0 }
+                    },
+                    {
+                        dataTransform: [
+                            { type: 'filter', field: 'type', oneOf: ['gene'] },
+                            { type: 'filter', field: 'strand', oneOf: ['-'] }
+                        ],
+                        mark: 'triangleLeft',
+                        x: { field: 'start', type: 'genomic' },
+                        size: { value: 15 },
+                        style: {
+                            align: 'right',
+                            outline: 'black',
+                            outlineWidth: 0
+                        }
+                    },
+                    {
+                        dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
+                        mark: 'rect',
+                        x: { field: 'start', type: 'genomic' },
+                        size: { value: 15 },
+                        xe: { field: 'end', type: 'genomic' }
+                    },
+                    {
+                        dataTransform: [
+                            { type: 'filter', field: 'type', oneOf: ['gene'] },
+                            { type: 'filter', field: 'strand', oneOf: ['+'] }
+                        ],
+                        mark: 'rule',
+                        x: { field: 'start', type: 'genomic' },
+                        strokeWidth: { value: 2 },
+                        xe: { field: 'end', type: 'genomic' },
+                        style: {
+                            linePattern: { type: 'triangleRight', size: 3.5 },
+                            outline: 'black',
+                            outlineWidth: 0
+                        }
+                    },
+                    {
+                        dataTransform: [
+                            { type: 'filter', field: 'type', oneOf: ['gene'] },
+                            { type: 'filter', field: 'strand', oneOf: ['-'] }
+                        ],
+                        mark: 'rule',
+                        x: { field: 'start', type: 'genomic' },
+                        strokeWidth: { value: 2 },
+                        xe: { field: 'end', type: 'genomic' },
+                        style: {
+                            linePattern: { type: 'triangleLeft', size: 3.5 },
+                            outline: 'black',
+                            outlineWidth: 0
+                        }
+                    }
+                ],
+                row: {
+                    field: 'strand',
+                    type: 'nominal',
+                    domain: ['+', '-']
+                },
+                color: {
+                    field: 'strand',
+                    type: 'nominal',
+                    domain: ['+', '-'],
+                    range: ['#97A8B2', '#D4C6BA'] //['blue', 'red']
+                },
+                visibility: [
+                    {
+                        operation: 'less-than',
+                        measure: 'width',
+                        threshold: '|xe-x|',
+                        transitionPadding: 10,
+                        target: 'mark'
+                    }
+                ],
+                // opacity: { value: 0.4 },
+                width,
+                height: 100
+            },
+            {
+                title: 'Sequence',
+                ...EX_TRACK_SEMANTIC_ZOOM.sequence,
+                style: { inlineLegend: true, textStrokeWidth: 0, outline: 'white' },
+                width,
+                height: 40
+            },
+            {
+                alignment: 'overlay',
+                title: 'Reads',
+                // prerelease: { testUsingNewRectRenderingForBAM: true },
+                data: {
+                    type: 'bam',
+                    // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
+                    url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam'
+                },
+                mark: 'rect',
+                tracks: [
+                    {
+                        dataTransform: [
+                            {
+                                type: 'displace',
+                                method: 'pile',
+                                boundingBox: {
+                                    startField: 'from',
+                                    endField: 'to',
+                                    groupField: 'strand',
+                                    padding: 5,
+                                    isPaddingBP: true
+                                },
+                                newField: 'pileup-row'
+                            }
+                        ],
+                        x: { field: 'from', type: 'genomic' },
+                        xe: { field: 'to', type: 'genomic' },
+                        stroke: { value: 'white' },
+                        strokeWidth: { value: 0.5 }
+                    },
+                    {
+                        dataTransform: [
+                            {
+                                type: 'displace',
+                                method: 'pile',
+                                boundingBox: {
+                                    startField: 'from',
+                                    endField: 'to',
+                                    groupField: 'strand',
+                                    padding: 5,
+                                    isPaddingBP: true
+                                },
+                                newField: 'pileup-row'
+                            },
+                            {
+                                type: 'subjson',
+                                field: 'substitutions',
+                                genomicField: 'pos',
+                                baseGenomicField: 'from',
+                                genomicLengthField: 'length'
+                            },
+                            { type: 'filter', field: 'type', oneOf: ['sub'] }
+                        ],
+                        x: { field: 'pos_start', type: 'genomic' },
+                        xe: { field: 'pos_end', type: 'genomic' },
+                        color: {
+                            field: 'variant',
+                            type: 'nominal',
+                            domain: ['A', 'T', 'G', 'C', 'S', 'H', 'X', 'I', 'D'],
+                            legend: true
+                        }
+                    }
+                ],
+                y: { field: 'pileup-row', type: 'nominal', flip: true },
+                row: { field: 'strand', type: 'nominal', domain: ['+', '-'], padding: 1 },
+                color: {
+                    field: 'strand',
+                    type: 'nominal',
+                    domain: ['+', '-'],
+                    range: strandColor ?? ['#97A8B2', '#D4C6BA']
+                },
+                style: { outlineWidth: 0.5 },
+                width,
+                height
+            }
+        ]
+    };
+}
 
 export const EX_SPEC_PILEUP: GoslingSpec = {
     title: 'Pileup Track Using BAM Data',
     subtitle: '',
-    static: false,
-    layout: 'linear',
-    centerRadius: 0.05,
-    xDomain: { chromosome: '1', interval: [136750, 139450] },
-    spacing: 0.01,
-    tracks: [
-        {
-            ...EX_TRACK_SEMANTIC_ZOOM.sequence,
-            style: { inlineLegend: true, textStrokeWidth: 0, outline: 'white' },
-            width: 800,
-            height: 40
-        },
-        {
-            title: 'Coverage',
-            prerelease: { testUsingNewRectRenderingForBAM: true },
-            data: {
-                type: 'bam',
-                // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
-                url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam'
-            },
-            dataTransform: [{ type: 'coverage', startField: 'from', endField: 'to' }],
-            mark: 'bar',
-            x: { field: 'from', type: 'genomic' },
-            xe: { field: 'to', type: 'genomic' },
-            y: { field: 'coverage', type: 'quantitative' },
-            color: { value: 'lightgray' },
-            stroke: { value: 'gray' },
-            width: 650,
-            height: 80
-        },
-        {
-            alignment: 'overlay',
-            title: 'Reads',
-            prerelease: { testUsingNewRectRenderingForBAM: true },
-            data: {
-                type: 'bam',
-                // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
-                url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam'
-            },
-            mark: 'rect',
-            tracks: [
-                {
-                    dataTransform: [
-                        {
-                            type: 'displace',
-                            method: 'pile',
-                            boundingBox: {
-                                startField: 'from',
-                                endField: 'to',
-                                groupField: 'strand',
-                                padding: 5,
-                                isPaddingBP: true
-                            },
-                            newField: 'pileup-row'
-                        }
-                    ],
-                    x: { field: 'from', type: 'genomic' },
-                    xe: { field: 'to', type: 'genomic' },
-                    stroke: { value: 'gray' }
-                    // strokeWidth: { value: 0.5 },
-                },
-                {
-                    dataTransform: [
-                        {
-                            type: 'displace',
-                            method: 'pile',
-                            boundingBox: {
-                                startField: 'from',
-                                endField: 'to',
-                                groupField: 'strand',
-                                padding: 5,
-                                isPaddingBP: true
-                            },
-                            newField: 'pileup-row'
-                        },
-                        {
-                            type: 'subjson',
-                            field: 'substitutions',
-                            genomicField: 'pos',
-                            baseGenomicField: 'from',
-                            genomicLengthField: 'length'
-                        },
-                        { type: 'filter', field: 'type', oneOf: ['sub'] }
-                    ],
-                    x: { field: 'pos_start', type: 'genomic' },
-                    xe: { field: 'pos_end', type: 'genomic' },
-                    color: {
-                        field: 'variant',
-                        type: 'nominal',
-                        domain: ['A', 'T', 'G', 'C', 'S', 'H', 'X', 'I', 'D'],
-                        legend: true
-                    }
-                }
-            ],
-            y: { field: 'pileup-row', type: 'nominal', flip: true },
-            row: { field: 'strand', type: 'nominal', domain: ['+', '-'], padding: 1 },
-            color: { field: 'strand', type: 'nominal', domain: ['+', '-'], range: ['#97A8B2', '#D4C6BA'] },
-            style: { outlineWidth: 0.5 },
-            width: 1250,
-            height: 650
-        }
-    ]
+    ...EX_SPEC_VIEW_PILEUP(1250, 600, { chromosome: '1', interval: [136750, 139450] })
 };

--- a/src/editor/example/sars-cov-2.ts
+++ b/src/editor/example/sars-cov-2.ts
@@ -27,7 +27,7 @@ export const EX_TRACK_SARS_COV_2_GENES: OverlaidTracks = {
             mark: 'text',
             text: { field: 'Gene symbol', type: 'nominal' },
             color: { value: 'black' },
-            style: { textStrokeWidth: 3 },
+            strokeWidth: { value: 3 },
             visibility: [
                 {
                     target: 'mark',
@@ -133,7 +133,8 @@ export const EX_SPEC_SARS_COV_2: GoslingSpec = {
                             mark: 'text',
                             text: { field: 'Protein', type: 'nominal' },
                             color: { value: '#333' },
-                            style: { textStrokeWidth: 3, textAnchor: 'end' }
+                            strokeWidth: { value: 3 },
+                            style: { textAnchor: 'end' }
                         }
                     ],
                     x: { field: 'Start', type: 'genomic' },
@@ -159,7 +160,7 @@ export const EX_SPEC_SARS_COV_2: GoslingSpec = {
                         ...(EX_TRACK_SEMANTIC_ZOOM.sequence.data as MultivecData),
                         url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=NC_045512_2-multivec'
                     },
-                    style: { inlineLegend: true, textStrokeWidth: 0 },
+                    style: { inlineLegend: true },
                     width: 800,
                     height: 40
                 },

--- a/src/editor/example/semantic-zoom.ts
+++ b/src/editor/example/semantic-zoom.ts
@@ -30,6 +30,7 @@ const ScalableSequenceTrack: OverlaidTracks = {
                 field: 'end',
                 type: 'genomic'
             },
+            size: { value: 24 },
             color: { value: 'white' },
             visibility: [
                 {
@@ -62,7 +63,6 @@ const ScalableSequenceTrack: OverlaidTracks = {
         field: 'base',
         type: 'nominal'
     },
-    size: { value: 24 },
     style: {
         textFontWeight: 'bold'
     },

--- a/src/editor/example/semantic-zoom.ts
+++ b/src/editor/example/semantic-zoom.ts
@@ -62,9 +62,8 @@ const ScalableSequenceTrack: OverlaidTracks = {
         field: 'base',
         type: 'nominal'
     },
+    size: { value: 24 },
     style: {
-        textFontSize: 24,
-        textStrokeWidth: 0,
         textFontWeight: 'bold'
     },
     width: 400,
@@ -154,10 +153,7 @@ const ScalableCytoBand: OverlaidTracks = {
                     transitionPadding: 10,
                     target: 'mark'
                 }
-            ],
-            style: {
-                textStrokeWidth: 0
-            }
+            ]
         },
         {
             mark: 'rect',

--- a/src/editor/example/track-template.ts
+++ b/src/editor/example/track-template.ts
@@ -1,0 +1,126 @@
+import { GoslingSpec } from '../../core/gosling.schema';
+import { GOSLING_PUBLIC_DATA } from './gosling-data';
+
+export const EX_SPEC_TEMPLATE: GoslingSpec = {
+    title: 'Track Template In Gosling.js',
+    subtitle: 'Gosling.js enables track templates! This allows to create complex visualization more easily.',
+    spacing: 0,
+    // layout: 'circular',
+    layout: 'linear',
+    centerRadius: 0.5,
+    style: { enableSmoothPath: true },
+    views: [
+        {
+            xDomain: { chromosome: '3', interval: [52168000, 52890000] },
+            tracks: [
+                {
+                    data: {
+                        url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec',
+                        type: 'multivec',
+                        row: 'sample',
+                        column: 'position',
+                        value: 'peak',
+                        categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4']
+                    },
+                    mark: 'point',
+                    x: { field: 'position', type: 'genomic' },
+                    y: { field: 'peak', type: 'quantitative', grid: true },
+                    size: { field: 'peak', type: 'quantitative' },
+                    color: { field: 'sample', type: 'nominal', legend: true },
+                    opacity: { value: 0.5 },
+                    width: 600,
+                    height: 330
+                },
+                {
+                    template: 'gene',
+                    data: {
+                        url: GOSLING_PUBLIC_DATA.geneAnnotation,
+                        type: 'beddb',
+                        genomicFields: [
+                            { index: 1, name: 'start' },
+                            { index: 2, name: 'end' }
+                        ],
+                        valueFields: [
+                            { index: 5, name: 'strand', type: 'nominal' },
+                            { index: 3, name: 'name', type: 'nominal' }
+                        ],
+                        exonIntervalFields: [
+                            { index: 12, name: 'start' },
+                            { index: 13, name: 'end' }
+                        ]
+                    },
+                    encoding: {
+                        startPosition: { field: 'start' },
+                        endPosition: { field: 'end' },
+                        strandColor: { field: 'strand', range: ['gray'] },
+                        strandRow: { field: 'strand' },
+                        opacity: { value: 0.4 },
+                        geneHeight: { value: 30 },
+                        geneLabel: { field: 'name' },
+                        geneLabelFontSize: { value: 30 },
+                        geneLabelColor: { field: 'strand', range: ['gray'] },
+                        geneLabelStroke: { value: 'white' },
+                        geneLabelStrokeThickness: { value: 4 },
+                        geneLabelOpacity: { value: 1 },
+                        type: { field: 'type' }
+                    },
+                    width: 800,
+                    height: 300
+                }
+            ]
+        },
+        {
+            xDomain: { chromosome: '1', interval: [77925299, 77925320] },
+            tracks: [
+                {
+                    template: 'sequence',
+                    data: {
+                        url: GOSLING_PUBLIC_DATA.fasta,
+                        type: 'multivec',
+                        row: 'base',
+                        column: 'position',
+                        value: 'count',
+                        categories: ['A', 'T', 'G', 'C'],
+                        start: 'start',
+                        end: 'end'
+                    },
+                    encoding: {
+                        barLength: { field: 'count', type: 'quantitative' },
+                        baseBackground: { field: 'base', type: 'nominal' },
+                        baseLabelColor: { field: 'base', type: 'nominal' },
+                        position: { field: 'position', type: 'genomic' },
+                        startPosition: { field: 'start', type: 'genomic' },
+                        endPosition: { field: 'end', type: 'genomic' }
+                    },
+                    width: 800,
+                    height: 100
+                }
+            ]
+        },
+        {
+            xDomain: { chromosome: '1' },
+            tracks: [
+                {
+                    template: 'ideogram',
+                    data: {
+                        url:
+                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                        type: 'csv',
+                        chromosomeField: 'Chromosome',
+                        genomicFields: ['chromStart', 'chromEnd']
+                    },
+                    encoding: {
+                        startPosition: { field: 'chromStart' },
+                        endPosition: { field: 'chromEnd' },
+                        stainBackgroundColor: { field: 'Stain' },
+                        stainLabelColor: { field: 'Stain' },
+                        name: { field: 'Name' },
+                        stainStroke: { value: 'black' }
+                    },
+                    width: 800,
+                    height: 60
+                }
+            ]
+        }
+    ]
+};

--- a/src/editor/example/track-template.ts
+++ b/src/editor/example/track-template.ts
@@ -13,24 +13,24 @@ export const EX_SPEC_TEMPLATE: GoslingSpec = {
         {
             xDomain: { chromosome: '3', interval: [52168000, 52890000] },
             tracks: [
-                {
-                    data: {
-                        url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec',
-                        type: 'multivec',
-                        row: 'sample',
-                        column: 'position',
-                        value: 'peak',
-                        categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4']
-                    },
-                    mark: 'point',
-                    x: { field: 'position', type: 'genomic' },
-                    y: { field: 'peak', type: 'quantitative', grid: true },
-                    size: { field: 'peak', type: 'quantitative' },
-                    color: { field: 'sample', type: 'nominal', legend: true },
-                    opacity: { value: 0.5 },
-                    width: 600,
-                    height: 330
-                },
+                // {
+                //     data: {
+                //         url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec',
+                //         type: 'multivec',
+                //         row: 'sample',
+                //         column: 'position',
+                //         value: 'peak',
+                //         categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4']
+                //     },
+                //     mark: 'point',
+                //     x: { field: 'position', type: 'genomic' },
+                //     y: { field: 'peak', type: 'quantitative', grid: true },
+                //     size: { field: 'peak', type: 'quantitative' },
+                //     color: { field: 'sample', type: 'nominal', legend: true },
+                //     opacity: { value: 0.5 },
+                //     width: 600,
+                //     height: 330
+                // },
                 {
                     template: 'gene',
                     data: {

--- a/src/gosling-template/index.ts
+++ b/src/gosling-template/index.ts
@@ -3,11 +3,7 @@ import { TemplateDef } from '..';
 export const GoslingBuiltInTemplates: TemplateDef[] = [
     {
         name: 'gene',
-        customChannels: [
-
-        ],
-        mapping: [
-            
-        ]
+        customChannels: [],
+        mapping: []
     }
-]
+];

--- a/src/gosling-template/index.ts
+++ b/src/gosling-template/index.ts
@@ -1,0 +1,13 @@
+import { TemplateDef } from '..';
+
+export const GoslingBuiltInTemplates: TemplateDef[] = [
+    {
+        name: 'gene',
+        customChannels: [
+
+        ],
+        mapping: [
+            
+        ]
+    }
+]

--- a/src/gosling-template/index.ts
+++ b/src/gosling-template/index.ts
@@ -1,9 +1,0 @@
-import { TemplateDef } from '..';
-
-export const GoslingBuiltInTemplates: TemplateDef[] = [
-    {
-        name: 'gene',
-        customChannels: [],
-        mapping: []
-    }
-];

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -596,6 +596,8 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
             const spec = JSON.parse(JSON.stringify(this.originalSpec));
 
+            // const [trackWidth, trackHeight] = this.dimensions; // actual size of a track
+
             resolveSuperposedTracks(spec).forEach(resolved => {
                 if (resolved.mark === 'brush') {
                     // we do not draw rectangular brush ourselves, higlass does.
@@ -692,6 +694,11 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 } catch (e) {
                     // ..
                 }
+
+                // Replace width and height information with the actual values
+                // TODO: we don't need this?
+                // resolved.width = trackWidth;
+                // resolved.height = trackHeight;
 
                 // Construct separate gosling models for individual tiles
                 const gm = new GoslingTrackModel(resolved, tile.gos.tabularDataFiltered, this.options.theme);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,9 @@ import pkg from '../package.json';
 import GoslingSchema from '../schema/gosling.schema.json';
 import ThemeSchema from '../schema/theme.schema.json';
 
-export type { GoslingSpec, TemplateDef } from './core/gosling.schema';
+export type { GoslingSpec, TemplateTrackDef } from './core/gosling.schema';
 export type { HiGlassSpec } from './core/higlass.schema';
+export { GoslingTemplates } from './core/utils/template';
 export type { Theme } from './core/utils/theme';
 export { GoslingSchema };
 export { ThemeSchema };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import pkg from '../package.json';
 import GoslingSchema from '../schema/gosling.schema.json';
 import ThemeSchema from '../schema/theme.schema.json';
 
-export type { GoslingSpec } from './core/gosling.schema';
+export type { GoslingSpec, TemplateDef } from './core/gosling.schema';
 export type { HiGlassSpec } from './core/higlass.schema';
 export type { Theme } from './core/utils/theme';
 export { GoslingSchema };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5718,6 +5718,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
 classnames@2.x, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
@@ -15663,7 +15668,7 @@ prop-types-extra@^1.0.1:
     react-is "^16.3.2"
     warning "^4.0.0"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.x, prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -16068,7 +16073,7 @@ react-draggable@3.x:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-draggable@^4.0.3:
+react-draggable@^4.0.0, react-draggable@^4.0.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.3.tgz#0727f2cae5813e36b0e4962bf11b2f9ef2b406f3"
   integrity sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==
@@ -16091,6 +16096,17 @@ react-grid-layout@^0.16.6:
     prop-types "15.x"
     react-draggable "3.x"
     react-resizable "1.x"
+
+react-grid-layout@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/react-grid-layout/-/react-grid-layout-1.2.5.tgz#fa40288d5a1fa783484c44ce78b1e10eb5313d26"
+  integrity sha512-P/NNWAExTX/zEq+RUh6hrIG67UBicDNCOOg9LZe8BAtSdYtCnCGgVmWBS+sIbM0C8RJIiyGsFHh5dIfCddhS/w==
+  dependencies:
+    classnames "2.3.1"
+    lodash.isequal "^4.0.0"
+    prop-types "^15.0.0"
+    react-draggable "^4.0.0"
+    react-resizable "^3.0.1"
 
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
@@ -16149,6 +16165,14 @@ react-resizable@1.x, react-resizable@^1.8.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-1.10.1.tgz#f0c2cf1d83b3470b87676ce6d6b02bbe3f4d8cd4"
   integrity sha512-Jd/bKOKx6+19NwC4/aMLRu/J9/krfxlDnElP41Oc+oLiUWs/zwV1S9yBfBZRnqAwQb6vQ/HRSk3bsSWGSgVbpw==
+  dependencies:
+    prop-types "15.x"
+    react-draggable "^4.0.3"
+
+react-resizable@^3.0.1:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-3.0.4.tgz#aa20108eff28c52c6fddaa49abfbef8abf5e581b"
+  integrity sha512-StnwmiESiamNzdRHbSSvA65b0ZQJ7eVQpPusrSmcpyGKzC0gojhtO62xxH6YOBmepk9dQTBi9yxidL3W4s3EBA==
   dependencies:
     prop-types "15.x"
     react-draggable "^4.0.3"


### PR DESCRIPTION
# Introduction
This PR enables to use of track templates by adding a schema for templates and their definition. We support three basic templates, i.e., gene annotation, ideogram, and sequence, but we will (1) support more default templates and (2) allow users to define their own templates.

### Some design decisions
1. If certain templates are not defined but used in the spec, they will be removed from the spec.

This PR also addresses some remaining issues regarding incorrect positioning of marks and tracks in some cases (#208, #323, #442, #414)🎉.

Toward #53
Fix #447