### PR TITLE
feat: expressive BAM rendering

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -564,6 +564,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -934,6 +940,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -1649,6 +1661,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -1950,6 +1968,9 @@
                   }
                 ]
               },
+              "xOffset": {
+                "type": "number"
+              },
               "xe": {
                 "$ref": "#/definitions/Channel"
               },
@@ -1961,6 +1982,9 @@
               },
               "y1e": {
                 "$ref": "#/definitions/Channel"
+              },
+              "yOffset": {
+                "type": "number"
               },
               "ye": {
                 "$ref": "#/definitions/Channel"
@@ -2061,6 +2085,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -2072,6 +2099,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -2415,6 +2445,9 @@
                         }
                       ]
                     },
+                    "xOffset": {
+                      "type": "number"
+                    },
                     "xe": {
                       "$ref": "#/definitions/Channel"
                     },
@@ -2426,6 +2459,9 @@
                     },
                     "y1e": {
                       "$ref": "#/definitions/Channel"
+                    },
+                    "yOffset": {
+                      "type": "number"
                     },
                     "ye": {
                       "$ref": "#/definitions/Channel"
@@ -2526,6 +2562,9 @@
                   }
                 ]
               },
+              "xOffset": {
+                "type": "number"
+              },
               "xe": {
                 "$ref": "#/definitions/Channel"
               },
@@ -2537,6 +2576,9 @@
               },
               "y1e": {
                 "$ref": "#/definitions/Channel"
+              },
+              "yOffset": {
+                "type": "number"
               },
               "ye": {
                 "$ref": "#/definitions/Channel"
@@ -2580,6 +2622,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -2591,6 +2636,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -2736,6 +2784,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -3079,6 +3133,9 @@
                             }
                           ]
                         },
+                        "xOffset": {
+                          "type": "number"
+                        },
                         "xe": {
                           "$ref": "#/definitions/Channel"
                         },
@@ -3090,6 +3147,9 @@
                         },
                         "y1e": {
                           "$ref": "#/definitions/Channel"
+                        },
+                        "yOffset": {
+                          "type": "number"
                         },
                         "ye": {
                           "$ref": "#/definitions/Channel"
@@ -3190,6 +3250,9 @@
                       }
                     ]
                   },
+                  "xOffset": {
+                    "type": "number"
+                  },
                   "xe": {
                     "$ref": "#/definitions/Channel"
                   },
@@ -3201,6 +3264,9 @@
                   },
                   "y1e": {
                     "$ref": "#/definitions/Channel"
+                  },
+                  "yOffset": {
+                    "type": "number"
                   },
                   "ye": {
                     "$ref": "#/definitions/Channel"
@@ -3244,6 +3310,9 @@
                 }
               ]
             },
+            "xOffset": {
+              "type": "number"
+            },
             "xe": {
               "$ref": "#/definitions/Channel"
             },
@@ -3255,6 +3324,9 @@
             },
             "y1e": {
               "$ref": "#/definitions/Channel"
+            },
+            "yOffset": {
+              "type": "number"
             },
             "ye": {
               "$ref": "#/definitions/Channel"
@@ -3604,6 +3676,9 @@
                                 }
                               ]
                             },
+                            "xOffset": {
+                              "type": "number"
+                            },
                             "xe": {
                               "$ref": "#/definitions/Channel"
                             },
@@ -3615,6 +3690,9 @@
                             },
                             "y1e": {
                               "$ref": "#/definitions/Channel"
+                            },
+                            "yOffset": {
+                              "type": "number"
                             },
                             "ye": {
                               "$ref": "#/definitions/Channel"
@@ -3715,6 +3793,9 @@
                           }
                         ]
                       },
+                      "xOffset": {
+                        "type": "number"
+                      },
                       "xe": {
                         "$ref": "#/definitions/Channel"
                       },
@@ -3726,6 +3807,9 @@
                       },
                       "y1e": {
                         "$ref": "#/definitions/Channel"
+                      },
+                      "yOffset": {
+                        "type": "number"
                       },
                       "ye": {
                         "$ref": "#/definitions/Channel"
@@ -3774,6 +3858,9 @@
                 }
               ]
             },
+            "xOffset": {
+              "type": "number"
+            },
             "xe": {
               "$ref": "#/definitions/Channel"
             },
@@ -3785,6 +3872,9 @@
             },
             "y1e": {
               "$ref": "#/definitions/Channel"
+            },
+            "yOffset": {
+              "type": "number"
             },
             "ye": {
               "$ref": "#/definitions/Channel"
@@ -3853,6 +3943,12 @@
                   "$ref": "#/definitions/DomainChr"
                 }
               ]
+            },
+            "xOffset": {
+              "type": "number"
+            },
+            "yOffset": {
+              "type": "number"
             }
           },
           "required": [
@@ -4017,6 +4113,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -4028,6 +4127,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -4433,6 +4535,9 @@
                             }
                           ]
                         },
+                        "xOffset": {
+                          "type": "number"
+                        },
                         "xe": {
                           "$ref": "#/definitions/Channel"
                         },
@@ -4444,6 +4549,9 @@
                         },
                         "y1e": {
                           "$ref": "#/definitions/Channel"
+                        },
+                        "yOffset": {
+                          "type": "number"
                         },
                         "ye": {
                           "$ref": "#/definitions/Channel"
@@ -4544,6 +4652,9 @@
                       }
                     ]
                   },
+                  "xOffset": {
+                    "type": "number"
+                  },
                   "xe": {
                     "$ref": "#/definitions/Channel"
                   },
@@ -4555,6 +4666,9 @@
                   },
                   "y1e": {
                     "$ref": "#/definitions/Channel"
+                  },
+                  "yOffset": {
+                    "type": "number"
                   },
                   "ye": {
                     "$ref": "#/definitions/Channel"
@@ -4603,6 +4717,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -4614,6 +4731,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"

--- a/schema/history/0.8.12/gosling0.8.12.schema.json
+++ b/schema/history/0.8.12/gosling0.8.12.schema.json
@@ -564,6 +564,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -934,6 +940,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -1649,6 +1661,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -1950,6 +1968,9 @@
                   }
                 ]
               },
+              "xOffset": {
+                "type": "number"
+              },
               "xe": {
                 "$ref": "#/definitions/Channel"
               },
