### PR TITLE
chore: expose react component instance api; add types

### DIFF
--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -50,7 +50,6 @@ interface GoslingCompProps {
     templates?: TemplateTrackDef[];
 }
 
-// TODO: specify types other than "any"
 export const GoslingComponent = forwardRef<{ api: GoslingComponentApi }, GoslingCompProps>((props, ref) => {
     // Gosling and HiGlass specs
     const [gs, setGs] = useState<gosling.GoslingSpec | undefined>(props.spec);

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -19,6 +19,25 @@ import { GoslingTemplates } from '..';
  */
 gosling.init();
 
+export interface GoslingComponentApi {
+    on: (type: EVENT_TYPE, callback: MouseHoverCallback) => void;
+    zoomTo: (viewId: string, position: string, duration?: number) => void;
+    zoomToExtent: (viewId: string, duration?: number) => void;
+    zoomToGene: (viewId: string, gene: string, duration?: number) => void;
+    getViewIds: () => string[];
+    exportPNG: (transparentBackground?: boolean) => void;
+    exportPDF: (transparentBackground?: boolean) => void;
+    getCanvas: (options?: {
+        resolution?: number;
+        transparentBackground?: boolean;
+    }) => {
+        canvas: HTMLCanvasElement;
+        canvasWidth: number;
+        canvasHeight: number;
+        resolution: number;
+    };
+}
+
 interface GoslingCompProps {
     spec?: gosling.GoslingSpec;
     compiled?: (goslingSpec: gosling.GoslingSpec, higlassSpec: gosling.HiGlassSpec) => void;
@@ -32,7 +51,7 @@ interface GoslingCompProps {
 }
 
 // TODO: specify types other than "any"
-export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) => {
+export const GoslingComponent = forwardRef<{ api: GoslingComponentApi }, GoslingCompProps>((props, ref) => {
     // Gosling and HiGlass specs
     const [gs, setGs] = useState<gosling.GoslingSpec | undefined>(props.spec);
     const [hs, setHs] = useState<gosling.HiGlassSpec>();
@@ -75,15 +94,16 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
 
     // HiGlassMeta APIs that can be called outside the library.
     useEffect(() => {
-        if (!ref) return;
+        // Must be React.MutableRefObj<T>
+        if (!ref || !('current' in ref)) return;
 
         ref.current = {
             api: {
-                on: (type: EVENT_TYPE, callback: MouseHoverCallback) => {
+                on: (type, callback) => {
                     userDefinedEvents.current[type] = callback;
                 },
                 // TODO: Support assemblies (we can infer this from the spec)
-                zoomTo: (viewId: string, position: string, duration = 1000) => {
+                zoomTo: (viewId, position, duration = 1000) => {
                     // Accepted input: 'chr1' or 'chr1:1-1000'
                     if (!position.includes('chr')) {
                         console.warn('Genomic interval you entered is not in a correct form.');
@@ -105,7 +125,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     hgRef?.current?.api?.zoomTo(viewId, start, end, start, end, duration);
                 },
                 // TODO: Support assemblies (we can infer this from the spec)
-                zoomToExtent: (viewId: string, duration = 1000) => {
+                zoomToExtent: (viewId, duration = 1000) => {
                     const [start, end] = [0, GET_CHROM_SIZES().total];
                     hgRef?.current?.api?.zoomTo(viewId, start, end, start, end, duration);
                 },
@@ -120,7 +140,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     });
                     return ids;
                 },
-                getCanvas: (options: { resolution: number; transparentBackground: boolean }) => {
+                getCanvas: options => {
                     const resolution = options?.resolution ?? 4;
                     const transparentBackground = options?.transparentBackground ?? false;
 
@@ -156,7 +176,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     };
                 },
                 exportPNG: (transparentBackground?: boolean) => {
-                    const { canvas } = ref.current.api.getCanvas({ resolution: 4, transparentBackground });
+                    const { canvas } = ref.current!.api.getCanvas({ resolution: 4, transparentBackground });
 
                     canvas.toBlob((blob: any) => {
                         const a = document.createElement('a');
@@ -171,7 +191,7 @@ export const GoslingComponent = forwardRef((props: GoslingCompProps, ref: any) =
                     }, 'image/png');
                 },
                 exportPDF: (transparentBackground?: boolean) => {
-                    const { canvas } = ref.current.api.getCanvas({ resolution: 4, transparentBackground });
+                    const { canvas } = ref.current!.api.getCanvas({ resolution: 4, transparentBackground });
 
                     const imgData = canvas.toDataURL('image/jpeg', 1);
 

--- a/src/core/gosling-embed.tsx
+++ b/src/core/gosling-embed.tsx
@@ -22,7 +22,7 @@ export function embed(
         className?: string;
         theme?: Theme;
     }
-) {
+): Promise<GoslingComponentApi> {
     const ref = React.createRef<{ api: GoslingComponentApi }>();
     return new Promise((resolve, reject) => {
         ReactDOM.render(React.createElement(GoslingComponent, { ref, spec, ...options }), element, () => {

--- a/src/core/gosling-embed.tsx
+++ b/src/core/gosling-embed.tsx
@@ -4,7 +4,7 @@ import { Theme } from '..';
 import { GoslingComponent, GoslingComponentApi } from './gosling-component';
 import { GoslingSpec } from './gosling.schema';
 
-const MAX_TRIES = 1000;
+const MAX_TRIES = 120;
 
 /**
  * Embed a Gosling component to a given HTMLElement.


### PR DESCRIPTION
Inspired from some of the work in `ipygosling`...

Adds stronger types for the forwarded `ref` that `GoslingComponent` accepts as a prop. Since `embed` is likely meant to be called in a non-React context, the function now returns a promise for the `GoslingComponentAPI` after `GoslingComponent` has been rendered and after `ref.current` is set to the API.

```javascript
import { embed } from 'gosling.js';

embed(/* ... */)
	.then(api => {
      // do something with the API
	})
    .catch(err => {
      // handle error
    })

```