### PR TITLE
feat(editor): support using relative CSV file URLs for Gist specs

### DIFF
--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -235,6 +235,20 @@ function Editor(props: any) {
         setHg(undefined);
     }, [demo]);
 
+    /**
+     * Convert relative CSV data URLs to absolute URLs.
+     * (e.g., './example.csv' => 'https://gist.githubusercontent.com/{urlGist}/raw/example.csv')
+     */
+    function resolveRelativeCsvUrls(spec: string) {
+        const newSpec = JSON.parse(spec);
+        gosling.traverseTracksAndViews(newSpec as gosling.GoslingSpec, (tv: any) => {
+            if (tv.data && tv.data.type === 'csv' && tv.data.url.indexOf('./') === 0) {
+                tv.data.url = tv.data.url.replace('./', `https://gist.githubusercontent.com/${urlGist}/raw/`);
+            }
+        });
+        return stringify(newSpec);
+    }
+
     useEffect(() => {
         let active = true;
 
@@ -244,7 +258,7 @@ function Editor(props: any) {
             .then(({ code, description, title }) => {
                 if (active && !!code) {
                     setReadOnly(false);
-                    setCode(code);
+                    setCode(resolveRelativeCsvUrls(code));
                     setGistTitle(title);
                     setDescription(description);
                 }

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -3,8 +3,11 @@ import * as uuid from 'uuid';
 import {
     SingleTrack,
     GoslingSpec,
+    View,
     SingleView,
     Track,
+    PartialTrack,
+    CommonTrackDef,
     CommonViewDef,
     MultipleViews,
     DisplaceTransform
@@ -34,12 +37,15 @@ import { getStyleOverridden } from '../utils/style';
  * @param callback
  */
 export function traverseTracks(
-    spec: GoslingSpec,
+    spec: GoslingSpec | View | PartialTrack,
     callback: (t: Partial<Track>, i: number, ts: Partial<Track>[]) => void
 ) {
     if ('tracks' in spec) {
-        spec.tracks.forEach((...args) => callback(...args));
-    } else {
+        spec.tracks.forEach((t, i, ts) => {
+            callback(t, i, ts);
+            traverseTracks(t, callback);
+        });
+    } else if ('views' in spec) {
         spec.views.forEach(view => traverseTracks(view, callback));
     }
 }
@@ -49,10 +55,16 @@ export function traverseTracks(
  * @param spec
  * @param callback
  */
-export function traverseTracksAndViews(spec: GoslingSpec, callback: (tv: CommonViewDef) => void) {
+export function traverseTracksAndViews(
+    spec: GoslingSpec | View | PartialTrack,
+    callback: (tv: CommonViewDef | CommonTrackDef) => void
+) {
     if ('tracks' in spec) {
-        spec.tracks.forEach(t => callback(t));
-    } else {
+        spec.tracks.forEach(t => {
+            callback(t);
+            traverseTracksAndViews(t, callback);
+        });
+    } else if ('views' in spec) {
         spec.views.forEach(v => {
             callback(v);
             traverseTracksAndViews(v, callback);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,3 @@ export { compile } from './core/compile';
 export { validateGoslingSpec } from './core/utils/validate';
 export { GoslingComponent } from './core/gosling-component';
 export { embed } from './core/gosling-embed';
-
-// Utils
-export { traverseTracksAndViews, traverseViewArrangements } from './core/utils/spec-preprocess';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,6 @@ export { compile } from './core/compile';
 export { validateGoslingSpec } from './core/utils/validate';
 export { GoslingComponent } from './core/gosling-component';
 export { embed } from './core/gosling-embed';
+
+// Utils
+export { traverseTracksAndViews, traverseViewArrangements } from './core/utils/spec-preprocess';


### PR DESCRIPTION
This PR allows Editor users to specify relative file URLs of CSV data in Gist specs. This will work when files are located in the same Gist where the spec (i.e., `gosling.js`) is located.

- Example URL for Editor: http://localhost:3000/?gist=sehilyi/c7d3494ef35366e9ee77b570ffd9d184
- Example Gist URL: https://gist.github.com/sehilyi/c7d3494ef35366e9ee77b570ffd9d184

File structure:
```js
GitHub Gist
ㄴ gosling.js    // spec
ㄴ example.csv   // file to be used
```

Original spec in Gist (`gosling.js`):
```js
data: { ..., type: 'csv', 
   url: './example.csv'
}
```

The spec that is updated in the Editor before compiling:
```js
data: { ..., type: 'csv', 
   url: 'https://gist.githubusercontent.com/sehilyi/c7d3494ef35366e9ee77b570ffd9d184/raw/NA_summits.bed'
}
```