### PR TITLE
chore: encourage users to ask questions on BioStars

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://www.biostars.org/tag/gosling.js/
+    about: Please ask questions on BioStars (https://www.biostars.org/tag/gosling.js/) or Stack Overflow (https://stackoverflow.com/tags/gosling.js).

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,0 @@
----
-name: Question
-about: Ask a question about how to use gosling.js
-title: ''
-labels: question
-assignees: ''
-
----


### PR DESCRIPTION
It might be better if we can provide a link that creates a new post with a predefined tag (i.e., `gosling.js`), like the `labels` in GitHub issue templates. But, it looks there is no such feature.

Also, there seems to be no subscription feature in BioStars & Stack Overflow (i.e., notify when new posts with specific tags are created by someone). I would need to manually visit those sites frequently.