### PR TITLE
feat!: change genomics field names of BAM files to `start` and `end` instead of `from` and `to`, consistent to other properties

### DIFF
--- a/editor/example/pileup.ts
+++ b/editor/example/pileup.ts
@@ -29,12 +29,12 @@ export function EX_SPEC_VIEW_PILEUP(
                         dataTransform: [
                             {
                                 type: 'coverage',
-                                startField: 'from',
-                                endField: 'to'
+                                startField: 'start',
+                                endField: 'end'
                             }
                         ],
-                        x: { field: 'from', type: 'genomic' },
-                        xe: { field: 'to', type: 'genomic' },
+                        x: { field: 'start', type: 'genomic' },
+                        xe: { field: 'end', type: 'genomic' },
                         y: { field: 'coverage', type: 'quantitative', axis: 'right' },
                         color: { value: '#C6C6C6' }
                     }
@@ -61,16 +61,16 @@ export function EX_SPEC_VIEW_PILEUP(
                                 type: 'displace',
                                 method: 'pile',
                                 boundingBox: {
-                                    startField: 'from',
-                                    endField: 'to',
+                                    startField: 'start',
+                                    endField: 'end',
                                     padding: 5,
                                     isPaddingBP: true
                                 },
                                 newField: 'pileup-row'
                             }
                         ],