@@ -1961,6 +1982,9 @@
               },
               "y1e": {
                 "$ref": "#/definitions/Channel"
+              },
+              "yOffset": {
+                "type": "number"
               },
               "ye": {
                 "$ref": "#/definitions/Channel"
@@ -2061,6 +2085,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -2072,6 +2099,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -2415,6 +2445,9 @@
                         }
                       ]
                     },
+                    "xOffset": {
+                      "type": "number"
+                    },
                     "xe": {
                       "$ref": "#/definitions/Channel"
                     },
@@ -2426,6 +2459,9 @@
                     },
                     "y1e": {
                       "$ref": "#/definitions/Channel"
+                    },
+                    "yOffset": {
+                      "type": "number"
                     },
                     "ye": {
                       "$ref": "#/definitions/Channel"
@@ -2526,6 +2562,9 @@
                   }
                 ]
               },
+              "xOffset": {
+                "type": "number"
+              },
               "xe": {
                 "$ref": "#/definitions/Channel"
               },
@@ -2537,6 +2576,9 @@
               },
               "y1e": {
                 "$ref": "#/definitions/Channel"
+              },
+              "yOffset": {
+                "type": "number"
               },
               "ye": {
                 "$ref": "#/definitions/Channel"
@@ -2580,6 +2622,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -2591,6 +2636,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -2736,6 +2784,12 @@
               "$ref": "#/definitions/DomainChr"
             }
           ]
+        },
+        "xOffset": {
+          "type": "number"
+        },
+        "yOffset": {
+          "type": "number"
         }
       },
       "required": [
@@ -3079,6 +3133,9 @@
                             }
                           ]
                         },
+                        "xOffset": {
+                          "type": "number"
+                        },
                         "xe": {
                           "$ref": "#/definitions/Channel"
                         },
@@ -3090,6 +3147,9 @@
                         },
                         "y1e": {
                           "$ref": "#/definitions/Channel"
+                        },
+                        "yOffset": {
+                          "type": "number"
                         },
                         "ye": {
                           "$ref": "#/definitions/Channel"
@@ -3190,6 +3250,9 @@
                       }
                     ]
                   },
+                  "xOffset": {
+                    "type": "number"
+                  },
                   "xe": {
                     "$ref": "#/definitions/Channel"
                   },
@@ -3201,6 +3264,9 @@
                   },
                   "y1e": {
                     "$ref": "#/definitions/Channel"
+                  },
+                  "yOffset": {
+                    "type": "number"
                   },
                   "ye": {
                     "$ref": "#/definitions/Channel"
@@ -3244,6 +3310,9 @@
                 }
               ]
             },
+            "xOffset": {
+              "type": "number"
+            },
             "xe": {
               "$ref": "#/definitions/Channel"
             },
@@ -3255,6 +3324,9 @@
             },
             "y1e": {
               "$ref": "#/definitions/Channel"
+            },
+            "yOffset": {
+              "type": "number"
             },
             "ye": {
               "$ref": "#/definitions/Channel"
@@ -3604,6 +3676,9 @@
                                 }
                               ]
                             },
+                            "xOffset": {
+                              "type": "number"
+                            },
                             "xe": {
                               "$ref": "#/definitions/Channel"
                             },
@@ -3615,6 +3690,9 @@
                             },
                             "y1e": {
                               "$ref": "#/definitions/Channel"
+                            },
+                            "yOffset": {
+                              "type": "number"
                             },
                             "ye": {
                               "$ref": "#/definitions/Channel"
@@ -3715,6 +3793,9 @@
                           }
                         ]
                       },
+                      "xOffset": {
+                        "type": "number"
+                      },
                       "xe": {
                         "$ref": "#/definitions/Channel"
                       },
@@ -3726,6 +3807,9 @@
                       },
                       "y1e": {
                         "$ref": "#/definitions/Channel"
+                      },
+                      "yOffset": {
+                        "type": "number"
                       },
                       "ye": {
                         "$ref": "#/definitions/Channel"
@@ -3774,6 +3858,9 @@
                 }
               ]
             },
+            "xOffset": {
+              "type": "number"
+            },
             "xe": {
               "$ref": "#/definitions/Channel"
             },
@@ -3785,6 +3872,9 @@
             },
             "y1e": {
               "$ref": "#/definitions/Channel"
+            },
+            "yOffset": {
+              "type": "number"
             },
             "ye": {
               "$ref": "#/definitions/Channel"
@@ -3853,6 +3943,12 @@
                   "$ref": "#/definitions/DomainChr"
                 }
               ]
+            },
+            "xOffset": {
+              "type": "number"
+            },
+            "yOffset": {
+              "type": "number"
             }
           },
           "required": [
@@ -4017,6 +4113,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -4028,6 +4127,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"
@@ -4433,6 +4535,9 @@
                             }
                           ]
                         },
+                        "xOffset": {
+                          "type": "number"
+                        },
                         "xe": {
                           "$ref": "#/definitions/Channel"
                         },
@@ -4444,6 +4549,9 @@
                         },
                         "y1e": {
                           "$ref": "#/definitions/Channel"
+                        },
+                        "yOffset": {
+                          "type": "number"
                         },
                         "ye": {
                           "$ref": "#/definitions/Channel"
@@ -4544,6 +4652,9 @@
                       }
                     ]
                   },
+                  "xOffset": {
+                    "type": "number"
+                  },
                   "xe": {
                     "$ref": "#/definitions/Channel"
                   },
@@ -4555,6 +4666,9 @@
                   },
                   "y1e": {
                     "$ref": "#/definitions/Channel"
+                  },
+                  "yOffset": {
+                    "type": "number"
                   },
                   "ye": {
                     "$ref": "#/definitions/Channel"
@@ -4603,6 +4717,9 @@
             }
           ]
         },
+        "xOffset": {
+          "type": "number"
+        },
         "xe": {
           "$ref": "#/definitions/Channel"
         },
@@ -4614,6 +4731,9 @@
         },
         "y1e": {
           "$ref": "#/definitions/Channel"
+        },
+        "yOffset": {
+          "type": "number"
         },
         "ye": {
           "$ref": "#/definitions/Channel"

--- a/schema/history/0.8.12/gosling0.8.12.schema.ts
+++ b/schema/history/0.8.12/gosling0.8.12.schema.ts
@@ -52,6 +52,10 @@ export interface CommonViewDef {
     spacing?: number;
     static?: boolean;
 
+    // offsets
+    xOffset?: number;
+    yOffset?: number;
+
     assembly?: Assembly;
 
     // TODO: Change to domain?

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -192,7 +192,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                 }
             }
         };
