### PR TITLE
fix: handle `embed()` and use the previous component structure

### DIFF
--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import { HiGlassApi, HiGlassComponentWrapper } from './higlass-component-wrapper';
-import uuid from 'uuid';
 import React, { useState, useEffect, useMemo, useRef, forwardRef } from 'react';
 import * as gosling from '..';
 import { getTheme, Theme } from './utils/theme';
@@ -21,7 +20,7 @@ interface GoslingCompProps {
 }
 
 export const GoslingComponent = forwardRef<{ api: GoslingApi }, GoslingCompProps>((props, ref) => {
-    const [initHs, setInitHs] = useState<gosling.HiGlassSpec>();
+    const [initViewConfig, setInitViewConfig] = useState<gosling.HiGlassSpec>();
     const [size, setSize] = useState({ width: 200, height: 200 });
 
     // HiGlass API
@@ -32,13 +31,13 @@ export const GoslingComponent = forwardRef<{ api: GoslingApi }, GoslingCompProps
     // Gosling APIs
     useEffect(() => {
         if (!ref) return;
-        const api = createApi(hgRef, initHs, theme);
+        const api = createApi(hgRef, initViewConfig, theme);
         if (typeof ref == 'function') {
             ref({ api });
         } else {
             ref.current = { api };
         }
-    }, [ref, hgRef, initHs, theme]);
+    }, [ref, hgRef, initViewConfig, theme]);
 
     useEffect(() => {
         if (props.spec) {
@@ -55,8 +54,8 @@ export const GoslingComponent = forwardRef<{ api: GoslingApi }, GoslingCompProps
                     // If a callback function is provided, return compiled information.
                     props.compiled?.(props.spec!, newHs);
                     setSize(newSize); // change the wrapper's size
-                    if (!initHs) {
-                        setInitHs(newHs);
+                    if (!initViewConfig) {
+                        setInitViewConfig(newHs);
                     } else {
                         // This allows reactive rendering if track ids are used
                         hgRef.current?.api.setViewConfig(newHs);
@@ -70,55 +69,23 @@ export const GoslingComponent = forwardRef<{ api: GoslingApi }, GoslingCompProps
 
     // HiGlass component should be mounted only once
     const higlassComponent = useMemo(
-        () => (initHs ? <HiGlassComponentWrapper ref={hgRef} viewConfig={initHs} /> : null),
-        [initHs]
-    );
-
-    // This determines the size, padding, and margin of the visualization
-    const higlassComponetWrapper = useMemo(
         () => (
-            <div
-                id={props.id ?? uuid.v4()}
-                className={`gosling-component ${props.className || ''}`}
-                style={{
-                    position: 'relative',
-                    padding: props.padding ?? 60,
-                    margin: props.margin ?? 0,
-                    border: props.border ?? 'none',
-                    background: theme.root.background,
-                    width: size.width + (props.padding ?? 60) * 2,
-                    height: size.height + (props.padding ?? 60) * 2,
-                    textAlign: 'left'
+            <HiGlassComponentWrapper
+                ref={hgRef}
+                viewConfig={initViewConfig}
+                size={size}
+                id={props.id}
+                className={props.className}
+                options={{
+                    padding: props.padding,
+                    border: props.border,
+                    margin: props.margin,
+                    background: theme.root.background
                 }}
-            >
-                <div
-                    id="higlass-wrapper"
-                    className="higlass-wrapper"
-                    style={{
-                        position: 'relative',
-                        display: 'block',
-                        background: theme.root.background,
-                        margin: 0,
-                        padding: 0, // non-zero padding acts unexpectedly w/ HiGlassComponent
-                        width: size.width,
-                        height: size.height
-                    }}
-                >
-                    {higlassComponent}
-                </div>
-            </div>
+            />
         ),
-        [
-            higlassComponent,
-            size,
-            props.id,
-            props.className,
-            props.padding,
-            props.margin,
-            props.border,
-            theme.root.background
-        ]
+        [initViewConfig, size, theme]
     );
 
-    return higlassComponetWrapper;
+    return higlassComponent;
 });

--- a/src/core/higlass-component-wrapper.tsx
+++ b/src/core/higlass-component-wrapper.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import * as PIXI from 'pixi.js';
-import React, { forwardRef } from 'react';
+import React, { useEffect, useState, forwardRef, useMemo } from 'react';
+import uuid from 'uuid';
 
 import * as gosling from '..';
 // @ts-ignore
@@ -20,31 +21,94 @@ export type HiGlassApi = {
 };
 
 export interface HiGlassComponentWrapperProps {
+    size: { width: number; height: number };
     viewConfig?: HiGlassSpec;
+    options: {
+        padding?: number;
+        margin?: number | string;
+        border?: string;
+        background?: string;
+    };
+    id?: string;
+    className?: string;
 }
 
 export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlassComponentWrapperProps>(
     (props, ref) => {
+        // div `id` and `className` for detailed customization
+        const [wrapperDivId, setWrapperDivId] = useState(props.id ?? uuid.v4());
+        useEffect(() => {
+            setWrapperDivId(props.id ?? uuid.v4());
+        }, [props.id]);
+
+        const viewConfig = props.viewConfig || {};
+        const higlassComponent = useMemo(
+            () => (
+                <HiGlassComponent
+                    ref={ref}
+                    options={{
+                        pixelPreciseMarginPadding: true, // this uses `rowHeight: 1` in react-grid-layout
+                        containerPaddingX: 0,
+                        containerPaddingY: 0,
+                        viewMarginTop: 0,
+                        viewMarginBottom: 0,
+                        viewMarginLeft: 0,
+                        viewMarginRight: 0,
+                        viewPaddingTop: 0,
+                        viewPaddingBottom: 0,
+                        viewPaddingLeft: 0,
+                        viewPaddingRight: 0,
+                        sizeMode: 'bounded',
+                        rangeSelectionOnAlt: true // this allows switching between `selection` and `zoom&pan` mode
+                    }}
+                    viewConfig={viewConfig}
+                />
+            ),
+            [viewConfig]
+        );
+
+        // Styling
+        const { padding = 60, margin = 0, border = 'none', background } = props.options || {};
         return (
-            <HiGlassComponent
-                ref={ref}
-                options={{
-                    pixelPreciseMarginPadding: true, // this uses `rowHeight: 1` in react-grid-layout
-                    containerPaddingX: 0,
-                    containerPaddingY: 0,
-                    viewMarginTop: 0,
-                    viewMarginBottom: 0,
-                    viewMarginLeft: 0,
-                    viewMarginRight: 0,
-                    viewPaddingTop: 0,
-                    viewPaddingBottom: 0,
-                    viewPaddingLeft: 0,
-                    viewPaddingRight: 0,
-                    sizeMode: 'bounded',
-                    rangeSelectionOnAlt: true // this allows switching between `selection` and `zoom&pan` mode
-                }}
-                viewConfig={props.viewConfig || {}}
-            />
+            <>
+                <div
+                    id={wrapperDivId}
+                    className={`gosling-component ${props.className || ''}`}
+                    style={{
+                        position: 'relative',
+                        padding: padding,
+                        margin: margin,
+                        border: border,
+                        background: background,
+                        width: props.size.width + padding * 2,
+                        height: props.size.height + padding * 2,
+                        textAlign: 'left'
+                    }}
+                >
+                    <div
+                        key={JSON.stringify(viewConfig)}
+                        id="higlass-wrapper"
+                        className="higlass-wrapper"
+                        style={{
+                            position: 'relative',
+                            display: 'block',
+                            background: background,
+                            margin: 0,
+                            padding: 0, // non-zero padding acts unexpectedly w/ HiGlassComponent
+                            width: props.size.width,
+                            height: props.size.height
+                        }}
+                        // onClick={(e) => {
+                        //     PubSub.publish('gosling.click', {
+                        //         mouseX: e.pageX - (document.getElementById('higlass-wrapper')?.offsetLeft ?? 0),
+                        //         mouseY: e.pageY - (document.getElementById('higlass-wrapper')?.offsetTop ?? 0)
+                        //     });
+                        // }}
+                    >
+                        {higlassComponent}
+                    </div>
+                </div>
+            </>
         );
     }
 );


### PR DESCRIPTION
🤦‍♂️ In #484, I overlooked the existence of `embed()`, and the restructure of react components was unnecessary. So I changed the structure back while supporting the reactive rendering.