### PR TITLE
feat: `unknown` assembly does not display `chrN:` on the genomic axis

### DIFF
--- a/src/core/utils/assembly.ts
+++ b/src/core/utils/assembly.ts
@@ -90,6 +90,13 @@ const CRHOM_SIZES: { [assembly: string]: ChromSize } = Object.freeze({
         interval: getChromInterval(CHROM_SIZE_MM9),
         total: getChromTotalSize(CHROM_SIZE_MM9),
         path: basePath('mm9')
+    },
+    // `unknown` assembly contains only one chromosome with max length
+    unknown: {
+        size: { chr: Number.MAX_VALUE },
+        interval: { chr: [0, Number.MAX_VALUE] },
+        total: Number.MAX_VALUE,
+        path: basePath('hg38') // just to ensure this does not make crash
     }
 });
 

--- a/src/gosling-genomic-axis/axis-track.ts
+++ b/src/gosling-genomic-axis/axis-track.ts
@@ -161,8 +161,7 @@ function AxisTrack(HGC: any, ...args: any[]): any {
 
                 const text = new HGC.libraries.PIXI.Text(chromName, this.pixiTextConfig);
 
-                // give each string a random hash so that some get hidden
-                // when there's overlaps
+                // give each string a random hash so that some get hidden when there's overlaps
                 text.hashValue = Math.random();
 
                 this.pTicks.addChild(text);
@@ -368,7 +367,7 @@ function AxisTrack(HGC: any, ...args: any[]): any {
                 if (this.flipText) tickTexts[i].scale.x = -1;
 
                 const chrText = this.options.assembly === 'unknown' ? '' : `${cumPos.chr}: `;
-                tickTexts[i].text = ticks[i] === 0 ? `${chrText}: 1` : `${chrText}: ${this.formatTick(ticks[i])}`;
+                tickTexts[i].text = ticks[i] === 0 ? `${chrText}1` : `${chrText}${this.formatTick(ticks[i])}`;
 
                 const x = this._xScale(cumPos.pos + ticks[i]);
 

--- a/src/gosling-genomic-axis/axis-track.ts
+++ b/src/gosling-genomic-axis/axis-track.ts
@@ -266,11 +266,17 @@ function AxisTrack(HGC: any, ...args: any[]): any {
             this.leftBoundTick.y = this.options.reverseOrientation
                 ? lineYEnd + this.tickTextSeparation
                 : lineYEnd - this.tickTextSeparation;
-            this.leftBoundTick.text = `${x1[0]}: ${this.formatTick(x1[1])}`;
+            this.leftBoundTick.text =
+                this.options.assembly === 'unknown'
+                    ? `${this.formatTick(x1[1])}`
+                    : `${x1[0]}: ${this.formatTick(x1[1])}`;
             this.leftBoundTick.anchor.y = this.options.reverseOrientation ? 0 : 1;
 
             this.rightBoundTick.x = this.dimensions[0];
-            this.rightBoundTick.text = `${x2[0]}: ${this.formatTick(x2[1])}`;
+            this.rightBoundTick.text =
+                this.options.assembly === 'unknown'
+                    ? `${this.formatTick(x2[1])}`
+                    : `${x2[0]}: ${this.formatTick(x2[1])}`;
             this.rightBoundTick.y = this.options.reverseOrientation
                 ? lineYEnd + this.tickTextSeparation
                 : lineYEnd - this.tickTextSeparation;
@@ -361,7 +367,8 @@ function AxisTrack(HGC: any, ...args: any[]): any {
 
                 if (this.flipText) tickTexts[i].scale.x = -1;
 
-                tickTexts[i].text = ticks[i] === 0 ? `${cumPos.chr}: 1` : `${cumPos.chr}: ${this.formatTick(ticks[i])}`;
+                const chrText = this.options.assembly === 'unknown' ? '' : `${cumPos.chr}: `;
+                tickTexts[i].text = ticks[i] === 0 ? `${chrText}: 1` : `${chrText}: ${this.formatTick(ticks[i])}`;
 
                 const x = this._xScale(cumPos.pos + ticks[i]);
 


### PR DESCRIPTION
Address #523 

If a view is with `unknown` assembly, genomic axes do not show `chrN:` in labels:

```js
"assembly": "unknown",
"data": {
   "type": "csv",
   "url": "https://s3.amazonaws.com/gosling-lang.org/data/COVID/NC_045512.2-Genes.csv",
   "genomicFields": ["Start", "Stop"]
},
...
```

<img width="848" alt="Screen Shot 2021-09-29 at 8 06 36 PM" src="https://user-images.githubusercontent.com/9922882/135256998-c757feab-db5c-41ef-bb67-9b97573ea5b0.png">