-    }, [ref, hgRef, hs]);
+    }, [ref, hgRef, hs, theme]);
 
     useEffect(() => {
         if (gs) {
@@ -216,7 +216,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                 theme
             );
         }
-    }, [gs]);
+    }, [gs, theme]);
 
     const higlassComponent = useMemo(() => {
         return hs && size ? (
@@ -272,7 +272,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                 </div>
             </>
         ) : null;
-    }, [hs, size]);
+    }, [hs, size, theme]);
 
     return higlassComponent;
 });

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -52,6 +52,10 @@ export interface CommonViewDef {
     spacing?: number;
     static?: boolean;
 
+    // offsets
+    xOffset?: number;
+    yOffset?: number;
+
     assembly?: Assembly;
 
     // TODO: Change to domain?

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -84,10 +84,6 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
             drawArea(HGC, trackInfo, tile, model);
             break;
         case 'rect':
-            if (model.spec().layout !== 'circular' && model.spec().prerelease?.testUsingNewRectRenderingForBAM) {
-                // In this case, we use different method for the rendering.
-                break;
-            }
             drawRect(HGC, trackInfo, tile, model);
             break;
         case 'triangleLeft':
@@ -130,6 +126,13 @@ export function drawPreEmbellishment(
         // We do not draw brush. Instead, higlass do.
         return;
     }
+
+    // This is only to render embellishments only once.
+    // TODO: Instead of rendering and removing for every tiles, render pBorder only once
+    trackInfo.pBackground.clear();
+    trackInfo.pBackground.removeChildren();
+    trackInfo.pBorder.clear();
+    trackInfo.pBorder.removeChildren();
 
     const CIRCULAR = model.spec().layout === 'circular';
 

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -22,6 +22,8 @@ import * as qs from 'qs';
 import { JSONCrush, JSONUncrush } from '../core/utils/json-crush';
 import './editor.css';
 import { ICONS, ICON_INFO } from './icon';
+// @ts-ignore
+import { Themes } from 'gosling-theme';
 
 const INIT_DEMO_INDEX = examples.findIndex(d => d.forceShow) !== -1 ? examples.findIndex(d => d.forceShow) : 0;
 
@@ -145,6 +147,7 @@ function Editor(props: any) {
     const [refreshData, setRefreshData] = useState<boolean>(false);
 
     const [demo, setDemo] = useState(examples[urlExampleIndex === -1 ? INIT_DEMO_INDEX : urlExampleIndex]);
+    const [theme, setTheme] = useState('light');
     const [hg, setHg] = useState<HiGlassSpec>();
     const [code, setCode] = useState(defaultCode);
     const [goslingSpec, setGoslingSpec] = useState<gosling.GoslingSpec>();
@@ -153,6 +156,7 @@ function Editor(props: any) {
     const [selectedPreviewData, setSelectedPreviewData] = useState<number>(0);
     const [gistTitle, setGistTitle] = useState<string>();
     const [description, setDescription] = useState<string | null>();
+    const [expertMode, setExpertMode] = useState(false);
 
     // This parameter only matter when a markdown description was loaded from a gist but the user wants to hide it
     const [hideDescription, setHideDescription] = useState<boolean>(IS_SMALL_SCREEN || false);
@@ -186,9 +190,6 @@ function Editor(props: any) {
 
     // whether to show "about" information
     const [isShowAbout, setIsShowAbout] = useState(false);
-
-    // Editor theme
-    const [theme] = useState<string>('light'); // not used
 
     // Resizer `div`
     const descResizerRef = useRef<any>();
@@ -314,7 +315,7 @@ function Editor(props: any) {
         previewData.current = [];
         setSelectedPreviewData(0);
         runSpecUpdateVis();
-    }, [code, autoRun]);
+    }, [code, autoRun, theme]);
 
     // Uncommnet below to use HiGlass APIs
     // useEffect(() => {
@@ -436,6 +437,23 @@ function Editor(props: any) {
                         </option>
                     ))}
                 </select>
