### PR TITLE
fix: fix an issue that `zoomToGene()` is not working with only first two parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,9 +168,9 @@
 
 ### Bug Fixes
 
-* remove improper loading message in track ([#418](https://github.com/gosling-lang/gosling.js/issues/418)) ([62bf073](https://github.com/gosling-lang/gosling.js/commit/62bf073d6a67bca03ddb5687b9ef4c51f99d3ea2))
-* **editor:** address hiccups in editor ([#411](https://github.com/gosling-lang/gosling.js/issues/411)) ([3025533](https://github.com/gosling-lang/gosling.js/commit/30255337e4eb0a6601319068a8be141edd19b861))
 * convert to numbers when quantitative fields are strings ([#402](https://github.com/gosling-lang/gosling.js/issues/402)) ([95212bd](https://github.com/gosling-lang/gosling.js/commit/95212bd42fc8cccf26517ea1da24d35ed7706e8d))
+* **editor:** address hiccups in editor ([#411](https://github.com/gosling-lang/gosling.js/issues/411)) ([3025533](https://github.com/gosling-lang/gosling.js/commit/30255337e4eb0a6601319068a8be141edd19b861))
+* remove improper loading message in track ([#418](https://github.com/gosling-lang/gosling.js/issues/418)) ([62bf073](https://github.com/gosling-lang/gosling.js/commit/62bf073d6a67bca03ddb5687b9ef4c51f99d3ea2))
 
 
 ### Features
@@ -178,9 +178,9 @@
 * add `margin` and `border` as props of GoslingComponent ([#420](https://github.com/gosling-lang/gosling.js/issues/420)) ([4df2b2e](https://github.com/gosling-lang/gosling.js/commit/4df2b2e00445a786833ce4a3d79bf1a07837c79c))
 * add a between-link mark ([#405](https://github.com/gosling-lang/gosling.js/issues/405)) ([c7a76e2](https://github.com/gosling-lang/gosling.js/commit/c7a76e22df9e7755242a764c70400c6beeb9cdb8))
 * allow specifying `id` and `className` in `GoslingComponent` ([#419](https://github.com/gosling-lang/gosling.js/issues/419)) ([30d45a3](https://github.com/gosling-lang/gosling.js/commit/30d45a31b057ee5884b55a14224417dddaee96a4))
+* **api:** zoom to extent ([#408](https://github.com/gosling-lang/gosling.js/issues/408)) ([0b3c71f](https://github.com/gosling-lang/gosling.js/commit/0b3c71ff3ab99ee7b5cb445c704c2fe35145be99))
 * background of circular tracks, legend titles, and better brush style ([#429](https://github.com/gosling-lang/gosling.js/issues/429)) ([e469efe](https://github.com/gosling-lang/gosling.js/commit/e469efe67c520d10a36c31863a5dab73f3ca2ab9))
 * rename link marks to betweenLink and withinLink ([#416](https://github.com/gosling-lang/gosling.js/issues/416)) ([8e7556c](https://github.com/gosling-lang/gosling.js/commit/8e7556cfbfd674ec21e7783df8e37513d0cad7ec))
-* **api:** zoom to extent ([#408](https://github.com/gosling-lang/gosling.js/issues/408)) ([0b3c71f](https://github.com/gosling-lang/gosling.js/commit/0b3c71ff3ab99ee7b5cb445c704c2fe35145be99))
 
 
 
@@ -189,8 +189,8 @@
 
 ### Features
 
-* **api:** support mouseover event listener ([#388](https://github.com/gosling-lang/gosling.js/issues/388)) ([e56e32c](https://github.com/gosling-lang/gosling.js/commit/e56e32cdbbcf3a68bb9ecebc45f2ff39d4833c94))
 * allow vertical band connection w/o independent scales yet ([#394](https://github.com/gosling-lang/gosling.js/issues/394)) ([5591e2d](https://github.com/gosling-lang/gosling.js/commit/5591e2d7ba6339c4a5eb7cc6a4e105a3c633c8f0))
+* **api:** support mouseover event listener ([#388](https://github.com/gosling-lang/gosling.js/issues/388)) ([e56e32c](https://github.com/gosling-lang/gosling.js/commit/e56e32cdbbcf3a68bb9ecebc45f2ff39d4833c94))
 
 
 
@@ -249,8 +249,8 @@
 * add 'about' model view ([#347](https://github.com/gosling-lang/gosling.js/issues/347)) ([53cb362](https://github.com/gosling-lang/gosling.js/commit/53cb3625ca79b7364bec756cd149797825d3ef0c))
 * add exon split transformation ([#364](https://github.com/gosling-lang/gosling.js/issues/364)) ([1413494](https://github.com/gosling-lang/gosling.js/commit/141349482645d3357442abc1c8fbfbd04ab727dd))
 * allow defining track styles in the upper level ([#363](https://github.com/gosling-lang/gosling.js/issues/363)) ([d00b871](https://github.com/gosling-lang/gosling.js/commit/d00b87191a8e7e0000dfe03ea9f8fcf7b6abb8af))
-* support a dark theme ([#359](https://github.com/gosling-lang/gosling.js/issues/359)) ([2248fc4](https://github.com/gosling-lang/gosling.js/commit/2248fc493dc39c9420bb903c0c09c8dab793e82d))
 * **api:** allow specifying transition duration in zoom ([#358](https://github.com/gosling-lang/gosling.js/issues/358)) ([78db378](https://github.com/gosling-lang/gosling.js/commit/78db378e95784c49013af8fb03abadc9a7bd76d3))
+* support a dark theme ([#359](https://github.com/gosling-lang/gosling.js/issues/359)) ([2248fc4](https://github.com/gosling-lang/gosling.js/commit/2248fc493dc39c9420bb903c0c09c8dab793e82d))
 
 
 
@@ -268,8 +268,8 @@
 
 ### Features
 
-* data transform as ordered array ([#355](https://github.com/gosling-lang/gosling.js/issues/355)) ([38ed0e4](https://github.com/gosling-lang/gosling.js/commit/38ed0e4fde5cfeba7a41ca6ab6bb59ad2a6559d5))
 * **api:** zoom to gene ([#353](https://github.com/gosling-lang/gosling.js/issues/353)) ([3021b82](https://github.com/gosling-lang/gosling.js/commit/3021b82350d524fcfa3b55105fae06cd3cebd8c7))
+* data transform as ordered array ([#355](https://github.com/gosling-lang/gosling.js/issues/355)) ([38ed0e4](https://github.com/gosling-lang/gosling.js/commit/38ed0e4fde5cfeba7a41ca6ab6bb59ad2a6559d5))
 * enable customizing stroke of brush ([#352](https://github.com/gosling-lang/gosling.js/issues/352)) ([b713b94](https://github.com/gosling-lang/gosling.js/commit/b713b948351bec90b21c57cae96f869b4955f708))
 
 

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -771,8 +771,9 @@ function Editor(props: any) {
                                                                 key={JSON.stringify(d)}
                                                                 onClick={() => setSelectedPreviewData(i)}
                                                             >
-                                                                {`${(JSON.parse(d.dataConfig).data
-                                                                    .type as string).toLocaleLowerCase()} `}
+                                                                {`${(
+                                                                    JSON.parse(d.dataConfig).data.type as string
+                                                                ).toLocaleLowerCase()} `}
                                                                 <small>{i}</small>
                                                             </button>
                                                         ))}

--- a/editor/example/cancer-variant.ts
+++ b/editor/example/cancer-variant.ts
@@ -27,8 +27,7 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             title: 'Patient Overview (PD35930a)',
                             alignment: 'overlay',
                             data: {
-                                url:
-                                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
                                 type: 'csv',
                                 chromosomeField: 'Chromosome',
                                 genomicFields: ['chromStart', 'chromEnd']
@@ -213,8 +212,7 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                             title: 'Ideogram',
                             alignment: 'overlay',
                             data: {
-                                url:
-                                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
                                 type: 'csv',
                                 chromosomeField: 'Chromosome',
                                 genomicFields: ['chromStart', 'chromEnd']
@@ -580,8 +578,7 @@ export function view(sample: string): GoslingSpec {
                 title: 'Overview',
                 alignment: 'overlay',
                 data: {
-                    url:
-                        'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                    url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
                     type: 'csv',
                     chromosomeField: 'Chromosome',
                     genomicFields: ['chromStart', 'chromEnd']

--- a/editor/example/circos.ts
+++ b/editor/example/circos.ts
@@ -81,8 +81,7 @@ export const EX_SPEC_CIRCOS: GoslingSpec = {
         // },
         {
             data: {
-                url:
-                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
                 type: 'csv',
                 chromosomeField: 'Chromosome',
                 genomicFields: ['chromStart', 'chromEnd']
@@ -181,8 +180,7 @@ export const EX_SPEC_CIRCOS_BETWEEN_LINK: GoslingSpec = {
         },
         {
             data: {
-                url:
-                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
                 type: 'csv',
                 chromosomeField: 'Chromosome',
                 genomicFields: ['chromStart', 'chromEnd']
@@ -246,8 +244,7 @@ export const EX_SPEC_CIRCOS_BETWEEN_LINK: GoslingSpec = {
         },
         {
             data: {
-                url:
-                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
                 type: 'csv',
                 chromosomeField: 'Chromosome',
                 genomicFields: ['chromStart', 'chromEnd']

--- a/editor/example/circular-overview-linear-detail-views.ts
+++ b/editor/example/circular-overview-linear-detail-views.ts
@@ -49,8 +49,7 @@ export const EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL: GoslingSpec = {
                 {
                     data: {
                         type: 'csv',
-                        url:
-                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/rearrangements.bulk.1639.simple.filtered.pub',
+                        url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/rearrangements.bulk.1639.simple.filtered.pub',
                         headerNames: [
                             'chr1',
                             'p1s',

--- a/editor/example/corces.ts
+++ b/editor/example/corces.ts
@@ -20,8 +20,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                     alignment: 'overlay',
                     title: 'chr3',
                     data: {
-                        url:
-                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/cytogenetic_band.csv',
+                        url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/cytogenetic_band.csv',
                         type: 'csv',
                         chromosomeField: 'Chr.',
                         genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop'],
@@ -91,8 +90,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
             tracks: [
                 {
                     data: {
-                        url:
-                            'https://s3.amazonaws.com/gosling-lang.org/data/ExcitatoryNeurons-insertions_bin100_RIPnorm.bw',
+                        url: 'https://s3.amazonaws.com/gosling-lang.org/data/ExcitatoryNeurons-insertions_bin100_RIPnorm.bw',
                         type: 'bigwig',
                         column: 'position',
                         value: 'peak'
@@ -102,8 +100,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                 },
                 {
                     data: {
-                        url:
-                            'https://s3.amazonaws.com/gosling-lang.org/data/InhibitoryNeurons-insertions_bin100_RIPnorm.bw',
+                        url: 'https://s3.amazonaws.com/gosling-lang.org/data/InhibitoryNeurons-insertions_bin100_RIPnorm.bw',
                         type: 'bigwig',
                         column: 'position',
                         value: 'peak'
@@ -113,8 +110,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                 },
                 {
                     data: {
-                        url:
-                            'https://s3.amazonaws.com/gosling-lang.org/data/DopaNeurons_Cluster10_AllFrags_projSUNI2_insertions_bin100_RIPnorm.bw',
+                        url: 'https://s3.amazonaws.com/gosling-lang.org/data/DopaNeurons_Cluster10_AllFrags_projSUNI2_insertions_bin100_RIPnorm.bw',
                         type: 'bigwig',
                         column: 'position',
                         value: 'peak'
@@ -135,8 +131,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                 },
                 {
                     data: {
-                        url:
-                            'https://s3.amazonaws.com/gosling-lang.org/data/Oligodendrocytes-insertions_bin100_RIPnorm.bw',
+                        url: 'https://s3.amazonaws.com/gosling-lang.org/data/Oligodendrocytes-insertions_bin100_RIPnorm.bw',
                         type: 'bigwig',
                         column: 'position',
                         value: 'peak'

--- a/editor/example/debug.ts
+++ b/editor/example/debug.ts
@@ -102,8 +102,7 @@ export const EX_SPEC_DEBUG: GoslingSpec =
                             },
                             {
                                 data: {
-                                    url:
-                                        'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                                    url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
                                     type: 'csv',
                                     chromosomeField: 'c2',
                                     genomicFields: ['s1', 'e1', 's2', 'e2']
@@ -130,8 +129,7 @@ export const EX_SPEC_DEBUG: GoslingSpec =
                                 tracks: [
                                     {
                                         data: {
-                                            url:
-                                                'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                                            url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
                                             type: 'csv',
                                             chromosomeField: 'c2',
                                             genomicFields: ['s1', 'e1', 's2', 'e2']
@@ -150,8 +148,7 @@ export const EX_SPEC_DEBUG: GoslingSpec =
                                     },
                                     {
                                         data: {
-                                            url:
-                                                'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                                            url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
                                             type: 'csv',
                                             chromosomeField: 'c2',
                                             genomicFields: ['s1', 'e1', 's2', 'e2']
@@ -176,8 +173,7 @@ export const EX_SPEC_DEBUG: GoslingSpec =
                                         title: 'Curved Connection',
                                         alignment: 'overlay',
                                         data: {
-                                            url:
-                                                'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                                            url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
                                             type: 'csv',
                                             chromosomeField: 'c2',
                                             genomicFields: ['s1', 'e1', 's2', 'e2']
@@ -226,8 +222,7 @@ export const EX_SPEC_DEBUG: GoslingSpec =
                         tracks: [
                             {
                                 data: {
-                                    url:
-                                        'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                                    url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
                                     type: 'csv',
                                     chromosomeField: 'c2',
                                     genomicFields: ['s1', 'e1', 's2', 'e2']
@@ -274,8 +269,7 @@ export const EX_SPEC_DEBUG: GoslingSpec =
                         tracks: [
                             {
                                 data: {
-                                    url:
-                                        'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                                    url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
                                     type: 'csv',
                                     chromosomeField: 'c2',
                                     genomicFields: ['s1', 'e1', 's2', 'e2']
@@ -294,8 +288,7 @@ export const EX_SPEC_DEBUG: GoslingSpec =
                             },
                             {
                                 data: {
-                                    url:
-                                        'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                                    url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
                                     type: 'csv',
                                     chromosomeField: 'c2',
                                     genomicFields: ['s1', 'e1', 's2', 'e2']

--- a/editor/example/give.ts
+++ b/editor/example/give.ts
@@ -129,8 +129,7 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                 {
                     alignment: 'overlay',
                     data: {
-                        url:
-                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                        url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
                         type: 'csv',
                         chromosomeField: 'Chromosome',
                         genomicFields: ['chromStart', 'chromEnd']
@@ -228,8 +227,7 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                 {
                     alignment: 'overlay',
                     data: {
-                        url:
-                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                        url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
                         type: 'csv',
                         chromosomeField: 'Chromosome',
                         genomicFields: ['chromStart', 'chromEnd']

--- a/editor/example/gremlin.ts
+++ b/editor/example/gremlin.ts
@@ -11,8 +11,7 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                     alignment: 'overlay',
                     title: 'Chromosome 5',
                     data: {
-                        url:
-                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                        url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
                         type: 'csv',
                         chromosomeField: 'Chromosome',
                         genomicFields: ['chromStart', 'chromEnd']
@@ -243,8 +242,7 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                                 {
                                     title: 'Rearrangement View',
                                     data: {
-                                        url:
-                                            'https://raw.githubusercontent.com/vigsterkr/circos/master/data/5/segdup.txt',
+                                        url: 'https://raw.githubusercontent.com/vigsterkr/circos/master/data/5/segdup.txt',
                                         type: 'csv',
                                         headerNames: ['id', 'chr', 'p1', 'p2'],
                                         chromosomePrefix: 'hs',

--- a/editor/example/matrix-hffc6.ts
+++ b/editor/example/matrix-hffc6.ts
@@ -149,8 +149,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                 },
                                 {
                                     data: {
-                                        url:
-                                            'https://s3.amazonaws.com/gosling-lang.org/data/HFFc6_Atacseq.mRp.clN.bigWig',
+                                        url: 'https://s3.amazonaws.com/gosling-lang.org/data/HFFc6_Atacseq.mRp.clN.bigWig',
                                         type: 'bigwig',
                                         column: 'position',
                                         value: 'peak',
@@ -170,8 +169,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                     tracks: [
                                         {
                                             data: {
-                                                url:
-                                                    'https://s3.amazonaws.com/gosling-lang.org/data/HFFC6_CTCF.mRp.clN.bigWig',
+                                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/HFFC6_CTCF.mRp.clN.bigWig',
                                                 type: 'bigwig',
                                                 column: 'position',
                                                 value: 'peak',
@@ -341,8 +339,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                 },
                                 {
                                     data: {
-                                        url:
-                                            'https://s3.amazonaws.com/gosling-lang.org/data/HFFc6_Atacseq.mRp.clN.bigWig',
+                                        url: 'https://s3.amazonaws.com/gosling-lang.org/data/HFFc6_Atacseq.mRp.clN.bigWig',
                                         type: 'bigwig',
                                         column: 'position',
                                         value: 'peak',
@@ -362,8 +359,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
                                     tracks: [
                                         {
                                             data: {
-                                                url:
-                                                    'https://s3.amazonaws.com/gosling-lang.org/data/HFFC6_CTCF.mRp.clN.bigWig',
+                                                url: 'https://s3.amazonaws.com/gosling-lang.org/data/HFFC6_CTCF.mRp.clN.bigWig',
                                                 type: 'bigwig',
                                                 column: 'position',
                                                 value: 'peak',

--- a/editor/example/matrix.ts
+++ b/editor/example/matrix.ts
@@ -41,8 +41,7 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                 {
                     alignment: 'overlay',
                     data: {
-                        url:
-                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                        url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
                         type: 'csv',
                         chromosomeField: 'Chromosome',
                         genomicFields: ['chromStart', 'chromEnd']

--- a/editor/example/sars-cov-2.ts
+++ b/editor/example/sars-cov-2.ts
@@ -170,8 +170,7 @@ export const EX_SPEC_SARS_COV_2: GoslingSpec = {
                     title: 'TRS-L-Dependent Recombination Events',
                     data: {
                         type: 'csv',
-                        url:
-                            'https://s3.amazonaws.com/gosling-lang.org/data/COVID/TRS-L-dependent_recombinationEvents_sorted.bed',
+                        url: 'https://s3.amazonaws.com/gosling-lang.org/data/COVID/TRS-L-dependent_recombinationEvents_sorted.bed',
                         genomicFields: ['Start1', 'Stop1', 'Start2', 'Stop2'],
                         sampleLength: 100
                     },

--- a/editor/example/semantic-zoom.ts
+++ b/editor/example/semantic-zoom.ts
@@ -73,8 +73,7 @@ const ScalableSequenceTrack: OverlaidTracks = {
 const ScalableCytoBand: OverlaidTracks = {
     alignment: 'overlay',
     data: {
-        url:
-            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+        url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
         type: 'csv',
         chromosomeField: 'Chromosome',
         genomicFields: ['chromStart', 'chromEnd']

--- a/editor/example/theme.ts
+++ b/editor/example/theme.ts
@@ -36,8 +36,7 @@ export const EX_SPEC_CUSTOM_THEME: GoslingSpec = {
                     alignment: 'overlay',
                     title: 'chr3',
                     data: {
-                        url:
-                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/cytogenetic_band.csv',
+                        url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/cytogenetic_band.csv',
                         type: 'csv',
                         chromosomeField: 'Chr.',
                         genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop'],
@@ -124,8 +123,7 @@ export const EX_SPEC_CUSTOM_THEME: GoslingSpec = {
             tracks: [
                 {
                     data: {
-                        url:
-                            'https://s3.amazonaws.com/gosling-lang.org/data/ExcitatoryNeurons-insertions_bin100_RIPnorm.bw',
+                        url: 'https://s3.amazonaws.com/gosling-lang.org/data/ExcitatoryNeurons-insertions_bin100_RIPnorm.bw',
                         type: 'bigwig',
                         column: 'position',
                         value: 'peak'
@@ -134,8 +132,7 @@ export const EX_SPEC_CUSTOM_THEME: GoslingSpec = {
                 },
                 {
                     data: {
-                        url:
-                            'https://s3.amazonaws.com/gosling-lang.org/data/InhibitoryNeurons-insertions_bin100_RIPnorm.bw',
+                        url: 'https://s3.amazonaws.com/gosling-lang.org/data/InhibitoryNeurons-insertions_bin100_RIPnorm.bw',
                         type: 'bigwig',
                         column: 'position',
                         value: 'peak'
@@ -144,8 +141,7 @@ export const EX_SPEC_CUSTOM_THEME: GoslingSpec = {
                 },
                 {
                     data: {
-                        url:
-                            'https://s3.amazonaws.com/gosling-lang.org/data/DopaNeurons_Cluster10_AllFrags_projSUNI2_insertions_bin100_RIPnorm.bw',
+                        url: 'https://s3.amazonaws.com/gosling-lang.org/data/DopaNeurons_Cluster10_AllFrags_projSUNI2_insertions_bin100_RIPnorm.bw',
                         type: 'bigwig',
                         column: 'position',
                         value: 'peak'

--- a/editor/example/track-template.ts
+++ b/editor/example/track-template.ts
@@ -103,8 +103,7 @@ export const EX_SPEC_TEMPLATE: GoslingSpec = {
                 {
                     template: 'ideogram',
                     data: {
-                        url:
-                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
+                        url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/UCSC.HG38.Human.CytoBandIdeogram.csv',
                         type: 'csv',
                         chromosomeField: 'Chromosome',
                         genomicFields: ['chromStart', 'chromEnd']

--- a/editor/example/visual-encoding.ts
+++ b/editor/example/visual-encoding.ts
@@ -278,8 +278,7 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                 {
                     id: 'track-9',
                     data: {
-                        url:
-                            'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                        url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
                         type: 'csv',
                         chromosomeField: 'c2',
                         genomicFields: ['s1', 'e1', 's2', 'e2']
@@ -537,8 +536,7 @@ export const EX_SPEC_VISUAL_ENCODING_CIRCULAR: GoslingSpec = {
                     tracks: [
                         {
                             data: {
-                                url:
-                                    'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
+                                url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
                                 type: 'csv',
                                 chromosomeField: 'c2',
                                 genomicFields: ['s1', 'e1', 's2', 'e2']

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "fflate": "^0.7.1",
         "generic-filehandle": "^2.2.1",
         "gosling-theme": "^0.0.10",
-        "higlass": "^1.11.7",
+        "higlass": "^1.11.8",
         "higlass-register": "^0.3.0",
         "higlass-text": "^0.1.1",
         "json-stringify-pretty-compact": "^2.0.0",

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -38,10 +38,7 @@ export interface GoslingApi {
     getViewIds(): string[];
     exportPng(transparentBackground?: boolean): void;
     exportPdf(transparentBackground?: boolean): void;
-    getCanvas(options?: {
-        resolution?: number;
-        transparentBackground?: boolean;
-    }): {
+    getCanvas(options?: { resolution?: number; transparentBackground?: boolean }): {
         canvas: HTMLCanvasElement;
         canvasWidth: number;
         canvasHeight: number;

--- a/src/core/example/hg-view-config-1.ts
+++ b/src/core/example/hg-view-config-1.ts
@@ -51,8 +51,7 @@ const example = {
                                         yOffset: 0,
                                         style: { outlineWidth: 0.5 },
                                         data: {
-                                            url:
-                                                'https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec',
+                                            url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec',
                                             type: 'multivec',
                                             row: 'sample',
                                             column: 'position',
@@ -673,8 +672,7 @@ const example = {
                                         yOffset: 0,
                                         style: { outlineWidth: 0.5 },
                                         data: {
-                                            url:
-                                                'https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec',
+                                            url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec',
                                             type: 'multivec',
                                             row: 'sample',
                                             column: 'position',

--- a/src/core/mark/triangle.ts
+++ b/src/core/mark/triangle.ts
@@ -126,11 +126,13 @@ export function drawTriangle(g: PIXI.Graphics, model: GoslingTrackModel, trackWi
                     xm -= markWidth;
                 }
 
-                const markToPoints: number[] = ({
-                    triangleLeft: [x1, y0, x0, ym, x1, y1, x1, y0],
-                    triangleRight: [x0, y0, x1, ym, x0, y1, x0, y0],
-                    triangleBottom: [x0, y0, x1, y0, xm, y1, x0, y0]
-                } as any)[spec.mark as MarkType];
+                const markToPoints: number[] = (
+                    {
+                        triangleLeft: [x1, y0, x0, ym, x1, y1, x1, y0],
+                        triangleRight: [x0, y0, x1, ym, x0, y1, x0, y0],
+                        triangleBottom: [x0, y0, x1, y0, xm, y1, x0, y0]
+                    } as any
+                )[spec.mark as MarkType];
 
                 const alphaTransition = model.markVisibility(d, { width: x1 - x0, zoomLevel });
                 const actualOpacity = Math.min(alphaTransition, opacity);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5058,7 +5058,7 @@ higlass@1.11.2:
     vkbeautify "^0.99.3"
     whatwg-fetch "^3.0.0"
 
-higlass@^1.11.7:
+higlass@^1.11.8:
   version "1.11.8"
   resolved "https://registry.yarnpkg.com/higlass/-/higlass-1.11.8.tgz#c15b33599cb1b03eac16d9a439f5c84d8dbcd596"
   integrity sha512-sIe3m05I+4NuSr1f068vLQrVgLD35YGeCrWE5/7+uVb8xA9jVkotZvGPLu4jp76YOfXP+u9VJH/GSyHIlaDrxg==


### PR DESCRIPTION
This PR mainly upgrades HiGlass. This fixes an issue that `zoomToGene()` API function was not working with only the first two parameters. iGlass recently added a parameter for its `zoomToGene()` function, (the third parameter, `padding`) and this was not reflected on our API.

Fixes #551 