### PR TITLE
chore: use the same default opacity of track title background between layouts

### DIFF
--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -73,7 +73,6 @@ export function goslingToHiGlass(
                 mousePositionColor: theme.root.mousePositionColor,
                 /* Track title */
                 name: firstResolvedSpec.layout === 'linear' ? firstResolvedSpec.title : ' ',
-                fontSize: theme.track.titleFontSize, // does not seem to be used?
                 labelPosition: firstResolvedSpec.title
                     ? theme.track.titleAlign === 'left'
                         ? 'topLeft'

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -73,8 +73,7 @@ export function goslingToHiGlass(
                 mousePositionColor: theme.root.mousePositionColor,
                 /* Track title */
                 name: firstResolvedSpec.layout === 'linear' ? firstResolvedSpec.title : ' ',
-                fontSize: theme.track.titleFontSize,
-                labelTextFontSize: theme.track.titleFontSize,
+                fontSize: theme.track.titleFontSize, // does not seem to be used?
                 labelPosition: firstResolvedSpec.title
                     ? theme.track.titleAlign === 'left'
                         ? 'topLeft'

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -74,6 +74,7 @@ export function goslingToHiGlass(
                 /* Track title */
                 name: firstResolvedSpec.layout === 'linear' ? firstResolvedSpec.title : ' ',
                 fontSize: theme.track.titleFontSize,
+                labelTextFontSize: theme.track.titleFontSize,
                 labelPosition: firstResolvedSpec.title
                     ? theme.track.titleAlign === 'left'
                         ? 'topLeft'
@@ -82,6 +83,7 @@ export function goslingToHiGlass(
                 labelShowResolution: false,
                 labelColor: theme.track.titleColor,
                 labelBackgroundColor: theme.track.titleBackground,
+                labelBackgroundOpacity: 0.5, // TODO: Support `theme.track.titleBackgroundOpacity`
                 labelTextOpacity: 1,
                 labelLeftMargin: 1,
                 labelTopMargin: 1,

--- a/src/core/mark/title.ts
+++ b/src/core/mark/title.ts
@@ -47,7 +47,7 @@ export function drawCircularTitle(
     /* Title label */
     const styleConfig = getTextStyle({
         color: theme.track.titleColor,
-        size: theme.axis.labelFontSize, // `theme.track.titleFontSize` seems to use much larger fonts
+        size: 12, // `theme.track.titleFontSize` seems to use much larger fonts
         fontFamily: theme.axis.labelFontFamily, // TODO: support
         fontWeight: theme.axis.labelFontWeight // TODO: support
     });

--- a/src/core/mark/title.ts
+++ b/src/core/mark/title.ts
@@ -78,7 +78,7 @@ export function drawCircularTitle(
     const endRad = valueToRadian(scaledEndX + padding, tw, startAngle, endAngle);
 
     g.lineStyle(1, colorToHex('red'), 0, 0.5);
-    g.beginFill(colorToHex(theme.track.titleBackground), 0.8); // override the opacity
+    g.beginFill(colorToHex(theme.track.titleBackground), 0.5); // TODO: support `theme.track.titleBackgroundOpacity`
     g.moveTo(pos.x, pos.y);
     g.arc(cx, cy, titleR - metric.height, startRad, endRad, true);
     g.arc(cx, cy, titleR, endRad, startRad, false);


### PR DESCRIPTION
In HiGlass, the default background opacity is defined here:
https://github.com/higlass/higlass/blob/54f5aae61d3474f9e868621228270f0c90ef9343/app/scripts/PixiTrack.js#L337