+                {expertMode ? (
+                    <select
+                        style={{ maxWidth: IS_SMALL_SCREEN ? window.innerWidth - 180 : 'none' }}
+                        onChange={e => {
+                            if (Object.keys(Themes).indexOf(e.target.value) !== -1) {
+                                setTheme(e.target.value);
+                            }
+                        }}
+                        defaultValue={theme}
+                    >
+                        {Object.keys(Themes).map((d: string) => (
+                            <option key={d} value={d}>
+                                {d}
+                            </option>
+                        ))}
+                    </select>
+                ) : null}
                 {demo.underDevelopment ? (
                     <span
                         style={{
@@ -584,6 +602,17 @@ function Editor(props: any) {
                             URL
                         </span>
                         <span
+                            title="Expert mode that turns on additional features, such as theme selection"
+                            className="side-panel-button"
+                            onClick={() => setExpertMode(!expertMode)}
+                        >
+                            {expertMode ? getIconSVG(ICONS.TOGGLE_ON, 23, 23, '#E18343') : getIconSVG(ICONS.TOGGLE_OFF)}
+                            <br />
+                            EXPERT
+                            <br />
+                            MODE
+                        </span>
+                        <span
                             title="Open GitHub repository"
                             className="side-panel-button"
                             onClick={() => window.open('https://github.com/gosling-lang/gosling.js', '_blank')}
@@ -673,7 +702,7 @@ function Editor(props: any) {
                                     <gosling.GoslingComponent
                                         ref={gosRef}
                                         spec={goslingSpec}
-                                        theme={'light'}
+                                        theme={theme}
                                         padding={60}
                                         margin={0}
                                         border={'none'}

--- a/src/editor/example/cancer-variant.ts
+++ b/src/editor/example/cancer-variant.ts
@@ -1,20 +1,25 @@
 import { GoslingSpec } from '../..';
+import { EX_SPEC_VIEW_PILEUP } from './pileup';
 
 export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
     title: 'Breast Cancer Variant (Staaf et al. 2019)',
     subtitle: 'Genetic characteristics of RAD51C- and PALB2-altered TNBCs',
-    // theme: { base: 'light', legend: { backgroundOpacity: 0, backgroundStroke: 'white' } },
     layout: 'linear',
     arrangement: 'vertical',
     centerRadius: 0.5,
     assembly: 'hg19',
     spacing: 40,
-    style: { outlineWidth: 1, outline: 'lightgray', enableSmoothPath: true },
+    style: {
+        outlineWidth: 1,
+        outline: 'lightgray',
+        enableSmoothPath: false
+    },
     views: [
         {
-            arrangement: 'horizontal',
+            arrangement: 'vertical',
             views: [
                 {
+                    xOffset: 400,
                     layout: 'circular',
                     spacing: 1,
                     tracks: [
@@ -62,18 +67,16 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                 genomicFields: ['ChrStart', 'ChrEnd']
                             },
                             dataTransform: [{ type: 'filter', field: 'Sample', oneOf: ['PD35930a'] }],
-                            tracks: [
-                                { mark: 'text' },
-                                {
-                                    mark: 'triangleBottom',
-                                    size: { value: 5 }
-                                }
-                            ],
+                            tracks: [{ mark: 'text' }, { mark: 'triangleBottom', size: { value: 5 } }],
                             x: { field: 'ChrStart', type: 'genomic' },
                             xe: { field: 'ChrEnd', type: 'genomic' },
                             text: { field: 'Gene', type: 'nominal' },
                             color: { value: 'black' },
-                            style: { textFontWeight: 'normal', dx: -10, outlineWidth: 0 },
+                            style: {
+                                textFontWeight: 'normal',
+                                dx: -10,
+                                outlineWidth: 0
+                            },
                             width: 500,
                             height: 40
                         },
@@ -110,8 +113,6 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
                             color: { value: '#FB6A4B' },
-                            // stroke: { value: '#444444' },
-                            // strokeWidth: { value: 0.6 },
                             width: 620,
                             height: 40
                         },
@@ -152,8 +153,6 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
                             color: { value: '#73C475' },
-                            // stroke: { value: 'black' },
-                            // strokeWidth: { value: 0.6 },
                             width: 500,
                             height: 40
                         },
@@ -202,6 +201,11 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                     layout: 'linear',
                     tracks: [
                         {
+                            style: {
+                                background: '#D7EBFF',
+                                outline: '#8DC1F2',
+                                outlineWidth: 5
+                            },
                             title: 'Ideogram',
                             alignment: 'overlay',
                             data: {
@@ -214,7 +218,14 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             tracks: [
                                 {
                                     mark: 'rect',
-                                    dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }]
+                                    dataTransform: [
+                                        {
+                                            type: 'filter',
+                                            field: 'Stain',
+                                            oneOf: ['acen'],
+                                            not: true
+                                        }
+                                    ]
                                 },
                                 {
                                     mark: 'triangleRight',
@@ -232,7 +243,14 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                 },
                                 {
                                     mark: 'text',
-                                    dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen'], not: true }],
+                                    dataTransform: [
+                                        {
+                                            type: 'filter',
+                                            field: 'Stain',
+                                            oneOf: ['acen'],
+                                            not: true
+                                        }
+                                    ],
                                     color: {
                                         field: 'Stain',
                                         type: 'nominal',
@@ -328,7 +346,11 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                     mark: 'triangleLeft',
                                     x: { field: 'start', type: 'genomic' },
                                     size: { value: 15 },
-                                    style: { align: 'right', outline: 'black', outlineWidth: 0 }
+                                    style: {
+                                        align: 'right',
+                                        outline: 'black',
+                                        outlineWidth: 0
+                                    }
                                 },
                                 {
                                     dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
@@ -382,12 +404,16 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                     opacity: { value: 0.3 }
                                 }
                             ],
-                            row: { field: 'strand', type: 'nominal', domain: ['+', '-'] },
+                            row: {
+                                field: 'strand',
+                                type: 'nominal',
+                                domain: ['+', '-']
+                            },
                             color: {
                                 field: 'strand',
                                 type: 'nominal',
                                 domain: ['+', '-'],
-                                range: ['blue', 'red']
+                                range: ['#97A8B2', '#D4C6BA'] //['blue', 'red']
                             },
                             visibility: [
                                 {
@@ -398,7 +424,7 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                     target: 'mark'
                                 }
                             ],
-                            opacity: { value: 0.4 },
+                            // opacity: { value: 0.4 },
                             width: 400,
                             height: 100
                         },
@@ -426,8 +452,6 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
                             color: { value: '#FB6A4B' },
-                            // stroke: { value: '#444444' },
-                            // strokeWidth: { value: 0.6 },
                             width: 620,
                             height: 20
                         },
@@ -461,8 +485,6 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             x: { field: 'start', type: 'genomic' },
                             xe: { field: 'end', type: 'genomic' },
                             color: { value: '#73C475' },
-                            // stroke: { value: 'black' },
-                            // strokeWidth: { value: 0.6 },
                             width: 500,
                             height: 20
                         },
@@ -517,389 +539,25 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             opacity: { value: 0.6 },
                             size: { value: 4 },
                             style: { legendTitle: 'SV Class', bazierLink: true },
-                            width: 800,
-                            height: 400
+                            width: 1000,
+                            height: 200
                         }
                     ]
                 }
-                // {
-                //     linkingId: 'mid-scale',
-                //     xDomain: { chromosome: '1' },
-                //     xAxis: 'bottom',
-                //     layout: 'linear',
-                //     spacing: 0,
-                //     tracks: [
-                //         {
-                //             title: 'Genomic Feature',
-                //             alignment: 'overlay',
-                //             data: {
-                //                 url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/rearrangement.PD35930a.csv',
-                //                 type: 'csv',
-                //                 genomicFieldsToConvert: [
-                //                     {
-                //                         chromosomeField: 'chr1',
-                //                         genomicFields: ['start1', 'end1']
-                //                     },
-                //                     {
-                //                         chromosomeField: 'chr2',
-                //                         genomicFields: ['start2', 'end2']
-                //                     }
-                //                 ]
-                //             },
-                //             tracks: [
-                //                 { mark: 'withinLink' },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-1' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-2' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 }
-                //             ],
-                //             x: { field: 'start1', type: 'genomic' },
-                //             xe: { field: 'end2', type: 'genomic' },
-                //             color: {
-                //                 field: 'svclass',
-                //                 type: 'nominal',
-                //                 legend: true,
-                //                 domain: ['translocation', 'delection', 'tandem-duplication', 'inversion']
-                //             },
-                //             stroke: {
-                //                 field: 'svclass',
-                //                 type: 'nominal',
-                //                 domain: ['translocation', 'delection', 'tandem-duplication', 'inversion']
-                //             },
-                //             style: {
-                //                 outline: 'lightgray',
-                //                 inlineLegend: true,
-                //                 bazierLink: true
-                //             },
-                //             strokeWidth: { value: 2.5 },
-                //             opacity: { value: 0.3 },
-                //             width: 400,
-                //             height: 250
-                //         },
-                //         {
-                //             title: 'LOH',
-                //             alignment: 'overlay',
-                //             data: {
-                //                 url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
-                //                 headerNames: [
-                //                     'id',
-                //                     'chr',
-                //                     'start',
-                //                     'end',
-                //                     'total_cn_normal',
-                //                     'minor_cp_normal',
-                //                     'total_cn_tumor',
-                //                     'minor_cn_tumor'
-                //                 ],
-                //                 type: 'csv',
-                //                 chromosomeField: 'chr',
-                //                 genomicFields: ['start', 'end']
-                //             },
-                //             dataTransform: [{ type: 'filter', field: 'minor_cn_tumor', oneOf: ['0'] }],
-                //             tracks: [
-                //                 { mark: 'rect' },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-1' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-2' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 }
-                //             ],
-                //             x: { field: 'start', type: 'genomic' },
-                //             xe: { field: 'end', type: 'genomic' },
-                //             color: { value: '#FD7E85' },
-                //             stroke: { value: 'lightgray' },
-                //             strokeWidth: { value: 0.3 },
-                //             style: { outline: 'lightgray' },
-                //             width: 620,
-                //             height: 20
-                //         },
-                //         {
-                //             title: 'Gain',
-                //             alignment: 'overlay',
-                //             data: {
-                //                 url: 'https://s3.amazonaws.com/gosling-lang.org/data/cancer/cnv.PD35930a.csv',
-                //                 headerNames: [
-                //                     'id',
-                //                     'chr',
-                //                     'start',
-                //                     'end',
-                //                     'total_cn_normal',
-                //                     'minor_cp_normal',
-                //                     'total_cn_tumor',
-                //                     'minor_cn_tumor'
-                //                 ],
-                //                 type: 'csv',
-                //                 chromosomeField: 'chr',
-                //                 genomicFields: ['start', 'end']
-                //             },
-                //             dataTransform: [
-                //                 {
-                //                     type: 'filter',
-                //                     field: 'total_cn_tumor',
-                //                     inRange: [4.5, 900]
-                //                 }
-                //             ],
-                //             tracks: [
-                //                 { mark: 'rect' },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-1' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-2' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 }
-                //             ],
-                //             x: { field: 'start', type: 'genomic' },
-                //             xe: { field: 'end', type: 'genomic' },
-                //             color: { value: '#DFFBBF' },
-                //             stroke: { value: 'lightgray' },
-                //             strokeWidth: { value: 0.3 },
-                //             style: { outline: 'lightgray' },
-                //             width: 500,
-                //             height: 20
-                //         },
-                //         {
-                //             alignment: 'overlay',
-                //             title: 'hg38 | Genes',
-                //             data: {
-                //                 url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
-                //                 type: 'beddb',
-                //                 genomicFields: [
-                //                     { index: 1, name: 'start' },
-                //                     { index: 2, name: 'end' }
-                //                 ],
-                //                 valueFields: [
-                //                     { index: 5, name: 'strand', type: 'nominal' },
-                //                     { index: 3, name: 'name', type: 'nominal' }
-                //                 ],
-                //                 exonIntervalFields: [
-                //                     { index: 12, name: 'start' },
-                //                     { index: 13, name: 'end' }
-                //                 ]
-                //             },
-                //             tracks: [
-                //                 {
-                //                     dataTransform: [
-                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
-                //                         { type: 'filter', field: 'strand', oneOf: ['+'] }
-                //                     ],
-                //                     mark: 'triangleRight',
-                //                     x: { field: 'end', type: 'genomic' },
-                //                     size: { value: 15 }
-                //                 },
-                //                 {
-                //                     dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
-                //                     mark: 'text',
-                //                     text: { field: 'name', type: 'nominal' },
-                //                     x: { field: 'start', type: 'genomic' },
-                //                     xe: { field: 'end', type: 'genomic' },
-                //                     style: { dy: -15, outline: 'black', outlineWidth: 0 }
-                //                 },
-                //                 {
-                //                     dataTransform: [
-                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
-                //                         { type: 'filter', field: 'strand', oneOf: ['-'] }
-                //                     ],
-                //                     mark: 'triangleLeft',
-                //                     x: { field: 'start', type: 'genomic' },
-                //                     size: { value: 15 },
-                //                     style: { align: 'right', outline: 'black', outlineWidth: 0 }
-                //                 },
-                //                 {
-                //                     dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
-                //                     mark: 'rect',
-                //                     x: { field: 'start', type: 'genomic' },
-                //                     size: { value: 15 },
-                //                     xe: { field: 'end', type: 'genomic' }
-                //                 },
-                //                 {
-                //                     dataTransform: [
-                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
-                //                         { type: 'filter', field: 'strand', oneOf: ['+'] }
-                //                     ],
-                //                     mark: 'rule',
-                //                     x: { field: 'start', type: 'genomic' },
-                //                     strokeWidth: { value: 2 },
-                //                     xe: { field: 'end', type: 'genomic' },
-                //                     style: {
-                //                         linePattern: { type: 'triangleRight', size: 3.5 },
-                //                         outline: 'black',
-                //                         outlineWidth: 0
-                //                     }
-                //                 },
-                //                 {
-                //                     dataTransform: [
-                //                         { type: 'filter', field: 'type', oneOf: ['gene'] },
-                //                         { type: 'filter', field: 'strand', oneOf: ['-'] }
-                //                     ],
-                //                     mark: 'rule',
-                //                     x: { field: 'start', type: 'genomic' },
-                //                     strokeWidth: { value: 2 },
-                //                     xe: { field: 'end', type: 'genomic' },
-                //                     style: {
-                //                         linePattern: { type: 'triangleLeft', size: 3.5 },
-                //                         outline: 'black',
-                //                         outlineWidth: 0
-                //                     }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-1' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' },
-                //                     opacity: { value: 0.3 }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-2' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' },
-                //                     opacity: { value: 0.3 }
-                //                 }
-                //             ],
-                //             row: { field: 'strand', type: 'nominal', domain: ['+', '-'] },
-                //             color: {
-                //                 field: 'strand',
-                //                 type: 'nominal',
-                //                 domain: ['+', '-'],
-                //                 range: ['gray', 'gray']
-                //             },
-                //             visibility: [
-                //                 {
-                //                     operation: 'less-than',
-                //                     measure: 'width',
-                //                     threshold: '|xe-x|',
-                //                     transitionPadding: 10,
-                //                     target: 'mark'
-                //                 }
-                //             ],
-                //             opacity: { value: 0.8 },
-                //             style: { background: '#F5F5F5', outline: 'lightgray' },
-                //             width: 400,
-                //             height: 100
-                //         },
-                //         {
-                //             alignment: 'overlay',
-                //             data: {
-                //                 url:
-                //                     'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
-                //                 type: 'csv',
-                //                 chromosomeField: 'Chromosome',
-                //                 genomicFields: ['chromStart', 'chromEnd']
-                //             },
-                //             tracks: [
-                //                 { mark: 'rect' },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-1' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 },
-                //                 {
-                //                     mark: 'brush',
-                //                     x: { linkingId: 'detail-2' },
-                //                     strokeWidth: { value: 0 },
-                //                     color: { value: 'gray' }
-                //                 }
-                //             ],
-                //             color: {
-                //                 field: 'Stain',
-                //                 type: 'nominal',
-                //                 domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
-                //                 range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
-                //             },
-                //             x: { field: 'chromStart', type: 'genomic', axis: 'bottom' },
-                //             xe: { field: 'chromEnd', type: 'genomic' },
-                //             opacity: { value: 0.3 },
-                //             width: 1000,
-                //             height: 20
-                //         }
-                //     ]
-                // }
+            ]
+        },
+        {
+            arrangement: 'horizontal',
+            spacing: 100,
+            views: [
+                {
+                    ...EX_SPEC_VIEW_PILEUP(450, 310, { chromosome: '1', interval: [205000, 207000] })
+                },
+                {
+                    ...EX_SPEC_VIEW_PILEUP(450, 310, { chromosome: '1', interval: [490000, 496000] })
+                }
             ]
         }
-        // {
-        //     arrangement: 'horizontal',
-        //     spacing: 90,
-        //     views: [
-        //         {
-        //             xDomain: { chromosome: '1', interval: [100000000, 110000000] },
-        //             linkingId: 'detail-1',
-        //             tracks: [
-        //                 {
-        //                     title: 'Reads Detail View 1 (To Be Added)',
-        //                     data: {
-        //                         url:
-        //                             'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
-        //                         type: 'csv',
-        //                         chromosomeField: 'Chromosome',
-        //                         genomicFields: ['chromStart', 'chromEnd']
-        //                     },
-        //                     mark: 'rect',
-        //                     color: {
-        //                         field: 'Stain',
-        //                         type: 'nominal',
-        //                         domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
-        //                         range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
-        //                     },
-        //                     x: { field: 'chromStart', type: 'genomic' },
-        //                     xe: { field: 'chromEnd', type: 'genomic' },
-        //                     opacity: { value: 0.3 },
-        //                     width: 452,
-        //                     height: 100
-        //                 }
-        //             ]
-        //         },
-        //         {
-        //             linkingId: 'detail-2',
-        //             xDomain: { chromosome: '1', interval: [240000000, 250000000] },
-        //             tracks: [
-        //                 {
-        //                     title: 'Reads Detail View 2 (To Be Added)',
-        //                     data: {
-        //                         url:
-        //                             'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
-        //                         type: 'csv',
-        //                         chromosomeField: 'Chromosome',
-        //                         genomicFields: ['chromStart', 'chromEnd']
-        //                     },
-        //                     mark: 'rect',
-        //                     color: {
-        //                         field: 'Stain',
-        //                         type: 'nominal',
-        //                         domain: ['gneg', 'gpos25', 'gpos50', 'gpos75', 'gpos100', 'gvar', 'acen'],
-        //                         range: ['#C0C0C0', '#808080', '#404040', 'black', 'black', 'black', '#B74780']
-        //                     },
-        //                     x: { field: 'chromStart', type: 'genomic' },
-        //                     xe: { field: 'chromEnd', type: 'genomic' },
-        //                     opacity: { value: 0.3 },
-        //                     width: 452,
-        //                     height: 100
-        //                 }
-        //             ]
-        //         }
-        //     ]
-        // }
     ]
 };
 

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -138,14 +138,14 @@ export const examples: ReadonlyArray<{
         name: 'Breast Cancer Variant (Staaf et al. 2019)',
         id: 'CANCER_VARIANT',
         spec: EX_SPEC_CANCER_VARIANT_PROTOTYPE,
-        underDevelopment: true
+        underDevelopment: true,
+        forceShow: true
     },
     {
         name: 'BAM file pileup tracks',
         id: 'BAM_PILEUP',
         spec: EX_SPEC_PILEUP,
-        underDevelopment: true,
-        forceShow: true
+        underDevelopment: true
     }
     // {
     //     name: 'Dark Theme (Beta)',

