### PR TITLE
fix: do not filter out small `withinLink` marks by default

### DIFF
--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -280,7 +280,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
 
                 if (xe - x <= 0.1) {
                     // Do not draw very small links
-                    return;
+                    // return;
                 }
 
                 const midX = (x + xe) / 2.0;

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -278,11 +278,6 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                     return;
                 }
 
-                if (xe - x <= 0.1) {
-                    // Do not draw very small links
-                    // return;
-                }
-
                 const midX = (x + xe) / 2.0;
 
                 // Must not fill color for `line`, just use `stroke`


### PR DESCRIPTION
Gosling shouldn't filter marks, instead, let users decide themselves.