### PR TITLE
chore: update editor styles to remove bootstrap dependency

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -248,6 +248,8 @@
 
 .editor-data-preview-table table {
     width: 100%;
+    border-spacing: 0;
+    border-collapse: collapse;
 }
 
 .editor-data-preview-table th,
@@ -459,6 +461,7 @@ td {
 }
 
 .hide-description-button {
+    cursor: pointer;
     font-size: 9px;
     color: rgb(89, 89, 89);
     border: 1px solid #aaa;

--- a/editor/editor.css
+++ b/editor/editor.css
@@ -10,11 +10,13 @@
 
 .logo {
     display: inline-block;
-    vertical-align: middle;
     height: 100%;
-    padding-top: 8px;
     margin-left: 7px;
     margin-right: 5px;
+}
+
+.logo svg {
+    vertical-align: middle;
 }
 
 .gosling-color {
@@ -149,7 +151,6 @@
     padding-left: 10px;
     background: #fafafa;
     border-bottom: 1px solid lightgray;
-    height: 30px;
     overflow-x: auto;
 }
 

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -307,7 +307,6 @@ function Editor(props: any) {
         const token = PubSub.subscribe('data-preview', (_: string, data: PreviewData) => {
             // Data with different `dataConfig` is shown separately in data preview.
             const id = `${data.dataConfig}`;
-
             const newPreviewData = previewData.current.filter(d => d.id !== id);
             previewData.current = [...newPreviewData, { ...data, id }];
         });
@@ -423,7 +422,10 @@ function Editor(props: any) {
                     // }
                 }}
             >
-                <span style={{ cursor: 'pointer' }} onClick={() => window.open('https://gosling.js.org', '_blank')}>
+                <span
+                    style={{ cursor: 'pointer', lineHeight: '40px' }}
+                    onClick={() => window.open('https://gosling.js.org', '_blank')}
+                >
                     <span className="logo">{GoslingLogoSVG(20, 20)}</span>
                     Gosling.js Editor
                 </span>

--- a/editor/index.css
+++ b/editor/index.css
@@ -7,6 +7,8 @@ body {
     margin: 0;
     height: 100%;
     width: 100%;
+    font-size: 14px;
+    line-height: 1.42857143;
     font-family: 'Helvetica Neue', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
         'Cantarell', 'Droid Sans', sans-serif;
     -webkit-font-smoothing: antialiased;

--- a/src/core/higlass-component-wrapper.tsx
+++ b/src/core/higlass-component-wrapper.tsx
@@ -80,8 +80,8 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
                         margin: margin,
                         border: border,
                         background: background,
-                        width: props.size.width + padding * 2,
-                        height: props.size.height + padding * 2,
+                        width: props.size.width,
+                        height: props.size.height,
                         textAlign: 'left'
                     }}
                 >

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -840,14 +840,10 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
                 // Send data preview to the editor so that it can be shown to users.
                 try {
-                    // !!! This shouldn't be called while using npm gosling.js package.
-                    /*eslint-disable */
-                    const pubsub = require('pubsub-js');
-                    /*eslint-enable */
-                    if (pubsub) {
+                    if (PubSub) {
                         const NUM_OF_ROWS_IN_PREVIEW = 100;
                         const numOrRows = tile.gos.tabularDataFiltered.length;
-                        pubsub.publish('data-preview', {
+                        PubSub.publish('data-preview', {
                             id: this.context.id,
                             dataConfig: JSON.stringify({ data: resolved.data }),
                             data:


### PR DESCRIPTION
This PR is intended to be merged to #494.

I figured the bootstrap CSS file (https://github.com/gosling-lang/gosling.js/pull/494#discussion_r702143794) was affecting the style of a few components in the online editor. This resulted in breaking some styles when we remove the dependency. To be able to entirely remove the bootstrap dependency, this PR touches some styles.