### PR TITLE
feat(api): getCanvas()

### DIFF
--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -120,6 +120,41 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     });
                     return ids;
                 },
+                getCanvas: (options: { resolution: number; transparentBackground: boolean }) => {
+                    const resolution = options?.resolution ?? 4;
+                    const transparentBackground = options?.transparentBackground ?? false;
+
+                    const renderer = hgRef.current.pixiRenderer;
+                    const renderTexture = PIXI.RenderTexture.create({
+                        width: renderer.width / 2,
+                        height: renderer.height / 2,
+                        resolution
+                    });
+
+                    renderer.render(hgRef.current.pixiStage, renderTexture);
+
+                    const canvas = renderer.plugins.extract.canvas(renderTexture);
+
+                    // Set background color for the given theme in the gosling spec
+                    // Otherwise, it is transparent
+                    const canvasWithBg = document.createElement('canvas') as HTMLCanvasElement;
+                    canvasWithBg.width = canvas.width;
+                    canvasWithBg.height = canvas.height;
+
+                    const ctx = canvasWithBg.getContext('2d')!;
+                    if (!transparentBackground) {
+                        ctx.fillStyle = theme.root.background;
+                        ctx.fillRect(0, 0, canvasWithBg.width, canvasWithBg.height);
+                    }
+                    ctx.drawImage(canvas, 0, 0);
+
+                    return {
+                        canvas: canvasWithBg,
+                        resolution,
+                        canvasWidth: canvas.width,
+                        canvasHeight: canvas.height
+                    };
+                },
                 exportPNG: (transparentBackground?: boolean) => {
                     const renderer = hgRef.current.pixiRenderer;
                     const renderTexture = PIXI.RenderTexture.create({

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -156,31 +156,9 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     };
                 },
                 exportPNG: (transparentBackground?: boolean) => {
-                    const renderer = hgRef.current.pixiRenderer;
-                    const renderTexture = PIXI.RenderTexture.create({
-                        width: renderer.width / 2,
-                        height: renderer.height / 2,
-                        resolution: 4
-                    });
+                    const { canvas } = ref.current.api.getCanvas({ resolution: 4, transparentBackground });
 
-                    renderer.render(hgRef.current.pixiStage, renderTexture);
-
-                    const canvas = renderer.plugins.extract.canvas(renderTexture);
-
-                    // Set background color for the given theme in the gosling spec
-                    // Otherwise, it is transparent
-                    const canvasWithBg = document.createElement('canvas') as HTMLCanvasElement;
-                    canvasWithBg.width = canvas.width;
-                    canvasWithBg.height = canvas.height;
-
-                    const ctx = canvasWithBg.getContext('2d')!;
-                    if (!transparentBackground) {
-                        ctx.fillStyle = theme.root.background;
-                        ctx.fillRect(0, 0, canvasWithBg.width, canvasWithBg.height);
-                    }
-                    ctx.drawImage(canvas, 0, 0);
-
-                    canvasWithBg.toBlob((blob: any) => {
+                    canvas.toBlob((blob: any) => {
                         const a = document.createElement('a');
 
                         document.body.append(a);
@@ -193,32 +171,9 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     }, 'image/png');
                 },
                 exportPDF: (transparentBackground?: boolean) => {
-                    const resolution = 4;
-                    const renderer = hgRef.current.pixiRenderer;
-                    const renderTexture = PIXI.RenderTexture.create({
-                        width: renderer.width / 2,
-                        height: renderer.height / 2,
-                        resolution
-                    });
+                    const { canvas } = ref.current.api.getCanvas({ resolution: 4, transparentBackground });
 
-                    renderer.render(hgRef.current.pixiStage, renderTexture);
-
-                    const canvas = renderer.plugins.extract.canvas(renderTexture);
-
-                    // Set background color for the given theme in the gosling spec
-                    // Otherwise, it is transparent
-                    const canvasWithBg = document.createElement('canvas') as HTMLCanvasElement;
-                    canvasWithBg.width = canvas.width;
-                    canvasWithBg.height = canvas.height;
-
-                    const ctx = canvasWithBg.getContext('2d')!;
-                    if (!transparentBackground) {
-                        ctx.fillStyle = theme.root.background;
-                        ctx.fillRect(0, 0, canvasWithBg.width, canvasWithBg.height);
-                    }
-                    ctx.drawImage(canvas, 0, 0);
-
-                    const imgData = canvasWithBg.toDataURL('image/jpeg', 1);
+                    const imgData = canvas.toDataURL('image/jpeg', 1);
 
                     const pdf = new jsPDF({
                         orientation: canvas.width < canvas.height ? 'p' : 'l',

--- a/src/editor/editor.tsx
+++ b/src/editor/editor.tsx
@@ -398,10 +398,20 @@ function Editor(props: any) {
                     if (!gosRef.current) return;
 
                     // To test APIs, uncomment the following code.
-                    // ! Be aware that the first view is for the title/subtitle track. So navigation API does not work.
+                    // // ! Be aware that the first view is for the title/subtitle track. So navigation API does not work.
                     // const id = gosRef.current.api.getViewIds()?.[1]; //'view-1';
                     // if(id) {
                     //     gosRef.current.api.zoomToExtent(id);
+                    // }
+                    //
+                    // // Static visualization rendered in canvas
+                    // const { canvas } = gosRef.current.api.getCanvas({
+                    //     resolution: 1,
+                    //     transparentBackground: true,
+                    // });
+                    // const testDiv = document.getElementById('preview-container');
+                    // if(canvas && testDiv) {
+                    //     testDiv.appendChild(canvas);
                     // }
                 }}
             >
@@ -698,7 +708,10 @@ function Editor(props: any) {
                                 size={isShowDataPreview ? '40%' : `calc(100% - ${BOTTOM_PANEL_HEADER_HEIGHT}px)`}
                                 maxSize={window.innerHeight - EDITOR_HEADER_HEIGHT - BOTTOM_PANEL_HEADER_HEIGHT}
                             >
-                                <div className={`preview-container ${theme === 'dark' ? 'dark' : ''}`}>
+                                <div
+                                    id="preview-container"
+                                    className={`preview-container ${theme === 'dark' ? 'dark' : ''}`}
+                                >
                                     <gosling.GoslingComponent
                                         ref={gosRef}
                                         spec={goslingSpec}


### PR DESCRIPTION
This PR adds a public API that provides a canvas (`HTMLCanvasElement`) that displays a static gosling visualization (Fix #449):

```js
const { 
   canvas, 
   resolution, 
   width, 
   height 
} = gosRef.current.api.getCanvas({ 
   resolution: 1, // default: 4
   transparentBackground: true // default: false
});
```

An example can be found on the following line of code: https://github.com/gosling-lang/gosling.js/blob/57649bca8531c9d995e4457dfcb9ce808a8bf21b/src/editor/editor.tsx#L407