### PR TITLE
fix: accurately fetch data when `data` and/or `dataTransform` is defined in individual tracks that are overlaid

### DIFF
--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -98,29 +98,29 @@ export function goslingToHiGlass(
         };
 
         if (
-            gosTrack.data &&
-            IsDataDeep(gosTrack.data) &&
-            (gosTrack.data.type === 'csv' ||
-                gosTrack.data.type === 'json' ||
-                gosTrack.data.type === 'bigwig' ||
-                gosTrack.data.type === 'bam')
+            firstResolvedSpec.data &&
+            IsDataDeep(firstResolvedSpec.data) &&
+            (firstResolvedSpec.data.type === 'csv' ||
+                firstResolvedSpec.data.type === 'json' ||
+                firstResolvedSpec.data.type === 'bigwig' ||
+                firstResolvedSpec.data.type === 'bam')
         ) {
             // use gosling's custom data fetchers
             hgTrack.data = {
-                ...gosTrack.data,
+                ...firstResolvedSpec.data,
                 // Additionally, add assembly, otherwise, a default genome build is used
                 assembly,
                 // Add a data transformation spec so that the fetcher can properly sample datasets
-                filter: (gosTrack as any).dataTransform?.filter((f: DataTransform) => f.type === 'filter')
+                filter: (firstResolvedSpec as any).dataTransform?.filter((f: DataTransform) => f.type === 'filter')
             };
         }
 
