### PR TITLE
feat: allow aggregation functions (`mean` and `sum`) for vector, bigwig, and multivec

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -230,9 +230,7 @@
     "BinAggregate": {
       "enum": [
         "mean",
-        "sum",
-        "min",
-        "max"
+        "sum"
       ],
       "type": "string"
     },

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -186,6 +186,10 @@
     "BIGWIGData": {
       "additionalProperties": false,
       "properties": {
+        "aggregation": {
+          "$ref": "#/definitions/BinAggregate",
+          "description": "Determine aggregation function to apply within bins. __Default__: `\"mean\"`"
+        },
         "binSize": {
           "description": "Binning the genomic interval in tiles (unit size: 256).",
           "type": "number"
@@ -222,6 +226,15 @@
         "value"
       ],
       "type": "object"
+    },
+    "BinAggregate": {
+      "enum": [
+        "mean",
+        "sum",
+        "min",
+        "max"
+      ],
+      "type": "string"
     },
     "CSVData": {
       "additionalProperties": false,
@@ -1375,6 +1388,10 @@
       "additionalProperties": false,
       "description": "Two-dimensional quantitative values, one axis for genomic coordinate and the other for different samples, can be converted into HiGlass' `\"multivec\"` data. For example, multiple BigWig files can be converted into a single multivec file. You can also convert sequence data (FASTA) into this format where rows will be different nucleotide bases (e.g., A, T, G, C) and quantitative values represent the frequency. Find out more about this format at [HiGlass Docs](https://docs.higlass.io/data_preparation.html#multivec-files).",
       "properties": {
+        "aggregation": {
+          "$ref": "#/definitions/BinAggregate",
+          "description": "Determine aggregation function to apply within bins. __Default__: `\"mean\"`"
+        },
         "binSize": {
           "description": "Binning the genomic interval in tiles (unit size: 256).",
           "type": "number"
@@ -5137,6 +5154,10 @@
       "additionalProperties": false,
       "description": "One-dimensional quantitative values along genomic position (e.g., bigwig) can be converted into HiGlass' `\"vector\"` format data. Find out more about this format at [HiGlass Docs](https://docs.higlass.io/data_preparation.html#bigwig-files).",
       "properties": {
+        "aggregation": {
+          "$ref": "#/definitions/BinAggregate",
+          "description": "Determine aggregation function to apply within bins. __Default__: `\"mean\"`"
+        },
         "binSize": {
           "description": "Binning the genomic interval in tiles (unit size: 256).",
           "type": "number"

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -592,7 +592,7 @@ export interface DomainGene {
 }
 
 export type Aggregate = 'max' | 'min' | 'mean' | 'bin' | 'count';
-export type BinAggregate = 'mean' | 'sum' | 'min' | 'max';
+export type BinAggregate = 'mean' | 'sum';
 
 /* ----------------------------- DATA ----------------------------- */
 export type DataDeep = JSONData | CSVData | BIGWIGData | MultivecData | BEDDBData | VectorData | MatrixData | BAMData;

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -592,6 +592,7 @@ export interface DomainGene {
 }
 
 export type Aggregate = 'max' | 'min' | 'mean' | 'bin' | 'count';
+export type BinAggregate = 'mean' | 'sum' | 'min' | 'max';
 
 /* ----------------------------- DATA ----------------------------- */
 export type DataDeep = JSONData | CSVData | BIGWIGData | MultivecData | BEDDBData | VectorData | MatrixData | BAMData;
@@ -604,7 +605,6 @@ export interface Datum {
 /**
  * The JSON data format allows users to include data directly in the Gosling's JSON specification.
  */
-
 export interface JSONData {
     /**
      * Define data type.
@@ -748,6 +748,9 @@ export interface MultivecData {
      * Binning the genomic interval in tiles (unit size: 256).
      */
     binSize?: number;
+
+    /** Determine aggregation function to apply within bins. __Default__: `"mean"` */
+    aggregation?: BinAggregate;
 }
 
 export interface BIGWIGData {
@@ -781,6 +784,9 @@ export interface BIGWIGData {
      * Binning the genomic interval in tiles (unit size: 256).
      */
     binSize?: number;
+
+    /** Determine aggregation function to apply within bins. __Default__: `"mean"` */
+    aggregation?: BinAggregate;
 }
 
 /**
@@ -809,6 +815,9 @@ export interface VectorData {
 
     /** Binning the genomic interval in tiles (unit size: 256). */
     binSize?: number;
+
+    /** Determine aggregation function to apply within bins. __Default__: `"mean"` */
+    aggregation?: BinAggregate;
 }
 
 /**

--- a/src/gosling-track/data-abstraction.ts
+++ b/src/gosling-track/data-abstraction.ts
@@ -48,6 +48,9 @@ export function getTabularData(
         const minValueName = `${valueName}_min`;
         const maxValueName = `${valueName}_max`;
 
+        // user's aggregation function
+        const agg = spec.data.aggregation ?? 'mean';
+
         // convert data to a visualization-friendly format
         let cumVal = 0;
         let minVal = Number.MAX_SAFE_INTEGER;
@@ -57,7 +60,7 @@ export function getTabularData(
         Array.from(Array(numOfGenomicPositions).keys()).forEach((g: number, j: number) => {
             // add individual rows
             if (bin === 1) {
-                const value = numericValues[j];
+                const value = numericValues[j] / (agg === 'mean' ? tileUnitSize : 1);
                 tabularData.push({
                     [valueName]: value,
                     [columnName]: data.tileX + (j + 0.5) * tileUnitSize,
@@ -76,7 +79,12 @@ export function getTabularData(
                 } else if (j % bin === bin - 1) {
                     // Add a row using the cumulative value
                     tabularData.push({
-                        [valueName]: cumVal / bin,
+                        [valueName]:
+                            agg === 'min'
+                                ? minVal
+                                : agg === 'max'
+                                ? maxVal
+                                : cumVal / bin / (agg === 'mean' ? tileUnitSize : 1),
                         [columnName]: data.tileX + (binStart + bin / 2.0) * tileUnitSize,
                         [startName]: data.tileX + binStart * tileUnitSize,
                         [endName]: data.tileX + binEnd * tileUnitSize,
@@ -88,7 +96,12 @@ export function getTabularData(
                     const smallBin = numOfGenomicPositions % bin;
                     const correctedBinEnd = binStart + smallBin;
                     tabularData.push({
-                        [valueName]: cumVal / smallBin,
+                        [valueName]:
+                            agg === 'min'
+                                ? minVal
+                                : agg === 'max'
+                                ? maxVal
+                                : cumVal / smallBin / (agg === 'mean' ? tileUnitSize : 1),
                         [columnName]: data.tileX + (binStart + smallBin / 2.0) * tileUnitSize,
                         [startName]: data.tileX + binStart * tileUnitSize,
                         [endName]: data.tileX + correctedBinEnd * tileUnitSize,
@@ -132,6 +145,9 @@ export function getTabularData(
         const minValueName = `${valueName}_min`;
         const maxValueName = `${valueName}_max`;
 
+        // user's aggregation function
+        const agg = spec.data.aggregation ?? 'mean';
+
         // convert data to a visualization-friendly format
         categories.forEach((c: string, i: number) => {
             let cumVal = 0;
@@ -142,7 +158,7 @@ export function getTabularData(
             Array.from(Array(numOfGenomicPositions).keys()).forEach((g: number, j: number) => {
                 // add individual rows
                 if (bin === 1) {
-                    const value = numericValues[numOfGenomicPositions * i + j];
+                    const value = numericValues[numOfGenomicPositions * i + j] / (agg === 'mean' ? tileUnitSize : 1);
                     tabularData.push({
                         [rowName]: c,
                         [valueName]: value,
@@ -163,7 +179,12 @@ export function getTabularData(
                         // Add a row using the cumulative value
                         tabularData.push({
                             [rowName]: c,
-                            [valueName]: cumVal / bin,
+                            [valueName]:
+                                agg === 'max'
+                                    ? maxVal
+                                    : agg === 'min'
+                                    ? minVal
+                                    : cumVal / bin / (agg === 'mean' ? tileUnitSize : 1),
                             [columnName]: data.tileX + (binStart + bin / 2.0) * tileUnitSize,
                             [startName]: data.tileX + binStart * tileUnitSize,
                             [endName]: data.tileX + binEnd * tileUnitSize,
@@ -176,7 +197,12 @@ export function getTabularData(
                         const correctedBinEnd = binStart + smallBin;
                         tabularData.push({
                             [rowName]: c,
-                            [valueName]: cumVal / smallBin,
+                            [valueName]:
+                                agg === 'min'
+                                    ? minVal
+                                    : agg === 'max'
+                                    ? maxVal
+                                    : cumVal / smallBin / (agg === 'mean' ? tileUnitSize : 1),
                             [columnName]: data.tileX + (binStart + smallBin / 2.0) * tileUnitSize,
                             [startName]: data.tileX + binStart * tileUnitSize,
                             [endName]: data.tileX + correctedBinEnd * tileUnitSize,

--- a/src/gosling-track/data-abstraction.ts
+++ b/src/gosling-track/data-abstraction.ts
@@ -57,7 +57,7 @@ export function getTabularData(
         Array.from(Array(numOfGenomicPositions).keys()).forEach((g: number, j: number) => {
             // add individual rows
             if (bin === 1) {
-                const value = numericValues[j] / tileUnitSize;
+                const value = numericValues[j];
                 tabularData.push({
                     [valueName]: value,
                     [columnName]: data.tileX + (j + 0.5) * tileUnitSize,
@@ -76,7 +76,7 @@ export function getTabularData(
                 } else if (j % bin === bin - 1) {
                     // Add a row using the cumulative value
                     tabularData.push({
-                        [valueName]: cumVal / bin / tileUnitSize,
+                        [valueName]: cumVal / bin,
                         [columnName]: data.tileX + (binStart + bin / 2.0) * tileUnitSize,
                         [startName]: data.tileX + binStart * tileUnitSize,
                         [endName]: data.tileX + binEnd * tileUnitSize,
@@ -88,7 +88,7 @@ export function getTabularData(
                     const smallBin = numOfGenomicPositions % bin;
                     const correctedBinEnd = binStart + smallBin;
                     tabularData.push({
-                        [valueName]: cumVal / smallBin / tileUnitSize,
+                        [valueName]: cumVal / smallBin,
                         [columnName]: data.tileX + (binStart + smallBin / 2.0) * tileUnitSize,
                         [startName]: data.tileX + binStart * tileUnitSize,
                         [endName]: data.tileX + correctedBinEnd * tileUnitSize,
@@ -142,7 +142,7 @@ export function getTabularData(
             Array.from(Array(numOfGenomicPositions).keys()).forEach((g: number, j: number) => {
                 // add individual rows
                 if (bin === 1) {
-                    const value = numericValues[numOfGenomicPositions * i + j] / tileUnitSize;
+                    const value = numericValues[numOfGenomicPositions * i + j];
                     tabularData.push({
                         [rowName]: c,
                         [valueName]: value,
@@ -163,7 +163,7 @@ export function getTabularData(
                         // Add a row using the cumulative value
                         tabularData.push({
                             [rowName]: c,
-                            [valueName]: cumVal / bin / tileUnitSize,
+                            [valueName]: cumVal / bin,
                             [columnName]: data.tileX + (binStart + bin / 2.0) * tileUnitSize,
                             [startName]: data.tileX + binStart * tileUnitSize,
                             [endName]: data.tileX + binEnd * tileUnitSize,
@@ -176,7 +176,7 @@ export function getTabularData(
                         const correctedBinEnd = binStart + smallBin;
                         tabularData.push({
                             [rowName]: c,
-                            [valueName]: cumVal / smallBin / tileUnitSize,
+                            [valueName]: cumVal / smallBin,
                             [columnName]: data.tileX + (binStart + smallBin / 2.0) * tileUnitSize,
                             [startName]: data.tileX + binStart * tileUnitSize,
                             [endName]: data.tileX + correctedBinEnd * tileUnitSize,

--- a/src/gosling-track/data-abstraction.ts
+++ b/src/gosling-track/data-abstraction.ts
@@ -79,12 +79,7 @@ export function getTabularData(
                 } else if (j % bin === bin - 1) {
                     // Add a row using the cumulative value
                     tabularData.push({
-                        [valueName]:
-                            agg === 'min'
-                                ? minVal
-                                : agg === 'max'
-                                ? maxVal
-                                : cumVal / bin / (agg === 'mean' ? tileUnitSize : 1),
+                        [valueName]: cumVal / bin / (agg === 'mean' ? tileUnitSize : 1),
                         [columnName]: data.tileX + (binStart + bin / 2.0) * tileUnitSize,
                         [startName]: data.tileX + binStart * tileUnitSize,
                         [endName]: data.tileX + binEnd * tileUnitSize,
@@ -96,12 +91,7 @@ export function getTabularData(
                     const smallBin = numOfGenomicPositions % bin;
                     const correctedBinEnd = binStart + smallBin;
                     tabularData.push({
-                        [valueName]:
-                            agg === 'min'
-                                ? minVal
-                                : agg === 'max'
-                                ? maxVal
-                                : cumVal / smallBin / (agg === 'mean' ? tileUnitSize : 1),
+                        [valueName]: cumVal / smallBin / (agg === 'mean' ? tileUnitSize : 1),
                         [columnName]: data.tileX + (binStart + smallBin / 2.0) * tileUnitSize,
                         [startName]: data.tileX + binStart * tileUnitSize,
                         [endName]: data.tileX + correctedBinEnd * tileUnitSize,
@@ -169,7 +159,6 @@ export function getTabularData(
                         [maxValueName]: value
                     });
                 } else {
-                    // EXPERIMENTAL: bin the data considering the `bin` options
                     if (j % bin === 0) {
                         // Start storing information for this bin
                         cumVal = minVal = maxVal = numericValues[numOfGenomicPositions * i + j];
@@ -179,12 +168,7 @@ export function getTabularData(
                         // Add a row using the cumulative value
                         tabularData.push({
                             [rowName]: c,
-                            [valueName]:
-                                agg === 'max'
-                                    ? maxVal
-                                    : agg === 'min'
-                                    ? minVal
-                                    : cumVal / bin / (agg === 'mean' ? tileUnitSize : 1),
+                            [valueName]: cumVal / (agg === 'mean' ? bin / tileUnitSize : 1),
                             [columnName]: data.tileX + (binStart + bin / 2.0) * tileUnitSize,
                             [startName]: data.tileX + binStart * tileUnitSize,
                             [endName]: data.tileX + binEnd * tileUnitSize,
@@ -197,12 +181,7 @@ export function getTabularData(
                         const correctedBinEnd = binStart + smallBin;
                         tabularData.push({
                             [rowName]: c,
-                            [valueName]:
-                                agg === 'min'
-                                    ? minVal
-                                    : agg === 'max'
-                                    ? maxVal
-                                    : cumVal / smallBin / (agg === 'mean' ? tileUnitSize : 1),
+                            [valueName]: cumVal / (agg === 'mean' ? smallBin / tileUnitSize : 1),
                             [columnName]: data.tileX + (binStart + smallBin / 2.0) * tileUnitSize,
                             [startName]: data.tileX + binStart * tileUnitSize,
                             [endName]: data.tileX + correctedBinEnd * tileUnitSize,


### PR DESCRIPTION
Fix #587 

```js
"data": {
  "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
  "type": "multivec", // or "vector" and "bigwig"
  ...,
  "aggregation": "sum" // or "mean" which is default
},
```