--- a/src/editor/example/index.ts
+++ b/src/editor/example/index.ts
@@ -144,7 +144,8 @@ export const examples: ReadonlyArray<{
         name: 'BAM file pileup tracks',
         id: 'BAM_PILEUP',
         spec: EX_SPEC_PILEUP,
-        underDevelopment: true
+        underDevelopment: true,
+        forceShow: true
     }
     // {
     //     name: 'Dark Theme (Beta)',

--- a/src/editor/example/pileup.ts
+++ b/src/editor/example/pileup.ts
@@ -1,109 +1,239 @@
-import { GoslingSpec } from '../../core/gosling.schema';
+import { Domain, DomainGene, GoslingSpec, View } from '../../core/gosling.schema';
 import { EX_TRACK_SEMANTIC_ZOOM } from './semantic-zoom';
+
+export function EX_SPEC_VIEW_PILEUP(
+    width: number,
+    height: number,
+    xDomain: Exclude<Domain, string[] | number[] | DomainGene>,
+    strandColor?: [number, number]
+): View {
+    return {
+        static: false,
+        layout: 'linear',
+        centerRadius: 0.05,
+        xDomain: xDomain,
+        spacing: 0.01,
+        tracks: [
+            {
+                title: 'Coverage',
+                // prerelease: { testUsingNewRectRenderingForBAM: true },
+                data: {
+                    type: 'bam',
+                    // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
+                    url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam'
+                },
+                dataTransform: [{ type: 'coverage', startField: 'from', endField: 'to' }],
+                mark: 'bar',
+                x: { field: 'from', type: 'genomic' },
+                xe: { field: 'to', type: 'genomic' },
+                y: { field: 'coverage', type: 'quantitative', axis: 'right', grid: true },
+                color: { value: 'lightgray' },
+                stroke: { value: 'gray' },
+                width,
+                height: 80
+            },
+            {
+                alignment: 'overlay',
+                title: 'hg38 | Genes',
+                data: {
+                    url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
+                    type: 'beddb',
+                    genomicFields: [
+                        { index: 1, name: 'start' },
+                        { index: 2, name: 'end' }
+                    ],
+                    valueFields: [
+                        { index: 5, name: 'strand', type: 'nominal' },
+                        { index: 3, name: 'name', type: 'nominal' }
+                    ],
+                    exonIntervalFields: [
+                        { index: 12, name: 'start' },
+                        { index: 13, name: 'end' }
+                    ]
+                },
+                tracks: [
+                    {
+                        dataTransform: [
+                            { type: 'filter', field: 'type', oneOf: ['gene'] },
+                            { type: 'filter', field: 'strand', oneOf: ['+'] }
+                        ],
+                        mark: 'triangleRight',
+                        x: { field: 'end', type: 'genomic' },
+                        size: { value: 15 }
+                    },
+                    {
+                        dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
+                        mark: 'text',
+                        text: { field: 'name', type: 'nominal' },
+                        x: { field: 'start', type: 'genomic' },
+                        xe: { field: 'end', type: 'genomic' },
+                        style: { dy: -15, outline: 'black', outlineWidth: 0 }
+                    },
+                    {
+                        dataTransform: [
+                            { type: 'filter', field: 'type', oneOf: ['gene'] },
+                            { type: 'filter', field: 'strand', oneOf: ['-'] }
+                        ],
+                        mark: 'triangleLeft',
+                        x: { field: 'start', type: 'genomic' },
+                        size: { value: 15 },
+                        style: {
+                            align: 'right',
+                            outline: 'black',
+                            outlineWidth: 0
+                        }
+                    },
+                    {
+                        dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
+                        mark: 'rect',
+                        x: { field: 'start', type: 'genomic' },
+                        size: { value: 15 },
+                        xe: { field: 'end', type: 'genomic' }
+                    },
+                    {
+                        dataTransform: [
+                            { type: 'filter', field: 'type', oneOf: ['gene'] },
+                            { type: 'filter', field: 'strand', oneOf: ['+'] }
+                        ],
+                        mark: 'rule',
+                        x: { field: 'start', type: 'genomic' },
+                        strokeWidth: { value: 2 },
+                        xe: { field: 'end', type: 'genomic' },
+                        style: {
+                            linePattern: { type: 'triangleRight', size: 3.5 },
+                            outline: 'black',
+                            outlineWidth: 0
+                        }
+                    },
+                    {
+                        dataTransform: [
+                            { type: 'filter', field: 'type', oneOf: ['gene'] },
+                            { type: 'filter', field: 'strand', oneOf: ['-'] }
+                        ],
+                        mark: 'rule',
+                        x: { field: 'start', type: 'genomic' },
+                        strokeWidth: { value: 2 },
+                        xe: { field: 'end', type: 'genomic' },
+                        style: {
+                            linePattern: { type: 'triangleLeft', size: 3.5 },
+                            outline: 'black',
+                            outlineWidth: 0
+                        }
+                    }
+                ],
+                row: {
+                    field: 'strand',
+                    type: 'nominal',
+                    domain: ['+', '-']
+                },
+                color: {
+                    field: 'strand',
+                    type: 'nominal',
+                    domain: ['+', '-'],
+                    range: ['#97A8B2', '#D4C6BA'] //['blue', 'red']
+                },
+                visibility: [
+                    {
+                        operation: 'less-than',
+                        measure: 'width',
+                        threshold: '|xe-x|',
+                        transitionPadding: 10,
+                        target: 'mark'
+                    }
+                ],
+                // opacity: { value: 0.4 },
+                width,
+                height: 100
+            },
+            {
+                title: 'Sequence',
+                ...EX_TRACK_SEMANTIC_ZOOM.sequence,
+                style: { inlineLegend: true, textStrokeWidth: 0, outline: 'white' },
+                width,
+                height: 40
+            },
+            {
+                alignment: 'overlay',
+                title: 'Reads',
+                // prerelease: { testUsingNewRectRenderingForBAM: true },
+                data: {
+                    type: 'bam',
+                    // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
+                    url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam'
+                },
+                mark: 'rect',
+                tracks: [
+                    {
+                        dataTransform: [
+                            {
+                                type: 'displace',
+                                method: 'pile',
+                                boundingBox: {
+                                    startField: 'from',
+                                    endField: 'to',
+                                    groupField: 'strand',
+                                    padding: 5,
+                                    isPaddingBP: true
+                                },
+                                newField: 'pileup-row'
+                            }
+                        ],
+                        x: { field: 'from', type: 'genomic' },
+                        xe: { field: 'to', type: 'genomic' },
+                        stroke: { value: 'white' },
+                        strokeWidth: { value: 0.5 }
+                    },
+                    {
+                        dataTransform: [
+                            {
+                                type: 'displace',
+                                method: 'pile',
+                                boundingBox: {
+                                    startField: 'from',
+                                    endField: 'to',
+                                    groupField: 'strand',
+                                    padding: 5,
+                                    isPaddingBP: true
+                                },
+                                newField: 'pileup-row'
+                            },
+                            {
+                                type: 'subjson',
+                                field: 'substitutions',
+                                genomicField: 'pos',
+                                baseGenomicField: 'from',
+                                genomicLengthField: 'length'
+                            },
+                            { type: 'filter', field: 'type', oneOf: ['sub'] }
+                        ],
+                        x: { field: 'pos_start', type: 'genomic' },
+                        xe: { field: 'pos_end', type: 'genomic' },
+                        color: {
+                            field: 'variant',
+                            type: 'nominal',
+                            domain: ['A', 'T', 'G', 'C', 'S', 'H', 'X', 'I', 'D'],
+                            legend: true
+                        }
+                    }
+                ],
+                y: { field: 'pileup-row', type: 'nominal', flip: true },
+                row: { field: 'strand', type: 'nominal', domain: ['+', '-'], padding: 1 },
+                color: {
+                    field: 'strand',
+                    type: 'nominal',
+                    domain: ['+', '-'],
+                    range: strandColor ?? ['#97A8B2', '#D4C6BA']
+                },
+                style: { outlineWidth: 0.5 },
+                width,
+                height
+            }
+        ]
+    };
+}
 
 export const EX_SPEC_PILEUP: GoslingSpec = {
     title: 'Pileup Track Using BAM Data',
     subtitle: '',
-    static: false,
-    layout: 'linear',
-    centerRadius: 0.05,
-    xDomain: { chromosome: '1', interval: [136750, 139450] },
-    spacing: 0.01,
-    tracks: [
-        {
-            title: 'Coverage',
-            // prerelease: { testUsingNewRectRenderingForBAM: true },
-            data: {
-                type: 'bam',
-                // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
-                url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam'
-            },
-            dataTransform: [{ type: 'coverage', startField: 'from', endField: 'to' }],
-            mark: 'bar',
-            x: { field: 'from', type: 'genomic' },
-            xe: { field: 'to', type: 'genomic' },
-            y: { field: 'coverage', type: 'quantitative', axis: 'right', grid: true },
-            color: { value: 'lightgray' },
-            stroke: { value: 'gray' },
-            width: 650,
-            height: 80
-        },
-        {
-            ...EX_TRACK_SEMANTIC_ZOOM.sequence,
-            style: { inlineLegend: true, textStrokeWidth: 0, outline: 'white' },
-            width: 800,
-            height: 40
-        },
-        {
-            alignment: 'overlay',
-            title: 'Reads',
-            // prerelease: { testUsingNewRectRenderingForBAM: true },
-            data: {
-                type: 'bam',
-                // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
-                url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam'
-            },
-            mark: 'rect',
-            tracks: [
-                {
-                    dataTransform: [
-                        {
-                            type: 'displace',
-                            method: 'pile',
-                            boundingBox: {
-                                startField: 'from',
-                                endField: 'to',
-                                groupField: 'strand',
-                                padding: 5,
-                                isPaddingBP: true
-                            },
-                            newField: 'pileup-row'
-                        }
-                    ],
-                    x: { field: 'from', type: 'genomic' },
-                    xe: { field: 'to', type: 'genomic' },
-                    stroke: { value: 'gray' },
-                    strokeWidth: { value: 0.5 }
-                },
-                {
-                    dataTransform: [
-                        {
-                            type: 'displace',
-                            method: 'pile',
-                            boundingBox: {
-                                startField: 'from',
-                                endField: 'to',
-                                groupField: 'strand',
-                                padding: 5,
-                                isPaddingBP: true
-                            },
-                            newField: 'pileup-row'
-                        },
-                        {
-                            type: 'subjson',
-                            field: 'substitutions',
-                            genomicField: 'pos',
-                            baseGenomicField: 'from',
-                            genomicLengthField: 'length'
-                        },
-                        { type: 'filter', field: 'type', oneOf: ['sub'] }
-                    ],
-                    x: { field: 'pos_start', type: 'genomic' },
-                    xe: { field: 'pos_end', type: 'genomic' },
-                    color: {
-                        field: 'variant',
-                        type: 'nominal',
-                        domain: ['A', 'T', 'G', 'C', 'S', 'H', 'X', 'I', 'D'],
-                        legend: true
-                    }
-                }
-            ],
-            y: { field: 'pileup-row', type: 'nominal', flip: true },
-            row: { field: 'strand', type: 'nominal', domain: ['+', '-'], padding: 1 },
-            color: { field: 'strand', type: 'nominal', domain: ['+', '-'], range: ['#97A8B2', '#D4C6BA'] },
-            style: { outlineWidth: 0.5 },
-            width: 1250,
-            height: 650
-        }
-    ]
+    ...EX_SPEC_VIEW_PILEUP(1250, 600, { chromosome: '1', interval: [136750, 139450] })
 };

