### PR TITLE
feat: support `ye` with `bar`

### DIFF
--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -451,9 +451,21 @@ export class GoslingTrackModel {
 
         // common visual properties, not specific to visual marks
         if (
-            ['text', 'color', 'row', 'stroke', 'opacity', 'strokeWidth', 'x', 'y', 'xe', 'x1', 'x1e', 'size'].includes(
-                propertyKey
-            )
+            [
+                'text',
+                'color',
+                'row',
+                'stroke',
+                'opacity',
+                'strokeWidth',
+                'x',
+                'y',
+                'xe',
+                'x1',
+                'x1e',
+                'ye',
+                'size'
+            ].includes(propertyKey)
         ) {
             return this.visualPropertyByChannel(propertyKey as any, datum);
         }

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -646,6 +646,7 @@ export class GoslingTrackModel {
                                 range = [0, spec.width];
                                 break;
                             case 'y':
+                            case 'ye':
                                 range = [0, rowHeight];
                                 break;
                             case 'color':
@@ -682,6 +683,7 @@ export class GoslingTrackModel {
                                 range = [0, spec.width];
                                 break;
                             case 'y':
+                            case 'ye':
                                 range = [rowHeight, 0]; // reversed because the origin is on the top
                                 break;
                             case 'color':
@@ -771,6 +773,7 @@ export class GoslingTrackModel {
                         case 'xe':
                         case 'x1e':
                         case 'y':
+                        case 'ye':
                         case 'size':
                         case 'opacity':
                         case 'strokeWidth':
@@ -797,6 +800,7 @@ export class GoslingTrackModel {
                         case 'x':
                         case 'xe':
                         case 'y':
+                        case 'ye':
                         case 'row':
                             this.channelScales[channelKey] = scaleBand()
                                 .domain(domain as string[])

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -205,7 +205,8 @@ export function IsStackedMark(track: SingleTrack): boolean {
         (!track.row || IsChannelValue(track.row)) &&
         // TODO: determine whether to use stacked bar for nominal fields or not
         IsChannelDeep(track.y) &&
-        track.y.type === 'quantitative'
+        track.y.type === 'quantitative' &&
+        !IsChannelDeep(track.ye)
     );
 }
 

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -95,7 +95,7 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
             drawBar(trackInfo, tile, model);
             break;
         case 'line':
-            drawLine(tile.graphics, model, trackInfo.tooltips);
+            drawLine(tile.graphics, model, trackInfo.tooltips, trackWidth, trackHeight);
             break;
         case 'area':
             drawArea(HGC, trackInfo, tile, model);

--- a/src/core/mark/line.test.ts
+++ b/src/core/mark/line.test.ts
@@ -21,6 +21,6 @@ describe('Rendering Point', () => {
             { x: 111, y: 222 }
         ];
         const model = new GoslingTrackModel(t, d, getTheme());
-        drawLine(g, model, []);
+        drawLine(g, model, [], 100, 100);
     });
 });

--- a/src/core/mark/line.ts
+++ b/src/core/mark/line.ts
@@ -6,7 +6,13 @@ import colorToHex from '../utils/color-to-hex';
 import { cartesianToPolar } from '../utils/polar';
 import { TooltipData, TOOLTIP_MOUSEOVER_MARGIN as G } from '../../gosling-tooltip';
 
-export function drawLine(g: PIXI.Graphics, tm: GoslingTrackModel, tooltips: TooltipData[]) {
+export function drawLine(
+    g: PIXI.Graphics,
+    tm: GoslingTrackModel,
+    tooltips: TooltipData[],
+    trackWidth: number,
+    trackHeight: number
+) {
     /* track spec */
     const spec = tm.spec();
 
@@ -17,10 +23,6 @@ export function drawLine(g: PIXI.Graphics, tm: GoslingTrackModel, tooltips: Tool
 
     /* data */
     const data = tm.data();
-
-    /* track size */
-    const trackWidth = spec.width;
-    const trackHeight = spec.height;
 
     /* circular parameters */
     const circular = spec.layout === 'circular';

--- a/src/core/mark/link.test.ts
+++ b/src/core/mark/link.test.ts
@@ -6,7 +6,7 @@ import { drawLink } from './link';
 
 describe('Rendering link', () => {
     const g = new PIXI.Graphics();
-    const trackInfo = { tooltips: [] };
+    const trackInfo = { tooltips: [], dimensions: [100, 100] };
     it('Linear Band', () => {
         const t: SingleTrack = {
             data: { type: 'csv', url: '' },

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -23,8 +23,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
     const data = model.data();
 
     /* track size */
-    const trackWidth = spec.width;
-    const trackHeight = spec.height;
+    const [trackWidth, trackHeight] = trackInfo.dimensions;
 
     /* circular parameters */
     const circular = spec.layout === 'circular';

--- a/src/core/mark/point.test.ts
+++ b/src/core/mark/point.test.ts
@@ -24,7 +24,7 @@ describe('Rendering Point', () => {
             { x: 111, y: 222 }
         ];
         const model = new GoslingTrackModel(t, d, getTheme());
-        drawPoint(null, g, model);
+        drawPoint({ dimensions: [100, 100] }, g, model);
     });
 });
 

--- a/src/core/mark/point.ts
+++ b/src/core/mark/point.ts
@@ -20,8 +20,7 @@ export function drawPoint(trackInfo: any, g: PIXI.Graphics, model: GoslingTrackM
     const data = model.data();
 
     /* track size */
-    const trackWidth = spec.width;
-    const trackHeight = spec.height;
+    const [trackWidth, trackHeight] = trackInfo.dimensions;
     const zoomLevel =
         (model.getChannelScale('x') as any).invert(trackWidth) - (model.getChannelScale('x') as any).invert(0);
 

--- a/src/core/visual-property.schema.ts
+++ b/src/core/visual-property.schema.ts
@@ -10,6 +10,7 @@ export type PIXIVisualProperty =
     | 'x1' // naive x1 value encoded
     | 'x1e' // naive x1e value encoded
     | 'y' // naive y value encoded
+    | 'ye' // naive ye value encoded
     | 'size' // size of visual marks, such as radius of points
     | 'text' // text annotations
     /* mark-specific visual properties */

--- a/src/editor/example/visual-encoding.ts
+++ b/src/editor/example/visual-encoding.ts
@@ -237,6 +237,47 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                 {
                     id: 'track-8',
                     data: {
+                        url: GOSLING_PUBLIC_DATA.multivec,
+                        type: 'multivec',
+                        row: 'sample',
+                        column: 'position',
+                        value: 'peak',
+                        categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4'],
+                        binSize: 4
+                    },
+                    mark: 'bar',
+                    x: {
+                        field: 'start',
+                        type: 'genomic',
+                        axis: 'top'
+                    },
+                    xe: {
+                        field: 'end',
+                        type: 'genomic',
+                        axis: 'top'
+                    },
+                    y: { field: 'peak_min', type: 'quantitative' },
+                    ye: { field: 'peak_max', type: 'quantitative' },
+                    row: { field: 'sample', type: 'nominal' },
+                    color: { field: 'sample', type: 'nominal', legend: true },
+                    stroke: { value: 'black' },
+                    strokeWidth: { value: 0.2 },
+                    tooltip: [
+                        { field: 'position', type: 'genomic', alt: 'Position' },
+                        { field: 'peak_min', type: 'quantitative', alt: 'min(Value)', format: '.2' },
+                        { field: 'peak_max', type: 'quantitative', alt: 'max(Value)', format: '.2' },
+                        { field: 'sample', type: 'nominal', alt: 'Sample' }
+                    ],
+                    width: 600,
+                    height: 130
+                }
+            ]
+        },
+        {
+            tracks: [
+                {
+                    id: 'track-9',
+                    data: {
                         url:
                             'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
                         type: 'csv',
@@ -529,6 +570,46 @@ export const EX_SPEC_VISUAL_ENCODING_CIRCULAR: GoslingSpec = {
                             height: 130
                         }
                     ]
+                }
+            ]
+        },
+        {
+            tracks: [
+                {
+                    data: {
+                        url: GOSLING_PUBLIC_DATA.multivec,
+                        type: 'multivec',
+                        row: 'sample',
+                        column: 'position',
+                        value: 'peak',
+                        categories: ['sample 1', 'sample 2'],
+                        binSize: 4
+                    },
+                    mark: 'bar',
+                    x: {
+                        field: 'start',
+                        type: 'genomic',
+                        axis: 'top'
+                    },
+                    xe: {
+                        field: 'end',
+                        type: 'genomic',
+                        axis: 'top'
+                    },
+                    y: { field: 'peak_min', type: 'quantitative' },
+                    ye: { field: 'peak_max', type: 'quantitative' },
+                    row: { field: 'sample', type: 'nominal' },
+                    color: { field: 'sample', type: 'nominal', legend: true },
+                    stroke: { value: 'black' },
+                    strokeWidth: { value: 0.2 },
+                    tooltip: [
+                        { field: 'position', type: 'genomic', alt: 'Position' },
+                        { field: 'peak_min', type: 'quantitative', alt: 'min(Value)', format: '.2' },
+                        { field: 'peak_max', type: 'quantitative', alt: 'max(Value)', format: '.2' },
+                        { field: 'sample', type: 'nominal', alt: 'Sample' }
+                    ],
+                    width: 350,
+                    height: 130
                 }
             ]
         }


### PR DESCRIPTION
Now, `ye` can be used along with `y` to determine both the start and end y positions of`bar` marks.

### Screenshots

![gosling-visualization (48)](https://user-images.githubusercontent.com/9922882/134413827-09c6859c-b523-4316-91d6-86a8ca613d00.png)

```js
{
  "xDomain": {"chromosome": "1", "interval": [1, 3000500]},
  "views": [
    {
        "spacing": 0.01,
        "style": { "outlineWidth": 1},
      "tracks": [
        {
          "data": {
            "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
            "type": "multivec",
            "row": "sample",
            "column": "position",
            "value": "peak",
            "categories": ["sample 1"],
            "binSize": 4
          },
          "mark": "bar",
          "x": {"field": "start", "type": "genomic", "axis": "top"},
          "xe": {"field": "end", "type": "genomic", "axis": "top"},
          "y": {"field": "peak_min", "type": "quantitative", "grid": true},
          "ye": {"field": "peak_max", "type": "quantitative"},
          "row": {"field": "sample", "type": "nominal"},
          "color": {"value": "lightgray"},
          "stroke": {"value": "black"},
          "strokeWidth": {"value": 0.2},
          "tooltip": [
            {"field": "position", "type": "genomic", "alt": "Position"},
            {
              "field": "peak",
              "type": "quantitative",
              "alt": "Value",
              "format": ".2"
            },
            {"field": "sample", "type": "nominal", "alt": "Sample"}
          ],
          "width": 600,
          "height": 130
        }
      ]
    }
  ]
}
```

Fix https://github.com/gosling-lang/gosling.js/issues/492#issuecomment-918766075