-        const isMatrix = gosTrack.data?.type === 'matrix';
+        const isMatrix = firstResolvedSpec.data?.type === 'matrix';
         if (isMatrix) {
             // Use HiGlass' heatmap track for matrix data
             hgTrack.type = 'heatmap';
             hgTrack.options.colorRange =
-                (gosTrack as any)?.color.range === 'warm'
+                (firstResolvedSpec as any)?.color.range === 'warm'
                     ? ['white', 'rgba(245,166,35,1.0)', 'rgba(208,2,27,1.0)', 'black']
                     : viridisColorMap;
             hgTrack.options.trackBorderWidth = 1;
@@ -128,17 +128,17 @@ export function goslingToHiGlass(
             hgTrack.options.colorbarPosition = (firstResolvedSpec.color as any)?.legend ? 'topRight' : 'hidden';
         }
 
-        if (gosTrack.overlayOnPreviousTrack) {
+        if (firstResolvedSpec.overlayOnPreviousTrack) {
             hgModel
-                .setViewOrientation(gosTrack.orientation) // TODO: Orientation should be assigned to 'individual' views
+                .setViewOrientation(firstResolvedSpec.orientation) // TODO: Orientation should be assigned to 'individual' views
                 .addTrackToCombined(hgTrack);
         } else {
             hgModel
-                .setViewOrientation(gosTrack.orientation) // TODO: Orientation should be assigned to 'individual' views
+                .setViewOrientation(firstResolvedSpec.orientation) // TODO: Orientation should be assigned to 'individual' views
                 .setAssembly(assembly) // TODO: Assembly should be assigned to 'individual' views
-                .addDefaultView(gosTrack.id ?? uuid.v1(), assembly)
+                .addDefaultView(firstResolvedSpec.id ?? uuid.v1(), assembly)
                 .setDomain(xDomain, Is2DTrack(firstResolvedSpec) ? yDomain : xDomain)
-                .adjustDomain(gosTrack.orientation, width, height)
+                .adjustDomain(firstResolvedSpec.orientation, width, height)
                 .setMainTrack(hgTrack)
                 .addTrackSourceServers(server)
                 .setZoomFixed(firstResolvedSpec.static === true)

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -205,6 +205,7 @@ export type DisplacementType = 'pile' | 'spread';
  */
 export type OverlaidTrack = Partial<SingleTrack> &
     CommonRequiredTrackDef & {
+        // This is a property internally used when compiling
         overlay: Partial<Omit<SingleTrack, 'height' | 'width' | 'layout' | 'title' | 'subtitle'>>[];
     };
 

--- a/src/core/utils/overlay.test.ts
+++ b/src/core/utils/overlay.test.ts
@@ -68,9 +68,8 @@ describe('Spread Tracks By Data', () => {
         const spread = spreadTracksByData([
             { overlay: [{}, { data: { type: 'csv', url: '' } }], width: 100, height: 100 }
         ]);
-        expect(spread).toHaveLength(2);
-        expect('data' in spread[1]).toBe(true); // Any overlaid tracks w/ data will be spread
-        expect(spread[1].overlayOnPreviousTrack).toBe(true); // Any spread tracks will have `overlayOnPreviousTrack` flags
+        expect(spread).toHaveLength(1); // There is only one unique data/dataTransform specification, so should not spread.
+        expect('data' in spread[0]).toBe(true); // Since there is not data spec in the parent, it should be borrowed from a child.
     });
     it('overlay: [{}, { data }, { data }]', () => {
         const spread = spreadTracksByData([
@@ -84,11 +83,10 @@ describe('Spread Tracks By Data', () => {
                 height: 100
             }
         ]);
-        expect(spread).toHaveLength(3);
+        expect(spread).toHaveLength(2); // first and second will be stored in a single track
+        expect('data' in spread[0]).toBe(true);
         expect('data' in spread[1]).toBe(true);
-        expect('data' in spread[2]).toBe(true);
         expect(spread[1].overlayOnPreviousTrack).toBe(true); // Any spread tracks will have `overlayOnPreviousTrack` flags
-        expect(spread[2].overlayOnPreviousTrack).toBe(true); // Any spread tracks will have `overlayOnPreviousTrack` flags
     });
     it('overlay: [{ data1 }, { data2 }]', () => {
         const spread = spreadTracksByData([
@@ -127,6 +125,7 @@ describe('Spread Tracks By Data', () => {
         expect('data' in spread[1]).toBe(true);
         expect(spread[0].overlayOnPreviousTrack).toBe(false);
         expect(spread[1].overlayOnPreviousTrack).toBe(true);
+        expect(spread[2].overlayOnPreviousTrack).toBe(true);
         expect((spread[1] as any).y.axis).toBe('right'); // position axis on the right to prevent visual occlusion
         expect((spread[2] as any).y.axis).toBe('none'); // hide axis
     });

--- a/src/core/utils/overlay.test.ts
+++ b/src/core/utils/overlay.test.ts
@@ -43,6 +43,17 @@ describe('Should handle superposition options correctly', () => {
             true
         );
     });
+    it('Should delete title except the last one in overlaid tracks', () => {
+        const tracks = resolveSuperposedTracks({
+            title: 'title',
+            overlay: [{ x: { axis: 'top' } }, { x: { axis: 'bottom' } }],
+            width: 100,
+            height: 100
+        });
+        expect(tracks).toHaveLength(2);
+        expect(tracks[0].title).toBeDefined();
+        expect(tracks[1].title).toBeUndefined();
+    });
 });
 
 describe('Spread Tracks By Data', () => {
@@ -128,5 +139,49 @@ describe('Spread Tracks By Data', () => {
         expect(spread[2].overlayOnPreviousTrack).toBe(true);
         expect((spread[1] as any).y.axis).toBe('right'); // position axis on the right to prevent visual occlusion
         expect((spread[2] as any).y.axis).toBe('none'); // hide axis
+    });
+    it('title of overlay: [{ data1 }]', () => {
+        const spread = spreadTracksByData([
+            {
+                title: 'title',
+                overlay: [{ data: { type: 'vector', url: '', column: 'c', value: 'p' } }],
+                width: 100,
+                height: 100
+            }
+        ]);
+        expect(spread).toHaveLength(1);
+        expect('title' in spread[0]).toBe(true);
+    });
+    it('title of overlay: [{ data1 }, { data1 }]', () => {
+        const spread = spreadTracksByData([
+            {
+                title: 'title',
+                overlay: [
+                    { data: { type: 'vector', url: '', column: 'c', value: 'p' } },
+                    { data: { type: 'vector', url: '', column: 'c', value: 'p' } }
+                ],
+                width: 100,
+                height: 100
+            }
+        ]);
+        expect(spread).toHaveLength(1);
+        expect('title' in spread[0]).toBe(true);
+    });
+
+    it('title of overlay: [{ data1 }, { data2 }]', () => {
+        const spread = spreadTracksByData([
+            {
+                title: 'title',
+                overlay: [
+                    { data: { type: 'csv', url: '' } },
+                    { data: { type: 'vector', url: '', column: 'c', value: 'p' } }
+                ],
+                width: 100,
+                height: 100
+            }
+        ]);
+        expect(spread).toHaveLength(2);
+        expect('title' in spread[0]).toBe(false);
+        expect('title' in spread[1]).toBe(true);
     });
 });

--- a/src/core/utils/overlay.ts
+++ b/src/core/utils/overlay.ts
@@ -125,7 +125,7 @@ export function isIdenticalDataTransformSpec(specs: (DataTransform[] | undefined
  * This process is necessary since we are passing over each track to HiGlass, and if a single track is mapped to multiple datastes, HiGlass cannot handle that.
  */
 export function spreadTracksByData(tracks: Track[]): Track[] {
-    const newTracks = ([] as Track[]).concat(
+    return ([] as Track[]).concat(
         ...tracks.map(t => {
             if (IsDataTrack(t) || !IsOverlaidTrack(t) || t.overlay.length <= 1) {
                 // no overlaid tracks to spread
@@ -153,6 +153,7 @@ export function spreadTracksByData(tracks: Track[]): Track[] {
             original.overlay = [];
 
             t.overlay.forEach((subSpec, i) => {
+                // If data specs are undefined, put the first spec to the parent
                 if (!t.data) {
                     t.data = subSpec.data;
                 }
@@ -160,7 +161,7 @@ export function spreadTracksByData(tracks: Track[]): Track[] {
                     t.dataTransform = subSpec.dataTransform;
                 }
 
-                // Determine if this `subSpec` should belong to the parent or become  a separate track
+                // Determine if this `subSpec` should be added to `overlay` or become a separate track
                 if (
                     (!t.data || !subSpec.data || isIdenticalDataSpec([t.data, subSpec.data])) &&
                     (!t.dataTransform ||
@@ -196,6 +197,4 @@ export function spreadTracksByData(tracks: Track[]): Track[] {
             });
         })
     );
-
-    return newTracks;
 }

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -163,7 +163,6 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
     if ('tracks' in spec) {
         let tracks: Track[] = convertToFlatTracks(spec);
 
-        // !!! TODO: (FOR THE RENDERING PERFORMANCE) We need to also combine overlaid tracks if they use identical data spec so that we have to load the data only once.
         // !!! Be aware that this should be taken before fixing `overlayOnPreviousTrack` options.
         /**
          * Spread superposed tracks if they are assigned to different data spec.

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -779,6 +779,8 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 }
 
                 tile.gos.tabularDataFiltered = Array.from(tile.gos.tabularData);
+
+                // !! TODO: why are we transforming data multiple times for each track?
                 /*
                  * Data Transformation
                  */


### PR DESCRIPTION
Fix https://github.com/manzt/gos/pull/38
Fix https://github.com/manzt/gos/pull/37

Spec that had issues:

```js
{
  "arrangement": "vertical",
  "views": [
    {
      "alignment": "stack",
      "layout": "circular",
      "static": true,
      "tracks": [
        {
          "alignment": "overlay",
          "height": 100,
          "tracks": [
            {
              "color": {
                "field": "sample",
                "type": "nominal"
              },
              "data": {
                "binSize": 4,
                "categories": [
                  "sample 1",
                  "sample 2",
                  "sample 3",
                  "sample 4"
                ],
                "column": "position",
                "row": "sample",
                "type": "multivec",
                "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
                "value": "peak"
              },
              "mark": "bar",
              "row": {
                "field": "sample",
                "type": "nominal"
              },
              "stroke": {
                "value": "black"
              },
              "strokeWidth": {
                "value": 0.3
              },
              "style": {
                "outlineWidth": 0
              },
              "x": {
                "field": "start",
                "type": "genomic"
              },
              "xe": {
                "field": "end",
                "type": "genomic"
              },
              "y": {
                "field": "peak",
                "type": "quantitative"
              }
            },
            {
              "color": {
                "value": "blue"
              },
              "data": {
                "binSize": 4,
                "categories": [
                  "sample 1",
                  "sample 2",
                  "sample 3",
                  "sample 4"
                ],
                "column": "position",
                "row": "sample",
                "type": "multivec",
                "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
                "value": "peak"
              },
              "mark": "brush",
              "row": {
                "field": "sample",
                "type": "nominal"
              },
              "stroke": {
                "value": "black"
              },
              "strokeWidth": {
                "value": 0.3
              },
              "style": {
                "outlineWidth": 0
              },
              "x": {
                "field": "start",
                "linkingId": "detail-1",
                "type": "genomic"
              },
              "xe": {
                "field": "end",
                "type": "genomic"
              },
              "y": {
                "field": "peak",
                "type": "quantitative"
              }
            },
            {
              "color": {
                "value": "red"
              },
              "data": {
                "binSize": 4,
                "categories": [
                  "sample 1",
                  "sample 2",
                  "sample 3",
                  "sample 4"
                ],
                "column": "position",
                "row": "sample",
                "type": "multivec",
                "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
                "value": "peak"
              },
              "mark": "brush",
              "row": {
                "field": "sample",
                "type": "nominal"
              },
              "stroke": {
                "value": "black"
              },
              "strokeWidth": {
                "value": 0.3
              },
              "style": {
                "outlineWidth": 0
              },
              "x": {
                "field": "start",
                "linkingId": "detail-2",
                "type": "genomic"
              },
              "xe": {
                "field": "end",
                "type": "genomic"
              },
              "y": {
                "field": "peak",
                "type": "quantitative"
              }
            }
          ],
          "width": 500
        },
        {
          "data": {
            "genomicFieldsToConvert": [
              {
                "chromosomeField": "chr1",
                "genomicFields": [
                  "p1s",
                  "p1e"
                ]
              },
              {
                "chromosomeField": "chr2",
                "genomicFields": [
                  "p2s",
                  "p2e"
                ]
              }
            ],
            "headerNames": [
              "chr1",
              "p1s",
              "p1e",
              "chr2",
              "p2s",
              "p2e",
              "type",
              "id",
              "f1",
              "f2",
              "f3",
              "f4",
              "f5",
              "f6"
            ],
            "separator": "\t",
            "type": "csv",
            "url": "https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/rearrangements.bulk.1639.simple.filtered.pub"
          },
          "dataTransform": [
            {
              "field": "chr1",
              "oneOf": [
                "1",
                "16",
                "14",
                "9",
                "6",
                "5",
                "3"
              ],
              "type": "filter"
            },
            {
              "field": "chr2",
              "oneOf": [
                "1",
                "16",
                "14",
                "9",
                "6",
                "5",
                "3"
              ],
              "type": "filter"
            }
          ],
          "height": 100,
          "mark": "withinLink",
          "opacity": {
            "value": 0.15
          },
          "stroke": {
            "domain": [
              "deletion",
              "inversion",
              "translocation",
              "tandem-duplication"
            ],
            "field": "type",
            "type": "nominal"
          },
          "strokeWidth": {
            "value": 0.8
          },
          "width": 500,
          "x": {
            "field": "p1s",
            "type": "genomic"
          },
          "x1": {
            "field": "p2s",
            "type": "genomic"
          },
          "x1e": {
            "field": "p2e",
            "type": "genomic"
          },
          "xe": {
            "field": "p1e",
            "type": "genomic"
          }
        }
      ]
    },
    {
      "arrangement": "horizontal",
      "spacing": 10,
      "views": [
        {
          "tracks": [
            {
              "color": {
                "field": "sample",
                "legend": false,
                "type": "nominal"
              },
              "data": {
                "binSize": 4,
                "categories": [
                  "sample 1",
                  "sample 2",
                  "sample 3",
                  "sample 4"
                ],
                "column": "position",
                "row": "sample",
                "type": "multivec",
                "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
                "value": "peak"
              },
              "height": 150,
              "mark": "bar",
              "row": {
                "field": "sample",
                "type": "nominal"
              },
              "stroke": {
                "value": "black"
              },
              "strokeWidth": {
                "value": 0.3
              },
              "style": {
                "background": "blue",
                "backgroundOpacity": 0.1
              },
              "width": 245,
              "x": {
                "domain": {
                  "chromosome": "5"
                },
                "field": "start",
                "linkingId": "detail-1",
                "type": "genomic"
              },
              "xe": {
                "field": "end",
                "type": "genomic"
              },
              "y": {
                "field": "peak",
                "type": "quantitative"
              }
            }
          ]
        },
        {
          "tracks": [
            {
              "color": {
                "field": "sample",
                "legend": true,
                "type": "nominal"
              },
              "data": {
                "binSize": 4,
                "categories": [
                  "sample 1",
                  "sample 2",
                  "sample 3",
                  "sample 4"
                ],
                "column": "position",
                "row": "sample",
                "type": "multivec",
                "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
                "value": "peak"
              },
              "height": 150,
              "mark": "bar",
              "row": {
                "field": "sample",
                "type": "nominal"
              },
              "stroke": {
                "value": "black"
              },
              "strokeWidth": {
                "value": 0.3
              },
              "style": {
                "background": "red",
                "backgroundOpacity": 0.1
              },
              "width": 245,
              "x": {
                "domain": {
                  "chromosome": "16"
                },
                "field": "start",
                "linkingId": "detail-2",
                "type": "genomic"
              },
              "xe": {
                "field": "end",
                "type": "genomic"
              },
              "y": {
                "field": "peak",
                "type": "quantitative"
              }
            }
          ]
        }
      ]
    }
  ]
}
```