### PR TITLE
fix: fix errors related to `process` and `global`

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,14 +46,6 @@
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>
         <div id="root"></div>
-        <script src="https://bundle.run/buffer@6.0.3"></script>
-        <script>
-          // Many dependencies reference `Buffer` without the use of an
-          // import. Since Vite relies on ESM, these references aren't resolved
-          // and we get runtime errors. We could use something like `@rollup/plugin-inject`
-          // but this breaks sourcemaps at the moment.
-          var Buffer = globalThis.buffer.Buffer; // referenced in many dependencies
-        </script>
         <script type="module" src="/editor/index.tsx"></script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "@types/node": "^12.0.0",
         "@types/rbush": "^3.0.0",
         "@types/uuid": "^8.3.1",
-        "bezier-js": "^4.1.1",
+        "bezier-js": "4.0.3",
         "buffer": "^6.0.3",
         "d3-array": "^2.5.1",
         "d3-color": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,9 @@
         "typescript": "~4.1.2",
         "vite": "^2.5.10"
     },
+    "resolutions": {
+        "slugid": "^3.0.0"
+    },
     "browserslist": {
         "production": [
             ">0.2%",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "d3-scale-chromatic": "^2.0.0",
         "d3-shape": "^2.0.0",
         "fflate": "^0.7.1",
-        "generic-filehandle": "^2.2.0",
+        "generic-filehandle": "^2.2.1",
         "gosling-theme": "^0.0.10",
         "higlass": "^1.11.7",
         "higlass-register": "^0.3.0",
@@ -136,7 +136,8 @@
         "vite": "^2.5.10"
     },
     "resolutions": {
-        "slugid": "^3.0.0"
+        "slugid": "^3.0.0",
+        "file-uri-to-path": "^2.0.0"
     },
     "browserslist": {
         "production": [

--- a/package.json
+++ b/package.json
@@ -136,8 +136,7 @@
         "vite": "^2.5.10"
     },
     "resolutions": {
-        "slugid": "^3.0.0",
-        "file-uri-to-path": "^2.0.0"
+        "slugid": "^3.0.0"
     },
     "browserslist": {
         "production": [

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,6 @@ import { defineConfig } from 'vite';
 import reactRefresh from '@vitejs/plugin-react-refresh';
 import * as esbuild from 'esbuild';
 import path from 'path';
-
 import pkg from './package.json';
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4571,10 +4571,10 @@ genbank-parser@^1.0.0:
   resolved "https://registry.yarnpkg.com/genbank-parser/-/genbank-parser-1.2.4.tgz#ee2f9c32f66875024af0c09ee0ec5e10fb231802"
   integrity sha512-r3pTgKHZx/rol90v2cezrNhfMhq3yHWCnBYyETNIJkvnJk+cwx/D/ZVgAy1SX8zwtnfvYQmFbqlpbh2f4t0h2w==
 
-generic-filehandle@^2.0.0, generic-filehandle@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-2.2.0.tgz#d3d17f0ee5d6813e6bcb60396be28802a7158d1f"
-  integrity sha512-cFmLs1ptKALiBs2ExsobnjQ8Y9x/YbiRmynhYiB87Xyrpuk3HV4uR+EpwBiUKS/1C6TXjR+GkWxL58PP1C2hKA==
+generic-filehandle@^2.0.0, generic-filehandle@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-2.2.1.tgz#395ecf5e44113ec33472df86e1c0a4f64fbb1012"
+  integrity sha512-aI1uusDj0zrAvz8t7DfWKn2hjWEZBXhqW063MJB8gsvgCt8LOBJkuNOPXhWik237NMqI2m/ffQ4oKbaO+32vqg==
   dependencies:
     "@babel/runtime" "^7.9.6"
     es6-promisify "^6.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,10 +2202,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-bezier-js@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/bezier-js/-/bezier-js-4.1.1.tgz#414df656833104e86765c0fa5e31439fb3e83a34"
-  integrity sha512-oVOS6SSFFFlfnZdzC+lsfvhs/RRcbxJ47U04M4s5QIBaJmr3YWmTIL3qmrOK9uW+nUUcl9Jccmo/xpTrG+bBoQ==
+bezier-js@4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bezier-js/-/bezier-js-4.0.3.tgz#9e076d66f609bca9fc08dd22201596d52d3cc49d"
+  integrity sha512-w85AFcZ7EkszFgxuHYQ2/BI2G7H5bEotZD9vcg8+Hx4S8zF2odJBoFSFvGbcFDH5ScSxG27/IhW03SigVmkXNQ==
 
 big-integer@^1.6.16:
   version "1.6.49"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8992,12 +8992,12 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-slugid@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/slugid/-/slugid-1.1.0.tgz#e09f00899c09f5a7058edc36dd49f046fd50a82a"
-  integrity sha1-4J8AiZwJ9acFjtw23UnwRv1QqCo=
+slugid@^1.1.0, slugid@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slugid/-/slugid-3.0.0.tgz#57cb692641a20feb4a1d774b2ad11594c9aa6125"
+  integrity sha512-MIir9SJS6BQFjFg8DHGMgPkDg21huT0+kYHiS6NkkWZXHSEdgIECo3nUVEG3GDkmecBTy+zRs6pCvPhpk4bKcg==
   dependencies:
-    uuid "^2.0.1"
+    uuid "^8.3.2"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -10076,11 +10076,6 @@ utrie@^1.0.1:
   integrity sha512-JPaDXF3vzgZxfeEwutdGzlrNoVFL5UvZcbO6Qo9D4GoahrieUPoMU8GCpVpR7MQqcKhmShIh8VlbEN3PLM3EBg==
   dependencies:
     base64-arraybuffer "^1.0.1"
-
-uuid@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-  integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
 
 uuid@^3.3.2:
   version "3.4.0"


### PR DESCRIPTION
Fix #553 
Fix #555

#541 is still not fixed, so the following addition is still required with `vite`.

```html
<script> var process = { platform: '', env: '' } </script>
```