### PR TITLE
feat!: set min height for bezier withinLink; faster bezier curve rendering; fix typo (i.e., `bazier` --> `bezier`)

### DIFF
--- a/editor/example/cancer-variant.ts
+++ b/editor/example/cancer-variant.ts
@@ -546,7 +546,7 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                 { field: 'end2', type: 'genomic' },
                                 { field: 'svclass', type: 'nominal' }
                             ],
-                            style: { legendTitle: 'SV Class', bazierLink: true },
+                            style: { legendTitle: 'SV Class', bezierLink: true },
                             width: 1000,
                             height: 200
                         }

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -4807,8 +4807,8 @@
         "backgroundOpacity": {
           "type": "number"
         },
-        "bazierLink": {
-          "description": "Specify whether to use bazier curves for the `link` marks.",
+        "bezierLink": {
+          "description": "Specify whether to use bezier curves for the `link` marks.",
           "type": "boolean"
         },
         "curve": {

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -554,8 +554,8 @@
         "backgroundOpacity": {
           "type": "number"
         },
-        "bazierLink": {
-          "description": "Specify whether to use bazier curves for the `link` marks.",
+        "bezierLink": {
+          "description": "Specify whether to use bezier curves for the `link` marks.",
           "type": "boolean"
         },
         "curve": {

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -305,11 +305,11 @@ export interface Style {
      */
     dy?: number;
     /**
-     *  Specify whether to use bazier curves for the `link` marks.
+     *  Specify whether to use bezier curves for the `link` marks.
      */
-    bazierLink?: boolean;
+    bezierLink?: boolean;
 
-    // TODO: betweenLinkStyle: 'regular' | 'bazier' | 'flat'
+    // TODO: betweenLinkStyle: 'regular' | 'bezier' | 'flat'
     /** Specify whether to use a flat within-links, such as the one in Sashimi plots. __Default__: `false` */
     flatWithinLink?: boolean;
 

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -334,9 +334,11 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                         const x1 = x;
                         const y1 = baseY;
                         const x2 = x + (xe - x) / 3.0;
-                        const y2 = baseY + Math.max(10, Math.min(rowHeight, (xe - x) / 2.0)) * (flipY ? 1 : -1);
+                        const y2 =
+                            baseY + Math.max(rowHeight / 2.0, Math.min(rowHeight, (xe - x) / 2.0)) * (flipY ? 1 : -1);
                         const x3 = x + ((xe - x) / 3.0) * 2;
-                        const y3 = baseY + Math.max(10, Math.min(rowHeight, (xe - x) / 2.0)) * (flipY ? 1 : -1);
+                        const y3 =
+                            baseY + Math.max(rowHeight / 2.0, Math.min(rowHeight, (xe - x) / 2.0)) * (flipY ? 1 : -1);
                         const x4 = xe;
                         const y4 = baseY;
 

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -311,7 +311,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                     g.moveTo(x1, y1);
 
                     const bezier = new Bezier(x1, y1, x2, y2, x3, y3, x4, y4);
-                    const points = bezier.getLUT(20);
+                    const points = bezier.getLUT(14);
                     points.forEach(d => g.lineTo(d.x, d.y));
 
                     /* click event data */
@@ -343,7 +343,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                         const y4 = baseY;
 
                         const bezier = new Bezier(x1, y1, x2, y2, x3, y3, x4, y4);
-                        const points = bezier.getLUT(20);
+                        const points = bezier.getLUT(14);
                         points.forEach(d => g.lineTo(d.x, d.y));
 
                         /* click event data */

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -173,7 +173,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
 
                     g.moveTo(_x1, baseY);
 
-                    if (spec.style?.bazierLink) {
+                    if (spec.style?.bezierLink) {
                         g.arc(
                             (_x1 + _x4) / 2.0, // cx
                             baseY, // cy
@@ -330,7 +330,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
 
                     g.moveTo(x, baseY);
 
-                    if (spec.style?.bazierLink) {
+                    if (spec.style?.bezierLink) {
                         const x1 = x;
                         const y1 = baseY;
                         const x2 = x + (xe - x) / 3.0;


### PR DESCRIPTION
## Update

- Draw a less number of segments for `withinLink` bezier curve line connections. We could later make this number (i.e., 14) dynamic depending on the distance of the stand and end positions.
- We use a minimum height of bezier curves in linear layouts, consistent with circular layouts. This allows the detection of small curves (e.g., breakpoints that are close to each other can be still found in SV vis).

![Screen Shot 2021-12-12 at 5 03 25 PM](https://user-images.githubusercontent.com/9922882/145731331-1ad6f56d-19f8-4221-8126-b065498df6e5.png)


## Breaking Change
We corrected the name of the bezier curve. Previously, we called it a b**a**zier curve. 

If you used bezier style links, you need to change the option name. 

**To** 
```js
style: { bezierLink: true }
```

**From** 
```js
style: { bazierLink: true }
```