--- a/src/editor/example/pileup.ts
+++ b/src/editor/example/pileup.ts
@@ -11,14 +11,8 @@ export const EX_SPEC_PILEUP: GoslingSpec = {
     spacing: 0.01,
     tracks: [
         {
-            ...EX_TRACK_SEMANTIC_ZOOM.sequence,
-            style: { inlineLegend: true, textStrokeWidth: 0, outline: 'white' },
-            width: 800,
-            height: 40
-        },
-        {
             title: 'Coverage',
-            prerelease: { testUsingNewRectRenderingForBAM: true },
+            // prerelease: { testUsingNewRectRenderingForBAM: true },
             data: {
                 type: 'bam',
                 // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
@@ -28,16 +22,22 @@ export const EX_SPEC_PILEUP: GoslingSpec = {
             mark: 'bar',
             x: { field: 'from', type: 'genomic' },
             xe: { field: 'to', type: 'genomic' },
-            y: { field: 'coverage', type: 'quantitative' },
+            y: { field: 'coverage', type: 'quantitative', axis: 'right', grid: true },
             color: { value: 'lightgray' },
             stroke: { value: 'gray' },
             width: 650,
             height: 80
         },
         {
+            ...EX_TRACK_SEMANTIC_ZOOM.sequence,
+            style: { inlineLegend: true, textStrokeWidth: 0, outline: 'white' },
+            width: 800,
+            height: 40
+        },
+        {
             alignment: 'overlay',
             title: 'Reads',
-            prerelease: { testUsingNewRectRenderingForBAM: true },
+            // prerelease: { testUsingNewRectRenderingForBAM: true },
             data: {
                 type: 'bam',
                 // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
@@ -62,8 +62,8 @@ export const EX_SPEC_PILEUP: GoslingSpec = {
                     ],
                     x: { field: 'from', type: 'genomic' },
                     xe: { field: 'to', type: 'genomic' },
-                    stroke: { value: 'gray' }
-                    // strokeWidth: { value: 0.5 },
+                    stroke: { value: 'gray' },
+                    strokeWidth: { value: 0.5 }
                 },
                 {
                     dataTransform: [


### PR DESCRIPTION
This PR removes the worker renderer to unify the rendering process for all data formats including BAM. Previously, we only allowed linear `rect` marks with the worker which limited the expressivity with BAM files. For the performance, this PR load BAM files with smaller genomic regions, but allows more expressive rendering.

# Screenshots

![Screen Shot 2021-07-30 at 12 14 55 PM](https://user-images.githubusercontent.com/9922882/127682009-b1d8dbc2-2e70-4d45-95fc-bc9039b56f4b.png)