### PR TITLE
feat: infer SV types and find mates from `bam` files; add an API to get raw data in JSON format

### DIFF
--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -229,9 +229,9 @@ function Editor(props: any) {
     // publish event listeners to Gosling.js
     useEffect(() => {
         // if (gosRef.current) {
-        //     gosRef.current.api.subscribe('mouseover', (/*_: CommonEventData*/) => {
-        //         // console.log('mouseover', _);
-        //     });
+        //    gosRef.current.api.subscribe('rawdata', (type: string, data: RawDataEventData) => {
+        //        console.log('rawdata', data);
+        //    });
         //     gosRef.current.api.subscribe('click', (type: string, data: CommonEventData) => {
         //         gosRef.current.api.zoomTo('bam-1', `chr${data.data.chr1}:${data.data.start1}-${data.data.end1}`, 2000);
         //         gosRef.current.api.zoomTo('bam-2', `chr${data.data.chr2}:${data.data.start2}-${data.data.end2}`, 2000);
@@ -239,7 +239,7 @@ function Editor(props: any) {
         //     });
         // }
         // return () => {
-        //     gosRef.current.api.unsubscribe('click');
+        //     gosRef.current.api.unsubscribe('rawdata');
         // }
     }, [gosRef.current]);
 

--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -157,7 +157,8 @@ export const examples: ReadonlyArray<{
         name: 'BAM file pileup tracks',
         id: 'BAM_PILEUP',
         spec: EX_SPEC_PILEUP,
-        underDevelopment: true
+        underDevelopment: true,
+        forceShow: true
     },
     {
         name: 'Track Template',

--- a/editor/example/pileup.ts
+++ b/editor/example/pileup.ts
@@ -15,165 +15,170 @@ export function EX_SPEC_VIEW_PILEUP(
         xDomain: xDomain,
         spacing: 0.01,
         tracks: [
-            {
-                id,
-                title: 'Coverage',
-                data: {
-                    type: 'bam',
-                    // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
-                    url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam',
-                    indexUrl: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam.bai'
-                },
-                dataTransform: [{ type: 'coverage', startField: 'from', endField: 'to' }],
-                mark: 'bar',
-                x: { field: 'from', type: 'genomic' },
-                xe: { field: 'to', type: 'genomic' },
-                y: { field: 'coverage', type: 'quantitative', axis: 'right', grid: true },
-                color: { value: 'lightgray' },
-                stroke: { value: 'gray' },
-                width,
-                height: 80
-            },
-            {
-                alignment: 'overlay',
-                title: 'hg38 | Genes',
-                data: {
-                    url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
-                    type: 'beddb',
-                    genomicFields: [
-                        { index: 1, name: 'start' },
-                        { index: 2, name: 'end' }
-                    ],
-                    valueFields: [
-                        { index: 5, name: 'strand', type: 'nominal' },
-                        { index: 3, name: 'name', type: 'nominal' }
-                    ],
-                    exonIntervalFields: [
-                        { index: 12, name: 'start' },
-                        { index: 13, name: 'end' }
-                    ]
-                },
-                tracks: [
-                    {
-                        dataTransform: [
-                            { type: 'filter', field: 'type', oneOf: ['gene'] },
-                            { type: 'filter', field: 'strand', oneOf: ['+'] }
-                        ],
-                        mark: 'triangleRight',
-                        x: { field: 'end', type: 'genomic' },
-                        size: { value: 15 }
-                    },
-                    {
-                        dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
-                        mark: 'text',
-                        text: { field: 'name', type: 'nominal' },
-                        x: { field: 'start', type: 'genomic' },
-                        xe: { field: 'end', type: 'genomic' },
-                        style: { dy: -15, outline: 'black', outlineWidth: 0 }
-                    },
-                    {
-                        dataTransform: [
-                            { type: 'filter', field: 'type', oneOf: ['gene'] },
-                            { type: 'filter', field: 'strand', oneOf: ['-'] }
-                        ],
-                        mark: 'triangleLeft',
-                        x: { field: 'start', type: 'genomic' },
-                        size: { value: 15 },
-                        style: {
-                            align: 'right',
-                            outline: 'black',
-                            outlineWidth: 0
-                        }
-                    },
-                    {
-                        dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
-                        mark: 'rect',
-                        x: { field: 'start', type: 'genomic' },
-                        size: { value: 15 },
-                        xe: { field: 'end', type: 'genomic' }
-                    },
-                    {
-                        dataTransform: [
-                            { type: 'filter', field: 'type', oneOf: ['gene'] },
-                            { type: 'filter', field: 'strand', oneOf: ['+'] }
-                        ],
-                        mark: 'rule',
-                        x: { field: 'start', type: 'genomic' },
-                        strokeWidth: { value: 2 },
-                        xe: { field: 'end', type: 'genomic' },
-                        style: {
-                            linePattern: { type: 'triangleRight', size: 3.5 },
-                            outline: 'black',
-                            outlineWidth: 0
-                        }
-                    },
-                    {
-                        dataTransform: [
-                            { type: 'filter', field: 'type', oneOf: ['gene'] },
-                            { type: 'filter', field: 'strand', oneOf: ['-'] }
-                        ],
-                        mark: 'rule',
-                        x: { field: 'start', type: 'genomic' },
-                        strokeWidth: { value: 2 },
-                        xe: { field: 'end', type: 'genomic' },
-                        style: {
-                            linePattern: { type: 'triangleLeft', size: 3.5 },
-                            outline: 'black',
-                            outlineWidth: 0
-                        }
-                    }
-                ],
-                row: {
-                    field: 'strand',
-                    type: 'nominal',
-                    domain: ['+', '-']
-                },
-                color: {
-                    field: 'strand',
-                    type: 'nominal',
-                    domain: ['+', '-'],
-                    range: ['#97A8B2', '#D4C6BA'] //['blue', 'red']
-                },
-                visibility: [
-                    {
-                        operation: 'less-than',
-                        measure: 'width',
-                        threshold: '|xe-x|',
-                        transitionPadding: 10,
-                        target: 'mark'
-                    }
-                ],
-                // opacity: { value: 0.4 },
-                width,
-                height: 100
-            },
-            {
-                title: 'Sequence',
-                ...EX_TRACK_SEMANTIC_ZOOM.sequence,
-                style: { inlineLegend: true, outline: 'white' },
-                width,
-                height: 40
-            },
+           //  {
+           //      id,
+           //      title: 'Coverage',
+           //      data: {
+           //          type: 'bam',
+           //          // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
+           //          url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam',
+           //          indexUrl: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam.bai'
+           //      },
+           //      dataTransform: [{ type: 'coverage', startField: 'from', endField: 'to' }],
+           //      mark: 'bar',
+           //      x: { field: 'from', type: 'genomic' },
+           //      xe: { field: 'to', type: 'genomic' },
+           //      y: { field: 'coverage', type: 'quantitative', axis: 'right', grid: true },
+           //      color: { value: 'lightgray' },
+           //      stroke: { value: 'gray' },
+           //      width,
+           //      height: 80
+           //  },
+           //  {
+           //      alignment: 'overlay',
+           //      title: 'hg38 | Genes',
+           //      data: {
+           //          url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
+           //          type: 'beddb',
+           //          genomicFields: [
+           //              { index: 1, name: 'start' },
+           //              { index: 2, name: 'end' }
+           //          ],
+           //          valueFields: [
+           //              { index: 5, name: 'strand', type: 'nominal' },
+           //              { index: 3, name: 'name', type: 'nominal' }
+           //          ],
+           //          exonIntervalFields: [
+           //              { index: 12, name: 'start' },
+           //              { index: 13, name: 'end' }
+           //          ]
+           //      },
+           //      tracks: [
+           //          {
+           //              dataTransform: [
+           //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
+           //                  { type: 'filter', field: 'strand', oneOf: ['+'] }
+           //              ],
+           //              mark: 'triangleRight',
+           //              x: { field: 'end', type: 'genomic' },
+           //              size: { value: 15 }
+           //          },
+           //          {
+           //              dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
+           //              mark: 'text',
+           //              text: { field: 'name', type: 'nominal' },
+           //              x: { field: 'start', type: 'genomic' },
+           //              xe: { field: 'end', type: 'genomic' },
+           //              style: { dy: -15, outline: 'black', outlineWidth: 0 }
+           //          },
+           //          {
+           //              dataTransform: [
+           //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
+           //                  { type: 'filter', field: 'strand', oneOf: ['-'] }
+           //              ],
+           //              mark: 'triangleLeft',
+           //              x: { field: 'start', type: 'genomic' },
+           //              size: { value: 15 },
+           //              style: {
+           //                  align: 'right',
+           //                  outline: 'black',
+           //                  outlineWidth: 0
+           //              }
+           //          },
+           //          {
+           //              dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
+           //              mark: 'rect',
+           //              x: { field: 'start', type: 'genomic' },
+           //              size: { value: 15 },
+           //              xe: { field: 'end', type: 'genomic' }
+           //          },
+           //          {
+           //              dataTransform: [
+           //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
+           //                  { type: 'filter', field: 'strand', oneOf: ['+'] }
+           //              ],
+           //              mark: 'rule',
+           //              x: { field: 'start', type: 'genomic' },
+           //              strokeWidth: { value: 2 },
+           //              xe: { field: 'end', type: 'genomic' },
+           //              style: {
+           //                  linePattern: { type: 'triangleRight', size: 3.5 },
+           //                  outline: 'black',
+           //                  outlineWidth: 0
+           //              }
+           //          },
+           //          {
+           //              dataTransform: [
+           //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
+           //                  { type: 'filter', field: 'strand', oneOf: ['-'] }
+           //              ],
+           //              mark: 'rule',
+           //              x: { field: 'start', type: 'genomic' },
+           //              strokeWidth: { value: 2 },
+           //              xe: { field: 'end', type: 'genomic' },
+           //              style: {
+           //                  linePattern: { type: 'triangleLeft', size: 3.5 },
+           //                  outline: 'black',
+           //                  outlineWidth: 0
+           //              }
+           //          }
+           //      ],
+           //      row: {
+           //          field: 'strand',
+           //          type: 'nominal',
+           //          domain: ['+', '-']
+           //      },
+           //      color: {
+           //          field: 'strand',
+           //          type: 'nominal',
+           //          domain: ['+', '-'],
+           //          range: ['#97A8B2', '#D4C6BA'] //['blue', 'red']
+           //      },
+           //      visibility: [
+           //          {
+           //              operation: 'less-than',
+           //              measure: 'width',
+           //              threshold: '|xe-x|',
+           //              transitionPadding: 10,
+           //              target: 'mark'
+           //          }
+           //      ],
+           //      // opacity: { value: 0.4 },
+           //      width,
+           //      height: 100
+           //  },
+           //  {
+           //      title: 'Sequence',
+           //      ...EX_TRACK_SEMANTIC_ZOOM.sequence,
+           //      style: { inlineLegend: true, outline: 'white' },
+           //      width,
+           //      height: 40
+           //  },
             {
                 alignment: 'overlay',
                 title: 'Reads',
                 data: {
                     type: 'bam',
-                    // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
                     url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam',
-                    indexUrl: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam.bai'
+                    indexUrl: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam.bai',
+                    loadMates: true
                 },
                 mark: 'rect',
                 tracks: [
                     {
                         dataTransform: [
                             {
+                                type: 'combineMates',
+                                idField: 'name',
+                                maintainDuplicates: true,
+                                maxInsertSize: 360 + 79 * 3
+                            },
+                            {
                                 type: 'displace',
                                 method: 'pile',
                                 boundingBox: {
                                     startField: 'from',
                                     endField: 'to',
-                                    groupField: 'strand',
                                     padding: 5,
                                     isPaddingBP: true
                                 },
@@ -182,50 +187,17 @@ export function EX_SPEC_VIEW_PILEUP(
                         ],
                         x: { field: 'from', type: 'genomic' },
                         xe: { field: 'to', type: 'genomic' },
+                        color: {
+                            field: 'is_long',
+                            type: 'nominal',
+                            domain: ['false', 'true'],
+                            range: ['#97A8B2', 'red']
+                        },
                         stroke: { value: 'white' },
                         strokeWidth: { value: 0.5 }
                     },
-                    {
-                        dataTransform: [
-                            {
-                                type: 'displace',
-                                method: 'pile',
-                                boundingBox: {
-                                    startField: 'from',
-                                    endField: 'to',
-                                    groupField: 'strand',
-                                    padding: 5,
-                                    isPaddingBP: true
-                                },
-                                newField: 'pileup-row'
-                            },
-                            {
-                                type: 'subjson',
-                                field: 'substitutions',
-                                genomicField: 'pos',
-                                baseGenomicField: 'from',
-                                genomicLengthField: 'length'
-                            },
-                            { type: 'filter', field: 'type', oneOf: ['sub'] }
-                        ],
-                        x: { field: 'pos_start', type: 'genomic' },
-                        xe: { field: 'pos_end', type: 'genomic' },
-                        color: {
-                            field: 'variant',
-                            type: 'nominal',
-                            domain: ['A', 'T', 'G', 'C', 'S', 'H', 'X', 'I', 'D'],
-                            legend: true
-                        }
-                    }
                 ],
-                y: { field: 'pileup-row', type: 'nominal', flip: false },
-                row: { field: 'strand', type: 'nominal', domain: ['+', '-'], padding: 1 },
-                color: {
-                    field: 'strand',
-                    type: 'nominal',
-                    domain: ['+', '-'],
-                    range: strandColor ?? ['#97A8B2', '#D4C6BA']
-                },
+                row: { field: 'pileup-row', type: 'nominal' },
                 style: { outlineWidth: 0.5 },
                 width,
                 height

--- a/editor/example/pileup.ts
+++ b/editor/example/pileup.ts
@@ -15,145 +15,145 @@ export function EX_SPEC_VIEW_PILEUP(
         xDomain: xDomain,
         spacing: 0.01,
         tracks: [
-           //  {
-           //      id,
-           //      title: 'Coverage',
-           //      data: {
-           //          type: 'bam',
-           //          // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
-           //          url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam',
-           //          indexUrl: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam.bai'
-           //      },
-           //      dataTransform: [{ type: 'coverage', startField: 'from', endField: 'to' }],
-           //      mark: 'bar',
-           //      x: { field: 'from', type: 'genomic' },
-           //      xe: { field: 'to', type: 'genomic' },
-           //      y: { field: 'coverage', type: 'quantitative', axis: 'right', grid: true },
-           //      color: { value: 'lightgray' },
-           //      stroke: { value: 'gray' },
-           //      width,
-           //      height: 80
-           //  },
-           //  {
-           //      alignment: 'overlay',
-           //      title: 'hg38 | Genes',
-           //      data: {
-           //          url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
-           //          type: 'beddb',
-           //          genomicFields: [
-           //              { index: 1, name: 'start' },
-           //              { index: 2, name: 'end' }
-           //          ],
-           //          valueFields: [
-           //              { index: 5, name: 'strand', type: 'nominal' },
-           //              { index: 3, name: 'name', type: 'nominal' }
-           //          ],
-           //          exonIntervalFields: [
-           //              { index: 12, name: 'start' },
-           //              { index: 13, name: 'end' }
-           //          ]
-           //      },
-           //      tracks: [
-           //          {
-           //              dataTransform: [
-           //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
-           //                  { type: 'filter', field: 'strand', oneOf: ['+'] }
-           //              ],
-           //              mark: 'triangleRight',
-           //              x: { field: 'end', type: 'genomic' },
-           //              size: { value: 15 }
-           //          },
-           //          {
-           //              dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
-           //              mark: 'text',
-           //              text: { field: 'name', type: 'nominal' },
-           //              x: { field: 'start', type: 'genomic' },
-           //              xe: { field: 'end', type: 'genomic' },
-           //              style: { dy: -15, outline: 'black', outlineWidth: 0 }
-           //          },
-           //          {
-           //              dataTransform: [
-           //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
-           //                  { type: 'filter', field: 'strand', oneOf: ['-'] }
-           //              ],
-           //              mark: 'triangleLeft',
-           //              x: { field: 'start', type: 'genomic' },
-           //              size: { value: 15 },
-           //              style: {
-           //                  align: 'right',
-           //                  outline: 'black',
-           //                  outlineWidth: 0
-           //              }
-           //          },
-           //          {
-           //              dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
-           //              mark: 'rect',
-           //              x: { field: 'start', type: 'genomic' },
-           //              size: { value: 15 },
-           //              xe: { field: 'end', type: 'genomic' }
-           //          },
-           //          {
-           //              dataTransform: [
-           //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
-           //                  { type: 'filter', field: 'strand', oneOf: ['+'] }
-           //              ],
-           //              mark: 'rule',
-           //              x: { field: 'start', type: 'genomic' },
-           //              strokeWidth: { value: 2 },
-           //              xe: { field: 'end', type: 'genomic' },
-           //              style: {
-           //                  linePattern: { type: 'triangleRight', size: 3.5 },
-           //                  outline: 'black',
-           //                  outlineWidth: 0
-           //              }
-           //          },
-           //          {
-           //              dataTransform: [
-           //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
-           //                  { type: 'filter', field: 'strand', oneOf: ['-'] }
-           //              ],
-           //              mark: 'rule',
-           //              x: { field: 'start', type: 'genomic' },
-           //              strokeWidth: { value: 2 },
-           //              xe: { field: 'end', type: 'genomic' },
-           //              style: {
-           //                  linePattern: { type: 'triangleLeft', size: 3.5 },
-           //                  outline: 'black',
-           //                  outlineWidth: 0
-           //              }
-           //          }
-           //      ],
-           //      row: {
-           //          field: 'strand',
-           //          type: 'nominal',
-           //          domain: ['+', '-']
-           //      },
-           //      color: {
-           //          field: 'strand',
-           //          type: 'nominal',
-           //          domain: ['+', '-'],
-           //          range: ['#97A8B2', '#D4C6BA'] //['blue', 'red']
-           //      },
-           //      visibility: [
-           //          {
-           //              operation: 'less-than',
-           //              measure: 'width',
-           //              threshold: '|xe-x|',
-           //              transitionPadding: 10,
-           //              target: 'mark'
-           //          }
-           //      ],
-           //      // opacity: { value: 0.4 },
-           //      width,
-           //      height: 100
-           //  },
-           //  {
-           //      title: 'Sequence',
-           //      ...EX_TRACK_SEMANTIC_ZOOM.sequence,
-           //      style: { inlineLegend: true, outline: 'white' },
-           //      width,
-           //      height: 40
-           //  },
+            //  {
+            //      id,
+            //      title: 'Coverage',
+            //      data: {
+            //          type: 'bam',
+            //          // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
+            //          url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam',
+            //          indexUrl: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam.bai'
+            //      },
+            //      dataTransform: [{ type: 'coverage', startField: 'from', endField: 'to' }],
+            //      mark: 'bar',
+            //      x: { field: 'from', type: 'genomic' },
+            //      xe: { field: 'to', type: 'genomic' },
+            //      y: { field: 'coverage', type: 'quantitative', axis: 'right', grid: true },
+            //      color: { value: 'lightgray' },
+            //      stroke: { value: 'gray' },
+            //      width,
+            //      height: 80
+            //  },
+            //  {
+            //      alignment: 'overlay',
+            //      title: 'hg38 | Genes',
+            //      data: {
+            //          url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
+            //          type: 'beddb',
+            //          genomicFields: [
+            //              { index: 1, name: 'start' },
+            //              { index: 2, name: 'end' }
+            //          ],
+            //          valueFields: [
+            //              { index: 5, name: 'strand', type: 'nominal' },
+            //              { index: 3, name: 'name', type: 'nominal' }
+            //          ],
+            //          exonIntervalFields: [
+            //              { index: 12, name: 'start' },
+            //              { index: 13, name: 'end' }
+            //          ]
+            //      },
+            //      tracks: [
+            //          {
+            //              dataTransform: [
+            //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
+            //                  { type: 'filter', field: 'strand', oneOf: ['+'] }
+            //              ],
+            //              mark: 'triangleRight',
+            //              x: { field: 'end', type: 'genomic' },
+            //              size: { value: 15 }
+            //          },
+            //          {
+            //              dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
+            //              mark: 'text',
+            //              text: { field: 'name', type: 'nominal' },
+            //              x: { field: 'start', type: 'genomic' },
+            //              xe: { field: 'end', type: 'genomic' },
+            //              style: { dy: -15, outline: 'black', outlineWidth: 0 }
+            //          },
+            //          {
+            //              dataTransform: [
+            //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
+            //                  { type: 'filter', field: 'strand', oneOf: ['-'] }
+            //              ],
+            //              mark: 'triangleLeft',
+            //              x: { field: 'start', type: 'genomic' },
+            //              size: { value: 15 },
+            //              style: {
+            //                  align: 'right',
+            //                  outline: 'black',
+            //                  outlineWidth: 0
+            //              }
+            //          },
+            //          {
+            //              dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
+            //              mark: 'rect',
+            //              x: { field: 'start', type: 'genomic' },
+            //              size: { value: 15 },
+            //              xe: { field: 'end', type: 'genomic' }
+            //          },
+            //          {
+            //              dataTransform: [
+            //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
+            //                  { type: 'filter', field: 'strand', oneOf: ['+'] }
+            //              ],
+            //              mark: 'rule',
+            //              x: { field: 'start', type: 'genomic' },
+            //              strokeWidth: { value: 2 },
+            //              xe: { field: 'end', type: 'genomic' },
+            //              style: {
+            //                  linePattern: { type: 'triangleRight', size: 3.5 },
+            //                  outline: 'black',
+            //                  outlineWidth: 0
+            //              }
+            //          },
+            //          {
+            //              dataTransform: [
+            //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
+            //                  { type: 'filter', field: 'strand', oneOf: ['-'] }
+            //              ],
+            //              mark: 'rule',
+            //              x: { field: 'start', type: 'genomic' },
+            //              strokeWidth: { value: 2 },
+            //              xe: { field: 'end', type: 'genomic' },
+            //              style: {
+            //                  linePattern: { type: 'triangleLeft', size: 3.5 },
+            //                  outline: 'black',
+            //                  outlineWidth: 0
+            //              }
+            //          }
+            //      ],
+            //      row: {
+            //          field: 'strand',
+            //          type: 'nominal',
+            //          domain: ['+', '-']
+            //      },
+            //      color: {
+            //          field: 'strand',
+            //          type: 'nominal',
+            //          domain: ['+', '-'],
+            //          range: ['#97A8B2', '#D4C6BA'] //['blue', 'red']
+            //      },
+            //      visibility: [
+            //          {
+            //              operation: 'less-than',
+            //              measure: 'width',
+            //              threshold: '|xe-x|',
+            //              transitionPadding: 10,
+            //              target: 'mark'
+            //          }
+            //      ],
+            //      // opacity: { value: 0.4 },
+            //      width,
+            //      height: 100
+            //  },
+            //  {
+            //      title: 'Sequence',
+            //      ...EX_TRACK_SEMANTIC_ZOOM.sequence,
+            //      style: { inlineLegend: true, outline: 'white' },
+            //      width,
+            //      height: 40
+            //  },
             {
                 alignment: 'overlay',
                 title: 'Reads',
@@ -195,7 +195,7 @@ export function EX_SPEC_VIEW_PILEUP(
                         },
                         stroke: { value: 'white' },
                         strokeWidth: { value: 0.5 }
-                    },
+                    }
                 ],
                 row: { field: 'pileup-row', type: 'nominal' },
                 style: { outlineWidth: 0.5 },

--- a/editor/example/pileup.ts
+++ b/editor/example/pileup.ts
@@ -41,7 +41,7 @@ export function EX_SPEC_VIEW_PILEUP(
                         color: { value: '#C6C6C6' }
                     }
                 ],
-                style: { outlineWidth: 0.5},
+                style: { outlineWidth: 0.5 },
                 width,
                 height: 80
             },
@@ -62,7 +62,7 @@ export function EX_SPEC_VIEW_PILEUP(
                                 type: 'combineMates',
                                 idField: 'name',
                                 maintainDuplicates: true,
-                                maxInsertSize, // 360 // + 79 * 3
+                                maxInsertSize // 360 // + 79 * 3
                             },
                             {
                                 type: 'displace',
@@ -78,18 +78,35 @@ export function EX_SPEC_VIEW_PILEUP(
                         ],
                         x: { field: 'from', type: 'genomic' },
                         xe: { field: 'to', type: 'genomic' },
-                        color: [{
-                            field: 'is_long',
-                            type: 'nominal',
-                            legend: true,
-                            domain: ['normal reads', 'deletion (+-)', 'inversion (++)', 'inversion (--)', 'translocation or duplication (-+)'],
-                            range: ['#C8C8C8', '#E79F00', '#029F73', '#0072B2', '#CB7AA7', '#D45E00', '#57B4E9', '#EFE441']
-                        },
-                        {
-                           field: 'insertSize',
-                           type: 'quantitative',
-                           legend: true
-                        }][1]
+                        color: [
+                            {
+                                field: 'is_long',
+                                type: 'nominal',
+                                legend: true,
+                                domain: [
+                                    'normal reads',
+                                    'deletion (+-)',
+                                    'inversion (++)',
+                                    'inversion (--)',
+                                    'translocation or duplication (-+)'
+                                ],
+                                range: [
+                                    '#C8C8C8',
+                                    '#E79F00',
+                                    '#029F73',
+                                    '#0072B2',
+                                    '#CB7AA7',
+                                    '#D45E00',
+                                    '#57B4E9',
+                                    '#EFE441'
+                                ]
+                            },
+                            {
+                                field: 'insertSize',
+                                type: 'quantitative',
+                                legend: true
+                            }
+                        ][1]
                     }
                 ],
                 tooltip: [
@@ -101,7 +118,7 @@ export function EX_SPEC_VIEW_PILEUP(
                 row: { field: 'pileup-row', type: 'nominal', padding: 0.5 },
                 // stroke: { value: 'grey' },
                 // strokeWidth: { value: 0.5 },
-                style: { outlineWidth: 0.5, legendTitle: `Max Insert Size = ${maxInsertSize}bp`},
+                style: { outlineWidth: 0.5, legendTitle: `Max Insert Size = ${maxInsertSize}bp` },
                 width,
                 height
             }

--- a/editor/example/pileup.ts
+++ b/editor/example/pileup.ts
@@ -1,12 +1,10 @@
 import type { Domain, DomainGene, GoslingSpec, View } from '@gosling.schema';
-// import { EX_TRACK_SEMANTIC_ZOOM } from './semantic-zoom';
 
 export function EX_SPEC_VIEW_PILEUP(
     id: string,
     width: number,
     height: number,
     xDomain: Exclude<Domain, string[] | number[] | DomainGene>
-    // strandColor?: [number, number]
 ): View {
     const maxInsertSize = 300;
     return {
@@ -16,45 +14,42 @@ export function EX_SPEC_VIEW_PILEUP(
         xDomain: xDomain,
         spacing: 0.01,
         tracks: [
-            // {
-            //     alignment: 'overlay',
-            //     title: 'example_higlass.bam',
-            //     data: {
-            //         type: 'bam',
-            //         url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam',
-            //         indexUrl: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam.bai', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam.bai',
-            //         loadMates: true
-            //     },
-            //     mark: 'bar',
-            //     tracks: [
-            //         {
-            //             dataTransform: [
-            //                 {
-            //                     type: 'coverage',
-            //                     startField: 'from',
-            //                     endField: 'to'
-            //                 }
-            //             ],
-            //             x: { field: 'from', type: 'genomic' },
-            //             xe: { field: 'to', type: 'genomic' },
-            //             y: { field: 'coverage', type: 'quantitative', axis: 'right' },
-            //             color: { value: '#C6C6C6' }
-            //         }
-            //     ],
-            //     style: { outlineWidth: 0.5 },
-            //     width,
-            //     height: 80
-            // },
             {
                 alignment: 'overlay',
-                // title: 'example_higlass.bam',
+                title: 'example_higlass.bam',
                 data: {
                     type: 'bam',
-                    // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam',
-                    // indexUrl: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam.bai',
-                    url: 'https://s3.amazonaws.com/gosling-lang.org/data/PCAWG.00e7f3bd-5c87-40c2-aeb6-4e4ca4a8e720.bam', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam',
-                    indexUrl:
-                        'https://s3.amazonaws.com/gosling-lang.org/data/PCAWG.00e7f3bd-5c87-40c2-aeb6-4e4ca4a8e720.bam.bai', //'https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam.bai',
+                    url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam',
+                    indexUrl: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam.bai',
+                    loadMates: true
+                },
+                mark: 'bar',
+                tracks: [
+                    {
+                        dataTransform: [
+                            {
+                                type: 'coverage',
+                                startField: 'from',
+                                endField: 'to'
+                            }
+                        ],
+                        x: { field: 'from', type: 'genomic' },
+                        xe: { field: 'to', type: 'genomic' },
+                        y: { field: 'coverage', type: 'quantitative', axis: 'right' },
+                        color: { value: '#C6C6C6' }
+                    }
+                ],
+                style: { outlineWidth: 0.5 },
+                width,
+                height: 80
+            },
+            {
+                alignment: 'overlay',
+                title: 'example_higlass.bam',
+                data: {
+                    type: 'bam',
+                    url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam',
+                    indexUrl: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam.bai',
                     loadMates: true,
                     maxInsertSize
                 },
@@ -146,8 +141,6 @@ export function EX_SPEC_VIEW_PILEUP(
                     { field: 'mateIds', type: 'nominal' }
                 ],
                 row: { field: 'pileup-row', type: 'nominal', padding: 0.2 },
-                // stroke: { value: 'grey' },
-                // strokeWidth: { value: 0.5 },
                 style: { outlineWidth: 0.5, legendTitle: `Insert Size = ${maxInsertSize}bp` },
                 width,
                 height
@@ -157,8 +150,7 @@ export function EX_SPEC_VIEW_PILEUP(
 }
 
 export const EX_SPEC_PILEUP: GoslingSpec = {
-    // title: 'Pileup Track Using BAM Data',
-    // subtitle: '',
-    // ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [136750, 139450] })
-    ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [98000, 101000] })
+    title: 'Pileup Track Using BAM Data',
+    subtitle: '',
+    ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [136750, 139450] })
 };

--- a/editor/example/pileup.ts
+++ b/editor/example/pileup.ts
@@ -107,7 +107,7 @@ export function EX_SPEC_VIEW_PILEUP(
                                 type: 'quantitative',
                                 legend: true
                             }
-                        ][0]
+                        ][0] as any
                     },
                     {
                         dataTransform: [

--- a/editor/example/pileup.ts
+++ b/editor/example/pileup.ts
@@ -62,12 +62,6 @@ export function EX_SPEC_VIEW_PILEUP(
                 tracks: [
                     {
                         dataTransform: [
-                            //  {
-                            //      type: 'combineMates',
-                            //      idField: 'name',
-                            //      maintainDuplicates: true,
-                            //      maxInsertSize // 360 // + 79 * 3
-                            //  },
                             {
                                 type: 'displace',
                                 method: 'pile',
@@ -93,8 +87,9 @@ export function EX_SPEC_VIEW_PILEUP(
                                     'inversion (++)',
                                     'inversion (--)',
                                     'duplication (-+)',
+                                    'more than two mates',
                                     'mates not found',
-                                    'more than two mates'
+                                    'clipping'
                                 ],
                                 range: [
                                     '#C8C8C8',
@@ -102,9 +97,9 @@ export function EX_SPEC_VIEW_PILEUP(
                                     '#029F73',
                                     '#0072B2',
                                     '#CB7AA7',
-                                    'gray',
                                     '#57B4E9',
-                                    '#EFE441'
+                                    '#D61E2E',
+                                    '#414141'
                                 ]
                             },
                             {
@@ -113,6 +108,32 @@ export function EX_SPEC_VIEW_PILEUP(
                                 legend: true
                             }
                         ][0]
+                    },
+                    {
+                        dataTransform: [
+                            {
+                                type: 'displace',
+                                method: 'pile',
+                                boundingBox: {
+                                    startField: 'from',
+                                    endField: 'to',
+                                    padding: 5,
+                                    isPaddingBP: true
+                                },
+                                newField: 'pileup-row'
+                            },
+                            {
+                                type: 'subjson',
+                                field: 'substitutions',
+                                genomicField: 'pos',
+                                baseGenomicField: 'from',
+                                genomicLengthField: 'length'
+                            },
+                            { type: 'filter', field: 'type', oneOf: ['S', 'H'] }
+                        ],
+                        x: { field: 'pos_start', type: 'genomic' },
+                        xe: { field: 'pos_end', type: 'genomic' },
+                        color: { value: '#414141' }
                     }
                 ],
                 tooltip: [
@@ -124,10 +145,10 @@ export function EX_SPEC_VIEW_PILEUP(
                     { field: 'numMates', type: 'quantitative' },
                     { field: 'mateIds', type: 'nominal' }
                 ],
-                row: { field: 'pileup-row', type: 'nominal', padding: 0.5 },
+                row: { field: 'pileup-row', type: 'nominal', padding: 0.2 },
                 // stroke: { value: 'grey' },
                 // strokeWidth: { value: 0.5 },
-                style: { outlineWidth: 0.5, legendTitle: `Insert Size Threshold = ${maxInsertSize}bp` },
+                style: { outlineWidth: 0.5, legendTitle: `Insert Size = ${maxInsertSize}bp` },
                 width,
                 height
             }
@@ -139,5 +160,5 @@ export const EX_SPEC_PILEUP: GoslingSpec = {
     // title: 'Pileup Track Using BAM Data',
     // subtitle: '',
     // ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [136750, 139450] })
-    ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [596000, 608000] })
+    ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [98000, 101000] })
 };

--- a/editor/example/pileup.ts
+++ b/editor/example/pileup.ts
@@ -88,7 +88,7 @@ export function EX_SPEC_VIEW_PILEUP(
                                     'inversion (--)',
                                     'duplication (-+)',
                                     'more than two mates',
-                                    'mates not found',
+                                    'mates not found within chromosome',
                                     'clipping'
                                 ],
                                 range: [

--- a/editor/example/pileup.ts
+++ b/editor/example/pileup.ts
@@ -8,6 +8,7 @@ export function EX_SPEC_VIEW_PILEUP(
     xDomain: Exclude<Domain, string[] | number[] | DomainGene>,
     strandColor?: [number, number]
 ): View {
+    const maxInsertSize = 300;
     return {
         static: false,
         layout: 'linear',
@@ -15,152 +16,42 @@ export function EX_SPEC_VIEW_PILEUP(
         xDomain: xDomain,
         spacing: 0.01,
         tracks: [
-            //  {
-            //      id,
-            //      title: 'Coverage',
-            //      data: {
-            //          type: 'bam',
-            //          // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam'
-            //          url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam',
-            //          indexUrl: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam.bai'
-            //      },
-            //      dataTransform: [{ type: 'coverage', startField: 'from', endField: 'to' }],
-            //      mark: 'bar',
-            //      x: { field: 'from', type: 'genomic' },
-            //      xe: { field: 'to', type: 'genomic' },
-            //      y: { field: 'coverage', type: 'quantitative', axis: 'right', grid: true },
-            //      color: { value: 'lightgray' },
-            //      stroke: { value: 'gray' },
-            //      width,
-            //      height: 80
-            //  },
-            //  {
-            //      alignment: 'overlay',
-            //      title: 'hg38 | Genes',
-            //      data: {
-            //          url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=gene-annotation',
-            //          type: 'beddb',
-            //          genomicFields: [
-            //              { index: 1, name: 'start' },
-            //              { index: 2, name: 'end' }
-            //          ],
-            //          valueFields: [
-            //              { index: 5, name: 'strand', type: 'nominal' },
-            //              { index: 3, name: 'name', type: 'nominal' }
-            //          ],
-            //          exonIntervalFields: [
-            //              { index: 12, name: 'start' },
-            //              { index: 13, name: 'end' }
-            //          ]
-            //      },
-            //      tracks: [
-            //          {
-            //              dataTransform: [
-            //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
-            //                  { type: 'filter', field: 'strand', oneOf: ['+'] }
-            //              ],
-            //              mark: 'triangleRight',
-            //              x: { field: 'end', type: 'genomic' },
-            //              size: { value: 15 }
-            //          },
-            //          {
-            //              dataTransform: [{ type: 'filter', field: 'type', oneOf: ['gene'] }],
-            //              mark: 'text',
-            //              text: { field: 'name', type: 'nominal' },
-            //              x: { field: 'start', type: 'genomic' },
-            //              xe: { field: 'end', type: 'genomic' },
-            //              style: { dy: -15, outline: 'black', outlineWidth: 0 }
-            //          },
-            //          {
-            //              dataTransform: [
-            //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
-            //                  { type: 'filter', field: 'strand', oneOf: ['-'] }
-            //              ],
-            //              mark: 'triangleLeft',
-            //              x: { field: 'start', type: 'genomic' },
-            //              size: { value: 15 },
-            //              style: {
-            //                  align: 'right',
-            //                  outline: 'black',
-            //                  outlineWidth: 0
-            //              }
-            //          },
-            //          {
-            //              dataTransform: [{ type: 'filter', field: 'type', oneOf: ['exon'] }],
-            //              mark: 'rect',
-            //              x: { field: 'start', type: 'genomic' },
-            //              size: { value: 15 },
-            //              xe: { field: 'end', type: 'genomic' }
-            //          },
-            //          {
-            //              dataTransform: [
-            //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
-            //                  { type: 'filter', field: 'strand', oneOf: ['+'] }
-            //              ],
-            //              mark: 'rule',
-            //              x: { field: 'start', type: 'genomic' },
-            //              strokeWidth: { value: 2 },
-            //              xe: { field: 'end', type: 'genomic' },
-            //              style: {
-            //                  linePattern: { type: 'triangleRight', size: 3.5 },
-            //                  outline: 'black',
-            //                  outlineWidth: 0
-            //              }
-            //          },
-            //          {
-            //              dataTransform: [
-            //                  { type: 'filter', field: 'type', oneOf: ['gene'] },
-            //                  { type: 'filter', field: 'strand', oneOf: ['-'] }
-            //              ],
-            //              mark: 'rule',
-            //              x: { field: 'start', type: 'genomic' },
-            //              strokeWidth: { value: 2 },
-            //              xe: { field: 'end', type: 'genomic' },
-            //              style: {
-            //                  linePattern: { type: 'triangleLeft', size: 3.5 },
-            //                  outline: 'black',
-            //                  outlineWidth: 0
-            //              }
-            //          }
-            //      ],
-            //      row: {
-            //          field: 'strand',
-            //          type: 'nominal',
-            //          domain: ['+', '-']
-            //      },
-            //      color: {
-            //          field: 'strand',
-            //          type: 'nominal',
-            //          domain: ['+', '-'],
-            //          range: ['#97A8B2', '#D4C6BA'] //['blue', 'red']
-            //      },
-            //      visibility: [
-            //          {
-            //              operation: 'less-than',
-            //              measure: 'width',
-            //              threshold: '|xe-x|',
-            //              transitionPadding: 10,
-            //              target: 'mark'
-            //          }
-            //      ],
-            //      // opacity: { value: 0.4 },
-            //      width,
-            //      height: 100
-            //  },
-            //  {
-            //      title: 'Sequence',
-            //      ...EX_TRACK_SEMANTIC_ZOOM.sequence,
-            //      style: { inlineLegend: true, outline: 'white' },
-            //      width,
-            //      height: 40
-            //  },
             {
                 alignment: 'overlay',
-                title: 'Reads',
+                title: 'example_higlass.bam',
                 data: {
                     type: 'bam',
-                    url: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam',
-                    indexUrl: 'https://aveit.s3.amazonaws.com/higlass/bam/example_higlass.bam.bai',
+                    url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam',
+                    indexUrl: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam.bai', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam.bai',
+                    loadMates: true
+                },
+                mark: 'bar',
+                tracks: [
+                    {
+                        dataTransform: [
+                            {
+                                type: 'coverage',
+                                startField: 'from',
+                                endField: 'to'
+                            }
+                        ],
+                        x: { field: 'from', type: 'genomic' },
+                        xe: { field: 'to', type: 'genomic' },
+                        y: { field: 'coverage', type: 'quantitative', axis: 'right' },
+                        color: { value: '#C6C6C6' }
+                    }
+                ],
+                style: { outlineWidth: 0.5},
+                width,
+                height: 80
+            },
+            {
+                alignment: 'overlay',
+                title: 'example_higlass.bam',
+                data: {
+                    type: 'bam',
+                    url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam',
+                    indexUrl: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam.bai', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam.bai',
                     loadMates: true
                 },
                 mark: 'rect',
@@ -171,7 +62,7 @@ export function EX_SPEC_VIEW_PILEUP(
                                 type: 'combineMates',
                                 idField: 'name',
                                 maintainDuplicates: true,
-                                maxInsertSize: 360 + 79 * 3
+                                maxInsertSize, // 360 // + 79 * 3
                             },
                             {
                                 type: 'displace',
@@ -187,18 +78,30 @@ export function EX_SPEC_VIEW_PILEUP(
                         ],
                         x: { field: 'from', type: 'genomic' },
                         xe: { field: 'to', type: 'genomic' },
-                        color: {
+                        color: [{
                             field: 'is_long',
                             type: 'nominal',
-                            domain: ['false', 'true'],
-                            range: ['#97A8B2', 'red']
+                            legend: true,
+                            domain: ['normal reads', 'deletion (+-)', 'inversion (++)', 'inversion (--)', 'translocation or duplication (-+)'],
+                            range: ['#C8C8C8', '#E79F00', '#029F73', '#0072B2', '#CB7AA7', '#D45E00', '#57B4E9', '#EFE441']
                         },
-                        stroke: { value: 'white' },
-                        strokeWidth: { value: 0.5 }
+                        {
+                           field: 'insertSize',
+                           type: 'quantitative',
+                           legend: true
+                        }][1]
                     }
                 ],
-                row: { field: 'pileup-row', type: 'nominal' },
-                style: { outlineWidth: 0.5 },
+                tooltip: [
+                    { field: 'from', type: 'genomic' },
+                    { field: 'to', type: 'genomic' },
+                    { field: 'is_long', type: 'nominal' },
+                    { field: 'strand', type: 'nominal' }
+                ],
+                row: { field: 'pileup-row', type: 'nominal', padding: 0.5 },
+                // stroke: { value: 'grey' },
+                // strokeWidth: { value: 0.5 },
+                style: { outlineWidth: 0.5, legendTitle: `Max Insert Size = ${maxInsertSize}bp`},
                 width,
                 height
             }
@@ -207,7 +110,8 @@ export function EX_SPEC_VIEW_PILEUP(
 }
 
 export const EX_SPEC_PILEUP: GoslingSpec = {
-    title: 'Pileup Track Using BAM Data',
-    subtitle: '',
-    ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [136750, 139450] })
+    // title: 'Pileup Track Using BAM Data',
+    // subtitle: '',
+    // ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [136750, 139450] })
+    ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [196000, 208000] })
 };

--- a/editor/example/pileup.ts
+++ b/editor/example/pileup.ts
@@ -1,12 +1,12 @@
 import type { Domain, DomainGene, GoslingSpec, View } from '@gosling.schema';
-import { EX_TRACK_SEMANTIC_ZOOM } from './semantic-zoom';
+// import { EX_TRACK_SEMANTIC_ZOOM } from './semantic-zoom';
 
 export function EX_SPEC_VIEW_PILEUP(
     id: string,
     width: number,
     height: number,
-    xDomain: Exclude<Domain, string[] | number[] | DomainGene>,
-    strandColor?: [number, number]
+    xDomain: Exclude<Domain, string[] | number[] | DomainGene>
+    // strandColor?: [number, number]
 ): View {
     const maxInsertSize = 300;
     return {
@@ -16,54 +16,58 @@ export function EX_SPEC_VIEW_PILEUP(
         xDomain: xDomain,
         spacing: 0.01,
         tracks: [
+            // {
+            //     alignment: 'overlay',
+            //     title: 'example_higlass.bam',
+            //     data: {
+            //         type: 'bam',
+            //         url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam',
+            //         indexUrl: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam.bai', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam.bai',
+            //         loadMates: true
+            //     },
+            //     mark: 'bar',
+            //     tracks: [
+            //         {
+            //             dataTransform: [
+            //                 {
+            //                     type: 'coverage',
+            //                     startField: 'from',
+            //                     endField: 'to'
+            //                 }
+            //             ],
+            //             x: { field: 'from', type: 'genomic' },
+            //             xe: { field: 'to', type: 'genomic' },
+            //             y: { field: 'coverage', type: 'quantitative', axis: 'right' },
+            //             color: { value: '#C6C6C6' }
+            //         }
+            //     ],
+            //     style: { outlineWidth: 0.5 },
+            //     width,
+            //     height: 80
+            // },
             {
                 alignment: 'overlay',
-                title: 'example_higlass.bam',
+                // title: 'example_higlass.bam',
                 data: {
                     type: 'bam',
-                    url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam',
-                    indexUrl: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam.bai', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam.bai',
-                    loadMates: true
-                },
-                mark: 'bar',
-                tracks: [
-                    {
-                        dataTransform: [
-                            {
-                                type: 'coverage',
-                                startField: 'from',
-                                endField: 'to'
-                            }
-                        ],
-                        x: { field: 'from', type: 'genomic' },
-                        xe: { field: 'to', type: 'genomic' },
-                        y: { field: 'coverage', type: 'quantitative', axis: 'right' },
-                        color: { value: '#C6C6C6' }
-                    }
-                ],
-                style: { outlineWidth: 0.5 },
-                width,
-                height: 80
-            },
-            {
-                alignment: 'overlay',
-                title: 'example_higlass.bam',
-                data: {
-                    type: 'bam',
-                    url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam',
-                    indexUrl: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam.bai', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam.bai',
-                    loadMates: true
+                    // url: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam',
+                    // indexUrl: 'https://s3.amazonaws.com/gosling-lang.org/data/example_higlass.bam.bai',
+                    url: 'https://s3.amazonaws.com/gosling-lang.org/data/PCAWG.00e7f3bd-5c87-40c2-aeb6-4e4ca4a8e720.bam', // https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam',
+                    indexUrl:
+                        'https://s3.amazonaws.com/gosling-lang.org/data/PCAWG.00e7f3bd-5c87-40c2-aeb6-4e4ca4a8e720.bam.bai', //'https://s3.amazonaws.com/gosling-lang.org/data/SV/PCAWG.c8e7bbdb-6d87-445f-bf43-dbf88805b1ed.bam.bai',
+                    loadMates: true,
+                    maxInsertSize
                 },
                 mark: 'rect',
                 tracks: [
                     {
                         dataTransform: [
-                            {
-                                type: 'combineMates',
-                                idField: 'name',
-                                maintainDuplicates: true,
-                                maxInsertSize // 360 // + 79 * 3
-                            },
+                            //  {
+                            //      type: 'combineMates',
+                            //      idField: 'name',
+                            //      maintainDuplicates: true,
+                            //      maxInsertSize // 360 // + 79 * 3
+                            //  },
                             {
                                 type: 'displace',
                                 method: 'pile',
@@ -80,15 +84,17 @@ export function EX_SPEC_VIEW_PILEUP(
                         xe: { field: 'to', type: 'genomic' },
                         color: [
                             {
-                                field: 'is_long',
+                                field: 'svType',
                                 type: 'nominal',
                                 legend: true,
                                 domain: [
-                                    'normal reads',
+                                    'normal read',
                                     'deletion (+-)',
                                     'inversion (++)',
                                     'inversion (--)',
-                                    'translocation or duplication (-+)'
+                                    'duplication (-+)',
+                                    'mates not found',
+                                    'more than two mates'
                                 ],
                                 range: [
                                     '#C8C8C8',
@@ -96,7 +102,7 @@ export function EX_SPEC_VIEW_PILEUP(
                                     '#029F73',
                                     '#0072B2',
                                     '#CB7AA7',
-                                    '#D45E00',
+                                    'gray',
                                     '#57B4E9',
                                     '#EFE441'
                                 ]
@@ -106,19 +112,22 @@ export function EX_SPEC_VIEW_PILEUP(
                                 type: 'quantitative',
                                 legend: true
                             }
-                        ][1]
+                        ][0]
                     }
                 ],
                 tooltip: [
                     { field: 'from', type: 'genomic' },
                     { field: 'to', type: 'genomic' },
-                    { field: 'is_long', type: 'nominal' },
-                    { field: 'strand', type: 'nominal' }
+                    { field: 'insertSize', type: 'quantitative' },
+                    { field: 'svType', type: 'nominal' },
+                    { field: 'strand', type: 'nominal' },
+                    { field: 'numMates', type: 'quantitative' },
+                    { field: 'mateIds', type: 'nominal' }
                 ],
                 row: { field: 'pileup-row', type: 'nominal', padding: 0.5 },
                 // stroke: { value: 'grey' },
                 // strokeWidth: { value: 0.5 },
-                style: { outlineWidth: 0.5, legendTitle: `Max Insert Size = ${maxInsertSize}bp` },
+                style: { outlineWidth: 0.5, legendTitle: `Insert Size Threshold = ${maxInsertSize}bp` },
                 width,
                 height
             }
@@ -130,5 +139,5 @@ export const EX_SPEC_PILEUP: GoslingSpec = {
     // title: 'Pileup Track Using BAM Data',
     // subtitle: '',
     // ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [136750, 139450] })
-    ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [196000, 208000] })
+    ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [596000, 608000] })
 };

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -44,9 +44,11 @@
           "type": "string"
         },
         "loadMates": {
+          "description": "Load mates that are located in the same chromosome. __Default__: `false`",
           "type": "boolean"
         },
         "maxInsertSize": {
+          "description": "Determines the threshold of insert sizes for determining the structural variants. __Default__: `5000`",
           "type": "number"
         },
         "type": {
@@ -428,7 +430,7 @@
           "description": "Determine the colors that should be bound to data value. Default properties are determined considering the field type."
         },
         "type": {
-          "description": "Data type",
+          "description": "Specify the data type",
           "enum": [
             "quantitative",
             "nominal"
@@ -436,33 +438,6 @@
           "type": "string"
         }
       },
-      "type": "object"
-    },
-    "CombineMatesTransform": {
-      "additionalProperties": false,
-      "description": "By looking up ids, combine mates (a pair of reads) into a single row, performing long-to-wide operation. Result data have `{field}` and `{field}_2` names.",
-      "properties": {
-        "idField": {
-          "type": "string"
-        },
-        "isLongField": {
-          "type": "string"
-        },
-        "maintainDuplicates": {
-          "type": "boolean"
-        },
-        "maxInsertSize": {
-          "type": "number"
-        },
-        "type": {
-          "const": "combineMates",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type",
-        "idField"
-      ],
       "type": "object"
     },
     "CoverageTransform": {
@@ -672,9 +647,6 @@
         },
         {
           "$ref": "#/definitions/CoverageTransform"
-        },
-        {
-          "$ref": "#/definitions/CombineMatesTransform"
         },
         {
           "$ref": "#/definitions/JSONParseTransform"
@@ -1500,7 +1472,7 @@
           "description": "Ranges of visual channel values"
         },
         "type": {
-          "description": "Data type",
+          "description": "Specify the data type",
           "enum": [
             "quantitative",
             "nominal"
@@ -3943,7 +3915,7 @@
         },
         "type": {
           "const": "nominal",
-          "description": "Data type",
+          "description": "Specify the data type",
           "type": "string"
         }
       },
@@ -4290,7 +4262,7 @@
           "description": "Ranges of visual channel values"
         },
         "type": {
-          "description": "Data type",
+          "description": "Specify the data type",
           "enum": [
             "quantitative",
             "nominal"
@@ -4759,7 +4731,7 @@
           "description": "Ranges of visual channel values"
         },
         "type": {
-          "description": "Data type",
+          "description": "Specify the data type",
           "enum": [
             "quantitative",
             "nominal"
@@ -4785,7 +4757,7 @@
           "description": "Ranges of visual channel values"
         },
         "type": {
-          "description": "Data type",
+          "description": "Specify the data type",
           "enum": [
             "quantitative",
             "nominal"
@@ -5089,7 +5061,7 @@
           "type": "array"
         },
         "type": {
-          "description": "Data type",
+          "description": "Specify the data type",
           "enum": [
             "quantitative",
             "nominal"

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -255,9 +255,6 @@
           "description": "The name of a nominal field to group rows by in prior to piling-up",
           "type": "string"
         },
-        "idField": {
-          "type": "string"
-        },
         "inRange": {
           "description": "Check whether the value is in a number range.",
           "items": {
@@ -268,15 +265,6 @@
         "include": {
           "description": "Check whether the value includes a substring.",
           "type": "string"
-        },
-        "isLongField": {
-          "type": "string"
-        },
-        "maintainDuplicates": {
-          "type": "boolean"
-        },
-        "maxInsertSize": {
-          "type": "number"
         },
         "maxRows": {
           "description": "Specify maximum rows to be generated (default has no limit).",
@@ -345,7 +333,6 @@
             "exonSplit",
             "genomicLength",
             "coverage",
-            "combineMates",
             "subjson"
           ],
           "type": "string"

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -11,6 +11,11 @@ export type CommonEventData = {
     genomicPosition: string;
 };
 
+export type RawDataEventData = {
+    id: string;
+    data: Datum[];
+};
+
 // Utility type for building strongly typed PubSub API.
 //
 // Add named events using a string union for `EventName`
@@ -23,7 +28,7 @@ type PubSubEvent<EventName extends string, Payload> = {
 };
 
 // New `PubSubEvent`s should be added to the `EventMap`...
-type EventMap = PubSubEvent<'mouseover' | 'click', CommonEventData>;
+type EventMap = PubSubEvent<'mouseover' | 'click', CommonEventData> & PubSubEvent<'rawdata', RawDataEventData>;
 // & PubSubEvent<'my-event', { hello: 'world' }> & PubSubEvent<'foo', "bar">;
 
 /**
@@ -111,6 +116,8 @@ export function createApi(
                 case 'mouseover':
                     return PubSub.subscribe(type, callback);
                 case 'click':
+                    return PubSub.subscribe(type, callback);
+                case 'rawdata':
                     return PubSub.subscribe(type, callback);
                 default: {
                     console.error(`Event type not recognized, got ${JSON.stringify(type)}.`);

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -28,6 +28,10 @@ export function goslingToHiGlass(
     // we only look into the first resolved spec to get information, such as size of the track
     const firstResolvedSpec = resolveSuperposedTracks(gosTrack)[0];
 
+    if (!gosTrack.id) {
+        gosTrack.id = uuid.v4();
+    }
+
     const assembly = firstResolvedSpec.assembly;
 
     if (IsDataDeep(firstResolvedSpec.data)) {
@@ -62,7 +66,7 @@ export function goslingToHiGlass(
                 ? HIGLASS_AXIS_SIZE
                 : 0);
         const hgTrack: HiGlassTrack = {
-            uid: `${firstResolvedSpec.id ?? uuid.v4()}-track`, // This is being used to cache the visualization
+            uid: `${gosTrack.id}-track`, // This is being used to cache the visualization
             type: Is2DTrack(firstResolvedSpec) ? 'gosling-2d-track' : 'gosling-track',
             server,
             tilesetUid,
@@ -138,7 +142,7 @@ export function goslingToHiGlass(
             hgModel
                 .setViewOrientation(firstResolvedSpec.orientation) // TODO: Orientation should be assigned to 'individual' views
                 .setAssembly(assembly) // TODO: Assembly should be assigned to 'individual' views
-                .addDefaultView(firstResolvedSpec.id ?? uuid.v1(), assembly)
+                .addDefaultView(gosTrack.id, assembly)
                 .setDomain(xDomain, Is2DTrack(firstResolvedSpec) ? yDomain : xDomain)
                 .adjustDomain(firstResolvedSpec.orientation, width, height)
                 .setMainTrack(hgTrack)
@@ -195,7 +199,7 @@ export function goslingToHiGlass(
             ) {
                 const narrowType = getAxisNarrowType(c as any, gosTrack.orientation, bb.width, bb.height);
                 hgModel.setAxisTrack(channel.axis, narrowType, {
-                    id: `${firstResolvedSpec.id ?? uuid.v4()}-axis`,
+                    id: `${gosTrack.id}-axis`,
                     layout: firstResolvedSpec.layout,
                     innerRadius:
                         channel.axis === 'top'
@@ -217,7 +221,7 @@ export function goslingToHiGlass(
         hgModel.validateSpec(true);
     } else if (firstResolvedSpec.mark === 'header') {
         // `text` tracks are used to show title and subtitle of the views
-        hgModel.addDefaultView(`${firstResolvedSpec.id ?? uuid.v1()}-title`).setLayout(layout);
+        hgModel.addDefaultView(`${gosTrack.id}-title`).setLayout(layout);
         if (typeof firstResolvedSpec.title === 'string') {
             hgModel.setTextTrack(
                 bb.width,

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -837,14 +837,22 @@ export interface BEDDBData {
  */
 export interface BAMData {
     type: 'bam';
-
-    /** URL link to the BAM data file */
+    /**
+     * URL link to the BAM data file
+     */
     url: string;
-
-    /** URL link to the index file of the BAM file */
+    /**
+     * URL link to the index file of the BAM file
+     */
     indexUrl: string;
-    loadMates?: boolean; // load mates as well?
-    maxInsertSize?: number; // default 50,000bp, only applied for across-chr, JBrowse https://github.com/GMOD/bam-js#async-getrecordsforrangerefname-start-end-opts
+    /**
+     * Load mates that are located in the same chromosome. __Default__: `false`
+     */
+    loadMates?: boolean;
+    /**
+     * Determines the threshold of insert sizes for determining the structural variants. __Default__: `5000`
+     */
+    maxInsertSize?: number; // https://github.com/GMOD/bam-js#async-getrecordsforrangerefname-start-end-opts
 }
 
 export interface MatrixData {
@@ -863,7 +871,6 @@ export type DataTransform =
     | ExonSplitTransform
     | GenomicLengthTransform
     | CoverageTransform
-    | CombineMatesTransform
     | JSONParseTransform;
 
 export type FilterTransform = OneOfFilter | RangeFilter | IncludeFilter;
@@ -972,18 +979,6 @@ export interface CoverageTransform {
     newField?: string;
     /** The name of a nominal field to group rows by in prior to piling-up */
     groupField?: string;
-}
-
-/**
- * By looking up ids, combine mates (a pair of reads) into a single row, performing long-to-wide operation.
- * Result data have `{field}` and `{field}_2` names.
- */
-export interface CombineMatesTransform {
-    type: 'combineMates';
-    idField: string;
-    isLongField?: string; // is this pair long reads, exceeding max insert size? default, `is_long`
-    maxInsertSize?: number; // thresold to determine long reads, default 360
-    maintainDuplicates?: boolean; // do not want to remove duplicated row? If true, the original reads will be contained in `{field}`
 }
 
 /**

--- a/src/core/mark/rect.ts
+++ b/src/core/mark/rect.ts
@@ -3,6 +3,7 @@ import { GoslingTrackModel } from '../gosling-track-model';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import { PIXIVisualProperty } from '../visual-property.schema';
 import colorToHex from '../utils/color-to-hex';
+import {IsChannelDeep} from '../gosling.schema.guards';
 
 export function drawRect(HGC: any, trackInfo: any, tile: any, model: GoslingTrackModel) {
     /* track spec */
@@ -33,15 +34,16 @@ export function drawRect(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
     /* row separation */
     const rowCategories: string[] = (model.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
     const rowHeight = trackHeight / rowCategories.length;
-
+    const RPAD = IsChannelDeep(spec.row) && spec.row.padding ? spec.row.padding :  0;
+    
     // TODO: what if quantitative Y field is used?
     const yCategories = (model.getChannelDomainArray('y') as string[]) ?? ['___SINGLE_Y_POSITION___'];
-    const cellHeight = rowHeight / yCategories.length;
+    const cellHeight = rowHeight / yCategories.length - RPAD * 2;
 
     /* render */
     const g = tile.graphics;
     data.forEach(d => {
-        const rowPosition = model.encodedPIXIProperty('row', d);
+        const rowPosition = model.encodedPIXIProperty('row', d) + RPAD;
         const x = model.encodedPIXIProperty('x', d);
         const color = model.encodedPIXIProperty('color', d);
         const stroke = model.encodedPIXIProperty('stroke', d);

--- a/src/core/mark/rect.ts
+++ b/src/core/mark/rect.ts
@@ -3,7 +3,7 @@ import { GoslingTrackModel } from '../gosling-track-model';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import { PIXIVisualProperty } from '../visual-property.schema';
 import colorToHex from '../utils/color-to-hex';
-import {IsChannelDeep} from '../gosling.schema.guards';
+import { IsChannelDeep } from '../gosling.schema.guards';
 
 export function drawRect(HGC: any, trackInfo: any, tile: any, model: GoslingTrackModel) {
     /* track spec */
@@ -34,8 +34,8 @@ export function drawRect(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
     /* row separation */
     const rowCategories: string[] = (model.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
     const rowHeight = trackHeight / rowCategories.length;
-    const RPAD = IsChannelDeep(spec.row) && spec.row.padding ? spec.row.padding :  0;
-    
+    const RPAD = IsChannelDeep(spec.row) && spec.row.padding ? spec.row.padding : 0;
+
     // TODO: what if quantitative Y field is used?
     const yCategories = (model.getChannelDomainArray('y') as string[]) ?? ['___SINGLE_Y_POSITION___'];
     const cellHeight = rowHeight / yCategories.length - RPAD * 2;

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -201,10 +201,10 @@ export function combineMates(t: CombineMatesTransform, data: Datum[]) {
             // no mate found. this read will not be included to the result data.
             return;
         }
-        
+
         const mate = rest[mateIndex];
 
-        if(!d.data.from || !d.data.to || !mate.data.from || !mate.data.to) {
+        if (!d.data.from || !d.data.to || !mate.data.from || !mate.data.to) {
             // no distance
             //console.log(
             //    d,
@@ -214,7 +214,7 @@ export function combineMates(t: CombineMatesTransform, data: Datum[]) {
         }
 
         const newRow: Datum = {};
-        
+
         // iterate all keys, assuming that keys are the same between mates
         Object.keys(d.data).forEach(k => {
             // if not maintaining duplicated rows, left mate should be stored in the first field
@@ -224,15 +224,17 @@ export function combineMates(t: CombineMatesTransform, data: Datum[]) {
 
             const [left, right] = [d, mate].sort((a, b) => +a.data.from - +b.data.from);
             const size = Math.abs(+left.data.to - +right.data.from);
-            
+
             // https://software.broadinstitute.org/software/igv/interpreting_pair_orientations
             const orientation = `${left.data.strand}${right.data.strand}`;
-            const svType = `${{
-                '+-': 'deletion',
-                '++': 'inversion',
-                '--': 'inversion',
-                '-+': 'translocation or duplication'
-            }[orientation]} (${orientation})`;
+            const svType = `${
+                {
+                    '+-': 'deletion',
+                    '++': 'inversion',
+                    '--': 'inversion',
+                    '-+': 'translocation or duplication'
+                }[orientation]
+            } (${orientation})`;
             newRow[isLongField] = size >= maxInsertSize ? svType : 'normal reads';
             newRow['insertSize'] = Math.abs(+left.data.to - +right.data.from);
         });

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -232,7 +232,7 @@ export function combineMates(t: CombineMatesTransform, data: Datum[]) {
                     '+-': 'deletion',
                     '++': 'inversion',
                     '--': 'inversion',
-                    '-+': 'translocation or duplication'
+                    '-+': 'duplication'
                 }[orientation]
             } (${orientation})`;
             newRow[isLongField] = size >= maxInsertSize ? svType : 'normal reads';

--- a/src/data-fetcher/bam/bam-worker.js
+++ b/src/data-fetcher/bam/bam-worker.js
@@ -458,9 +458,9 @@ const tile = async (uid, z, x) => {
         const { chromLengths, cumPositions } = chromInfo;
 
         const opt = {
-            viewAsPairs: typeof loadMates === 'undefined' ? false : loadMates,
-            pairAcrossChr: typeof loadMates === 'undefined' ? false : loadMates,
-            maxInsertSize: maxInsertSize ?? 50000
+            viewAsPairs: true, // typeof loadMates === 'undefined' ? false : loadMates,
+            pairAcrossChr: true, //typeof loadMates === 'undefined' ? false : loadMates,
+            maxInsertSize: 1000000 // maxInsertSize ?? 50000
         }
 
         for (let i = 0; i < cumPositions.length; i++) {

--- a/src/data-fetcher/bam/bam-worker.js
+++ b/src/data-fetcher/bam/bam-worker.js
@@ -454,7 +454,7 @@ const tile = async (uid, z, x) => {
             // TODO: Turning this on results in "too many requests error"
             // https://github.com/gosling-lang/gosling.js/pull/556
             // pairAcrossChr: typeof loadMates === 'undefined' ? false : loadMates, 
-            // maxInsertSize: 500 // maxInsertSize ?? 50000
+            maxInsertSize: 248956422 / 2.0 // sufficiently large value to search entire chromosome 
         }
         
         for (let i = 0; i < cumPositions.length; i++) {
@@ -579,7 +579,7 @@ const getTabularData = (uid, tileIds) => {
         // find and set mate info when the `data.loadMates` flag is on.
         findMates(uid, segmentList);
     }
-    
+
     const buffer = Buffer.from(JSON.stringify(segmentList)).buffer;
     return Transfer(buffer, [buffer]);
 };
@@ -633,6 +633,7 @@ const findMates = (uid, segments) => {
         } else {
             // We do not handle such cases for now
             segmentGroup.forEach(d => {
+                d.mateIds = segmentGroup.filter(mate => mate.id !== d.id).map(mate => mate.id);
                 d.foundMate = false;
                 d.insertSize = -1;
                 d.largInsertSize = false; 

--- a/src/data-fetcher/bam/bam-worker.js
+++ b/src/data-fetcher/bam/bam-worker.js
@@ -454,7 +454,6 @@ const tile = async (uid, z, x) => {
             // TODO: Turning this on results in "too many requests error"
             // https://github.com/gosling-lang/gosling.js/pull/556
             // pairAcrossChr: typeof loadMates === 'undefined' ? false : loadMates, 
-            maxInsertSize: 248956422 / 2.0 // sufficiently large value to search entire chromosome 
         }
         
         for (let i = 0; i < cumPositions.length; i++) {
@@ -637,7 +636,7 @@ const findMates = (uid, segments) => {
                 d.foundMate = false;
                 d.insertSize = -1;
                 d.largInsertSize = false; 
-                d.svType = segmentGroup.length === 1 ? 'mates not found' : 'more than two mates';
+                d.svType = segmentGroup.length === 1 ? 'mates not found within chromosome' : 'more than two mates';
                 d.numMates = segmentGroup.length;
             });
         }

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -101,20 +101,6 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             this.drawnAtScale = HGC.libraries.d3Scale.scaleLinear();
             this.scalableGraphics = {};
 
-            // this.loadingText = new HGC.libraries.PIXI.Text('Loading', {
-            //     fontSize: '14px',
-            //     fontFamily: 'Arial',
-            //     fill: 'black'
-            // });
-
-            // this.loadingText.x = 0;
-            // this.loadingText.y = 0;
-
-            // this.loadingText.anchor.x = 0;
-            // this.loadingText.anchor.y = 0;
-
-            // this.pLabel.addChild(this.loadingText);
-
             const { valid, errorMessages } = validateTrack(this.options.spec);
 
             if (!valid) {
@@ -152,16 +138,16 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 );
             }
 
-            // Custom error label
-            // this.errorText = new HGC.libraries.PIXI.Text('', {
-            //     fontSize: '16px',
-            //     fontFamily: 'Arial',
-            //     fill: 'black',
-            //     fontWeight: 'bold',
-            // });
-            // this.errorText.anchor.x = 0.5;
-            // this.errorText.anchor.y = 0.5;
-            // this.pLabel.addChild(this.errorText);
+            // Custom loading label
+            this.loadingText = new HGC.libraries.PIXI.Text('', {
+                fontSize: '18px',
+                fontFamily: 'Arial',
+                fill: 'gray',
+                fontWeight: 'bold'
+            });
+            this.loadingText.anchor.x = 0.5;
+            this.loadingText.anchor.y = 0.5;
+            this.pLabel.addChild(this.loadingText);
 
             this.tooltips = [];
             this.svgData = [];
@@ -207,6 +193,9 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
                 // Record tiles so that we ignore loading same tiles again
                 this.prevVisibleAndFetchedTiles = this.visibleAndFetchedTiles();
+
+                //
+                this.drawLoading(false);
             };
 
             if (
@@ -398,7 +387,8 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             this.xDomain = this._xScale.domain();
             this.xRange = this._xScale.range();
 
-            this.labelText.text = ' Loading...';
+            this.drawLoading();
+            this.trackNotFoundText.text = ''; // HiGlass complains about tileset, but we are using BAM files.
 
             this.worker.then((tileFunctions: any) => {
                 tileFunctions
@@ -421,8 +411,6 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                             tile.tileData.tilePos = [refTile[1]];
                         }
                         callback();
-
-                        this.labelText.text = this.options.spec.title ?? '';
                     });
             });
         }
@@ -458,7 +446,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             return this.visibleAndFetchedIds().map((x: any) => this.fetchedTiles[x]);
         }
 
-        // !! This is called in the constructor, `super(context, options)`. So be aware not to use variables that is not prepared.
+        // !! This is called in the constructor, `super(context, options)`. So be aware to use variables that is prepared.
         calculateVisibleTiles() {
             if (usePrereleaseRendering(this.options.spec)) {
                 const tiles = HGC.utils.trackUtils.calculate1DVisibleTiles(this.tilesetInfo, this._xScale);
@@ -600,27 +588,32 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             }
         }
 
-        // Custom error message
-        // drawError() {
-        //     this.errorText.x = this.position[0] + this.dimensions[0] / 2;
-        //     this.errorText.y = this.position[1] + this.dimensions[1] / 2;
+        // Custom loading message
+        drawLoading(show = true) {
+            const loadingLabelNotReady = true;
+            if (loadingLabelNotReady) return; // TODO: not used yet
 
-        //     this.errorText.text = this.errorTextText;
+            this.loadingText.x = this.position[0] + this.dimensions[0] / 2;
+            this.loadingText.y = this.position[1] + this.dimensions[1] / 2;
 
-        //     if (this.errorTextText && this.errorTextText.length) {
-        //       // draw a red border around the track to bring attention to its error
-        //       const g = this.pBorder;
-        //       g.clear();
-        //       g.lineStyle(1, colorToHex('black'), 1);
-        //       g.beginFill(colorToHex('black'), 0.2);
-        //       g.drawRect(
-        //             this.position[0],
-        //             this.position[1],
-        //             this.dimensions[0],
-        //             this.dimensions[1],
-        //         );
-        //     }
-        // }
+            this.loadingText.text = show ? 'Loading...' : '';
+
+            if (show) {
+                // draw a border around the track to bring attention to the loading message
+                // const g = this.pBorder;
+                // g.clear();
+                // g.lineStyle(2, colorToHex('lightgray'), 1);
+                // g.beginFill(colorToHex('lightgray'), 0.1);
+                // g.drawRect(
+                //       this.position[0],
+                //       this.position[1],
+                //       this.dimensions[0],
+                //       this.dimensions[1],
+                //   );
+            } else {
+                // this.pBorder.clear();
+            }
+        }
 
         /**
          * This function reorganize the tileset information so that it can be more conveniently managed afterwards.

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -18,7 +18,6 @@ import {
     concatString,
     displace,
     filterData,
-    combineMates,
     calculateGenomicLength,
     parseSubJSON,
     replaceString,
@@ -719,6 +718,14 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
             shareScaleAcrossTracks(gms);
 
+            const flatTileData = ([] as Datum[]).concat(...gms.map(d => d.data()));
+            if (flatTileData.length !== 0) {
+                PubSub.publish('rawdata', {
+                    id: this.options.spec.id,
+                    data: flatTileData
+                });
+            }
+
             // console.log('processed gosling model', gms);
 
             // IMPORTANT: If no genomic fields specified, no point to use multiple tiles, i.e., we need to draw a track only once with the data combined.
@@ -827,9 +834,6 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                                     tile.gos.tabularDataFiltered,
                                     this._xScale.copy()
                                 );
-                                break;
-                            case 'combineMates':
-                                tile.gos.tabularDataFiltered = combineMates(t, tile.gos.tabularDataFiltered);
                                 break;
                             case 'subjson':
                                 tile.gos.tabularDataFiltered = parseSubJSON(t, tile.gos.tabularDataFiltered);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4571,7 +4571,16 @@ genbank-parser@^1.0.0:
   resolved "https://registry.yarnpkg.com/genbank-parser/-/genbank-parser-1.2.4.tgz#ee2f9c32f66875024af0c09ee0ec5e10fb231802"
   integrity sha512-r3pTgKHZx/rol90v2cezrNhfMhq3yHWCnBYyETNIJkvnJk+cwx/D/ZVgAy1SX8zwtnfvYQmFbqlpbh2f4t0h2w==
 
-generic-filehandle@^2.0.0, generic-filehandle@^2.2.1:
+generic-filehandle@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-2.2.0.tgz#d3d17f0ee5d6813e6bcb60396be28802a7158d1f"
+  integrity sha512-cFmLs1ptKALiBs2ExsobnjQ8Y9x/YbiRmynhYiB87Xyrpuk3HV4uR+EpwBiUKS/1C6TXjR+GkWxL58PP1C2hKA==
+  dependencies:
+    "@babel/runtime" "^7.9.6"
+    es6-promisify "^6.1.1"
+    file-uri-to-path "^2.0.0"
+
+generic-filehandle@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-2.2.1.tgz#395ecf5e44113ec33472df86e1c0a4f64fbb1012"
   integrity sha512-aI1uusDj0zrAvz8t7DfWKn2hjWEZBXhqW063MJB8gsvgCt8LOBJkuNOPXhWik237NMqI2m/ffQ4oKbaO+32vqg==


### PR DESCRIPTION
![gosling-visualization (1)](https://user-images.githubusercontent.com/9922882/140515266-94997def-5295-4eef-8ded-d1b5a08e6b8b.png)


# Updates
- Put clipping representations back
- Highlight reads with potential SVs
- Highlight reads with no mates found

# Issues
- When `opts.pairAcrossChr` is set (https://github.com/GMOD/bam-js), I see the following error message from both `Gosling.js` and `higlass/higlass-pileup`:
<img width="1509" alt="Screen Shot 2021-11-05 at 6 19 46 AM" src="https://user-images.githubusercontent.com/9922882/140495811-497c332d-10e1-42f2-b8db-7179387ee7d4.png">
