### PR TITLE
chore: Fix TSC compilation errors; add type-checking to CI

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -32,6 +32,17 @@ jobs:
       with:
         fail_ci_if_error: true
   
+  typecheck:
+    name: Type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: yarn install
+      - run: yarn build-types
+
   deploy:
     name: Deploy editor
 

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -29,7 +29,7 @@ type EventMap = PubSubEvent<'mouseover' | 'click', CommonEventData>;
 export interface GoslingApi {
     subscribe<EventName extends keyof EventMap>(
         type: EventName,
-        callback: (payload: EventMap[EventName]) => void
+        callback: (message: string, payload: EventMap[EventName]) => void
     ): void;
     unsubscribe(tokenOrFunction: string | ((...args: unknown[]) => unknown)): void;
     zoomTo(viewId: string, position: string, padding?: number, duration?: number): void;


### PR DESCRIPTION
Vite doesn't perform any type-checking, so running `tsc` is no long a part of the CI. This PR fixes a compiler error with the gosling API, and adds a GH Action to perform typechecking as a part of our CI.