-                        x: { field: 'from', type: 'genomic' },
-                        xe: { field: 'to', type: 'genomic' },
+                        x: { field: 'start', type: 'genomic' },
+                        xe: { field: 'end', type: 'genomic' },
                         color: [
                             {
                                 field: 'svType',
@@ -110,8 +110,8 @@ export function EX_SPEC_VIEW_PILEUP(
                                 type: 'displace',
                                 method: 'pile',
                                 boundingBox: {
-                                    startField: 'from',
-                                    endField: 'to',
+                                    startField: 'start',
+                                    endField: 'end',
                                     padding: 5,
                                     isPaddingBP: true
                                 },
@@ -121,7 +121,7 @@ export function EX_SPEC_VIEW_PILEUP(
                                 type: 'subjson',
                                 field: 'substitutions',
                                 genomicField: 'pos',
-                                baseGenomicField: 'from',
+                                baseGenomicField: 'start',
                                 genomicLengthField: 'length'
                             },
                             { type: 'filter', field: 'type', oneOf: ['S', 'H'] }
@@ -132,8 +132,8 @@ export function EX_SPEC_VIEW_PILEUP(
                     }
                 ],
                 tooltip: [
-                    { field: 'from', type: 'genomic' },
-                    { field: 'to', type: 'genomic' },
+                    { field: 'start', type: 'genomic' },
+                    { field: 'end', type: 'genomic' },
                     { field: 'insertSize', type: 'quantitative' },
                     { field: 'svType', type: 'nominal' },
                     { field: 'strand', type: 'nominal' },

--- a/editor/example/sashimi.ts
+++ b/editor/example/sashimi.ts
@@ -61,13 +61,13 @@ export const EX_SPEC_SASHIMI: GoslingSpec = {
                     dataTransform: [
                         {
                             type: 'coverage',
-                            startField: 'from',
-                            endField: 'to'
+                            startField: 'start',
+                            endField: 'end'
                         }
                     ],
                     mark: 'bar',
-                    x: { field: 'from', type: 'genomic' },
-                    xe: { field: 'to', type: 'genomic' },
+                    x: { field: 'start', type: 'genomic' },
+                    xe: { field: 'end', type: 'genomic' },
                     y: { field: 'coverage', type: 'quantitative' },
                     color: { value: '#FFC153' },
                     width: 800,
@@ -123,13 +123,13 @@ export const EX_SPEC_SASHIMI: GoslingSpec = {
                         {
                             type: 'displace',
                             method: 'pile',
-                            boundingBox: { startField: 'from', endField: 'to', padding: 4, isPaddingBP: true },
+                            boundingBox: { startField: 'start', endField: 'end', padding: 4, isPaddingBP: true },
                             newField: 'pileup-row'
                         }
                     ],
                     mark: 'bar',
-                    x: { field: 'from', type: 'genomic', axis: 'none' },
-                    xe: { field: 'to', type: 'genomic' },
+                    x: { field: 'start', type: 'genomic', axis: 'none' },
+                    xe: { field: 'end', type: 'genomic' },
                     row: { field: 'pileup-row', type: 'nominal', padding: 0.05 },
                     color: { value: 'grey' },
                     width: 800,

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -838,17 +838,14 @@ export interface BEDDBData {
  */
 export interface BAMData {
     type: 'bam';
-    /**
-     * URL link to the BAM data file
-     */
+
+    /** URL link to the BAM data file */
     url: string;
-    /**
-     * URL link to the index file of the BAM file
-     */
+
+    /** URL link to the index file of the BAM file */
     indexUrl: string;
-    /**
-     * Load mates that are located in the same chromosome. __Default__: `false`
-     */
+
+    /** Load mates that are located in the same chromosome. __Default__: `false` */
     loadMates?: boolean;
 
     /** Determine whether to extract exon-to-exon junctions. __Default__: `false` */
@@ -857,9 +854,7 @@ export interface BAMData {
     /** Determine the threshold of coverage when extracting exon-to-exon junctions. __Default__: `1` */
     junctionMinCoverage?: number;
 
-    /**
-     * Determines the threshold of insert sizes for determining the structural variants. __Default__: `5000`
-     */
+    /** Determines the threshold of insert sizes for determining the structural variants. __Default__: `5000` */
     maxInsertSize?: number; // https://github.com/GMOD/bam-js#async-getrecordsforrangerefname-start-end-opts
 }
 

--- a/src/data-fetcher/bam/bam-worker.js
+++ b/src/data-fetcher/bam/bam-worker.js
@@ -143,7 +143,7 @@ export const getSubstitutions = (segment, seq) => {
         // soft clipping at the end
         if (lastSub.type === 'S') {
             substitutions.push({
-                pos: segment.to - segment.from,
+                pos: segment.end - segment.start,
                 length: lastSub.length,
                 type: 'S'
             });
@@ -160,7 +160,7 @@ export const getSubstitutions = (segment, seq) => {
         }
         if (lastSub.type === 'H') {
             substitutions.push({
-                pos: segment.to - segment.from,
+                pos: segment.end - segment.start,
                 length: lastSub.length,
                 type: 'H'
             });
@@ -342,8 +342,8 @@ const bamRecordToJson = (bamRecord, chrName, chrOffset) => {
         // https://github.com/GMOD/bam-js/blob/7a57d24b6aef08a1366cca86ba5092254c7a7f56/src/bamFile.ts#L386
         id: bamRecord._id,
         name: bamRecord.get('name'), 
-        from: +bamRecord.data.start + 1 + chrOffset,
-        to: +bamRecord.data.end + 1 + chrOffset,
+        start: +bamRecord.data.start + 1 + chrOffset,
+        end: +bamRecord.data.end + 1 + chrOffset,
         md: bamRecord.get('MD'),
         chrName,
         chrOffset,
@@ -606,8 +606,8 @@ const findMates = (uid, segments) => {
             mate.mateIds = [read.id];
            
             // Additional info we want
-            const [l, r] = [read, mate].sort((a, b) => +a.from - +b.from);
-            const insertSize = Math.max(0, +r.from - +l.to);
+            const [l, r] = [read, mate].sort((a, b) => +a.start - +b.start);
+            const insertSize = Math.max(0, +r.start - +l.end);
             const largeInsertSize = insertSize >= maxInsertSize;
             let svType;
             if(!largeInsertSize) {
@@ -654,9 +654,9 @@ const findJunctions = (uid, segments) => {
     segments.forEach(segment => {
         const substitutions = JSON.parse(segment.substitutions);
         substitutions.forEach(sub => {
-            const don = segment.from + sub.pos;
-            const acc = segment.from + sub.pos + sub.length;
-            if(segment.from < don && acc < segment.to) {
+            const don = segment.start + sub.pos;
+            const acc = segment.start + sub.pos + sub.length;
+            if(segment.start < don && acc < segment.end) {
                 const j = junctions.find(d => d.start === don && d.end === acc);
                 if(j) {
                     j.score += 1;


### PR DESCRIPTION
# Breaking Change
if you were using built-in `from` and `to` fields with `BAM` files, you need to change them to `start` and `end` fields:

**To**: 
```js
data: { type: 'bam', ...},
x: { field: 'from', type: 'genomic' ),
xe: { field: 'to', type: 'genomic' ),
...
```

**From**: 
```js
data: { type: 'bam', ...},
x: { field: 'start', type: 'genomic' ),
xe: { field: 'end', type: 'genomic' ),
...
```