### PR TITLE
feat(api): support searching for a gene position

### DIFF
--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -26,6 +26,17 @@ type PubSubEvent<EventName extends string, Payload> = {
 type EventMap = PubSubEvent<'mouseover' | 'click', CommonEventData>;
 // & PubSubEvent<'my-event', { hello: 'world' }> & PubSubEvent<'foo', "bar">;
 
+/**
+ * Information of suggested genes.
+ */
+interface geneSuggestion {
+    geneName: string; // gene symbol
+    score: number; // higher score means suggested gene is more likely to match the searched keyword
+    chr: string; // chromosome name
+    txStart: number; // absolute genomic position assuming chromosomes are concat end-to-end
+    txEnd: number; // absolute genomic position assuming chromosomes are concat end-to-end
+}
+
 export interface GoslingApi {
     subscribe<EventName extends keyof EventMap>(
         type: EventName,
@@ -35,6 +46,7 @@ export interface GoslingApi {
     zoomTo(viewId: string, position: string, padding?: number, duration?: number): void;
     zoomToExtent(viewId: string, duration?: number): void;
     zoomToGene(viewId: string, gene: string, padding?: number, duration?: number): void;
+    suggestGene(viewId: string, keyword: string, callback: (suggestions: geneSuggestion[]) => void): void;
     getViewIds(): string[];
     exportPng(transparentBackground?: boolean): void;
     exportPdf(transparentBackground?: boolean): void;
@@ -136,6 +148,9 @@ export function createApi(
         },
         zoomToGene: (viewId, gene, padding = 0, duration = 1000) => {
             getHg().api.zoomToGene(viewId, gene, padding, duration);
+        },
+        suggestGene: (viewId: string, keyword: string, callback: (suggestions: geneSuggestion[]) => void) => {
+            getHg().api.suggestGene(viewId, keyword, callback);
         },
         getViewIds: () => {
             if (!hgSpec) return [];


### PR DESCRIPTION
This PR supports the HiGlass' `suggestGene` API which allows users to search for the genomic position of gene symbols.

**Example Usage:**
```js
gosRef.current.api.suggestGene('view-1', 'MYC', (suggestions) => {
   console.log(suggestions);
});
```

**Example Suggestions (`suggestions`):**
```js
[
    {
        "chr": "chr8",
        "txStart": 127736068,
        "txEnd": 127741434,
        "score": 1582, // higher score means the search keyword is more likely to match the suggested gene
        "geneName": "MYC"
    },
    {
        "chr": "chr1",
        "txStart": 11106530,
        "txEnd": 11262551,
        "score": 1510,
        "geneName": "MTOR"
    },
    {
        "chr": "chr2",
        "txStart": 15940437,
        "txEnd": 15947007,
        "score": 316,
        "geneName": "MYCN"
    },
    {
        "chr": "chr8",
        "txStart": 133237170,
        "txEnd": 133297304,
        "score": 185,
        "geneName": "NDRG1"
    },
    {
        "chr": "chr14",
        "txStart": 65006100,
        "txEnd": 65102695,
        "score": 161,
        "geneName": "MAX"
    },
    {
        "chr": "chr13",
        "txStart": 77044656,
        "txEnd": 77327042,
        "score": 69,
        "geneName": "MYCBP2"
    },
    {
        "chr": "chr17",
        "txStart": 30248194,
        "txEnd": 30292166,
        "score": 63,
        "geneName": "BLMH"
    },
    {
        "chr": "chr17",
        "txStart": 47522956,
        "txEnd": 47623276,
        "score": 56,
        "geneName": "NPEPPS"
    },
    {
        "chr": "chr2",
        "txStart": 151270467,
        "txEnd": 151289916,
        "score": 51,
        "geneName": "NMI"
    },
    {
        "chr": "chr16",
        "txStart": 29806095,
        "txEnd": 29811183,
        "score": 45,
        "geneName": "MAZ"
    }
]
```

Fix #551