### PR TITLE
fix: refer to actual track size instead of spec.width and spec.height for track encoding

### DIFF
--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -95,7 +95,7 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
             drawBar(trackInfo, tile, model);
             break;
         case 'line':
-            drawLine(tile.graphics, model, trackInfo.tooltips);
+            drawLine(tile.graphics, model, trackInfo.tooltips, trackWidth, trackHeight);
             break;
         case 'area':
             drawArea(HGC, trackInfo, tile, model);

--- a/src/core/mark/line.test.ts
+++ b/src/core/mark/line.test.ts
@@ -21,6 +21,6 @@ describe('Rendering Point', () => {
             { x: 111, y: 222 }
         ];
         const model = new GoslingTrackModel(t, d, getTheme());
-        drawLine(g, model, []);
+        drawLine(g, model, [], 100, 100);
     });
 });

--- a/src/core/mark/line.ts
+++ b/src/core/mark/line.ts
@@ -6,7 +6,13 @@ import colorToHex from '../utils/color-to-hex';
 import { cartesianToPolar } from '../utils/polar';
 import { TooltipData, TOOLTIP_MOUSEOVER_MARGIN as G } from '../../gosling-tooltip';
 
-export function drawLine(g: PIXI.Graphics, tm: GoslingTrackModel, tooltips: TooltipData[]) {
+export function drawLine(
+    g: PIXI.Graphics,
+    tm: GoslingTrackModel,
+    tooltips: TooltipData[],
+    trackWidth: number,
+    trackHeight: number
+) {
     /* track spec */
     const spec = tm.spec();
 
@@ -17,10 +23,6 @@ export function drawLine(g: PIXI.Graphics, tm: GoslingTrackModel, tooltips: Tool
 
     /* data */
     const data = tm.data();
-
-    /* track size */
-    const trackWidth = spec.width;
-    const trackHeight = spec.height;
 
     /* circular parameters */
     const circular = spec.layout === 'circular';

--- a/src/core/mark/link.test.ts
+++ b/src/core/mark/link.test.ts
@@ -6,7 +6,7 @@ import { drawLink } from './link';
 
 describe('Rendering link', () => {
     const g = new PIXI.Graphics();
-    const trackInfo = { tooltips: [] };
+    const trackInfo = { tooltips: [], dimensions: [100, 100] };
     it('Linear Band', () => {
         const t: SingleTrack = {
             data: { type: 'csv', url: '' },

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -23,8 +23,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
     const data = model.data();
 
     /* track size */
-    const trackWidth = spec.width;
-    const trackHeight = spec.height;
+    const [trackWidth, trackHeight] = trackInfo.dimensions;
 
     /* circular parameters */
     const circular = spec.layout === 'circular';

--- a/src/core/mark/point.test.ts
+++ b/src/core/mark/point.test.ts
@@ -24,7 +24,7 @@ describe('Rendering Point', () => {
             { x: 111, y: 222 }
         ];
         const model = new GoslingTrackModel(t, d, getTheme());
-        drawPoint(null, g, model);
+        drawPoint({ dimensions: [100, 100] }, g, model);
     });
 });
 

--- a/src/core/mark/point.ts
+++ b/src/core/mark/point.ts
@@ -20,8 +20,7 @@ export function drawPoint(trackInfo: any, g: PIXI.Graphics, model: GoslingTrackM
     const data = model.data();
 
     /* track size */
-    const trackWidth = spec.width;
-    const trackHeight = spec.height;
+    const [trackWidth, trackHeight] = trackInfo.dimensions;
     const zoomLevel =
         (model.getChannelScale('x') as any).invert(trackWidth) - (model.getChannelScale('x') as any).invert(0);
 


### PR DESCRIPTION
Fix #515