### PR TITLE
feat!: `quantitativeFields` is removed entirely from `csv` and `json` data specs

### DIFF
--- a/editor/example/cancer-variant.ts
+++ b/editor/example/cancer-variant.ts
@@ -603,8 +603,7 @@ export function view(sample: string): GoslingSpec {
             //         url: `https://s3.amazonaws.com/gosling-lang.org/data/cancer/substitution.${sample}.csv`,
             //         type: 'csv',
             //         chromosomeField: 'Chrom',
-            //         genomicFields: ['Pos'],
-            //         quantitativeFields: ['GP', 'SP', 'DP', 'PosDiff']
+            //         genomicFields: ['Pos']
             //     },
             //     dataTransform: [
             //         { type: 'concat', fields: ['Ref', 'Alt'], separator: ' > ', newField: 'sub' },

--- a/editor/example/corces.ts
+++ b/editor/example/corces.ts
@@ -23,8 +23,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                         url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/cytogenetic_band.csv',
                         type: 'csv',
                         chromosomeField: 'Chr.',
-                        genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop'],
-                        quantitativeFields: ['Band', 'Density']
+                        genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop']
                     },
                     tracks: [
                         {

--- a/editor/example/ideograms.ts
+++ b/editor/example/ideograms.ts
@@ -7,8 +7,7 @@ export const CytoBands: OverlaidTracks = {
         url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/cytogenetic_band.csv',
         type: 'csv',
         chromosomeField: 'Chr.',
-        genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop'],
-        quantitativeFields: ['Band', 'Density']
+        genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop']
     },
     tracks: [
         {

--- a/editor/example/theme.ts
+++ b/editor/example/theme.ts
@@ -39,8 +39,7 @@ export const EX_SPEC_CUSTOM_THEME: GoslingSpec = {
                         url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/cytogenetic_band.csv',
                         type: 'csv',
                         chromosomeField: 'Chr.',
-                        genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop'],
-                        quantitativeFields: ['Band', 'Density']
+                        genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop']
                     },
                     tracks: [
                         {

--- a/editor/example/visual-encoding.ts
+++ b/editor/example/visual-encoding.ts
@@ -844,8 +844,7 @@ export const EX_SPEC_RULE: GoslingSpec = {
                             { c: 'chr10', p: 100000, v: 0.0009 }
                         ],
                         chromosomeField: 'c',
-                        genomicFields: ['p'],
-                        quantitativeFields: ['v']
+                        genomicFields: ['p']
                     },
                     mark: 'rule',
                     x: { field: 'p', type: 'genomic' },
@@ -862,8 +861,7 @@ export const EX_SPEC_RULE: GoslingSpec = {
                             { c: 'chr10', p: 100000, v: 0.009 }
                         ],
                         chromosomeField: 'c',
-                        genomicFields: ['p'],
-                        quantitativeFields: ['v']
+                        genomicFields: ['p']
                     },
                     mark: 'rule',
                     x: { field: 'p', type: 'genomic' },

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -287,13 +287,6 @@
           "description": "experimental",
           "type": "string"
         },
-        "quantitativeFields": {
-          "description": "Specify the name of quantitative data fields.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "sampleLength": {
           "description": "Specify the number of rows loaded from the URL.\n\n__Default:__ `1000`",
           "type": "number"
@@ -1126,13 +1119,6 @@
               "genomicFields"
             ],
             "type": "object"
-          },
-          "type": "array"
-        },
-        "quantitativeFields": {
-          "description": "Specify the name of quantitative data fields.",
-          "items": {
-            "type": "string"
           },
           "type": "array"
         },

--- a/schema/higlass.schema.json
+++ b/schema/higlass.schema.json
@@ -66,12 +66,6 @@
           },
           "type": "array"
         },
-        "quantitativeFields": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "tiles": {
         },
         "tilesetInfo": {

--- a/src/core/gosling.schema.guards.test.ts
+++ b/src/core/gosling.schema.guards.test.ts
@@ -9,8 +9,7 @@ describe('Type Guard', () => {
                     url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/cytogenetic_band.csv',
                     type: 'csv',
                     chromosomeField: 'Chr.',
-                    genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop'],
-                    quantitativeFields: ['Band', 'Density']
+                    genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop']
                 },
                 overlay: [
                     {

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -614,9 +614,6 @@ export interface JSONData {
     /** Values in the form of JSON. */
     values: Datum[];
 
-    /** Specify the name of quantitative data fields. */
-    quantitativeFields?: string[];
-
     /** Specify the name of chromosome data fields. */
     chromosomeField?: string;
 
@@ -652,11 +649,6 @@ export interface CSVData {
      * Specify file separator, __Default:__ ','
      */
     separator?: string;
-
-    /**
-     * Specify the name of quantitative data fields.
-     */
-    quantitativeFields?: string[];
 
     /**
      * Specify the name of chromosome data fields.

--- a/src/core/higlass.schema.ts
+++ b/src/core/higlass.schema.ts
@@ -108,8 +108,6 @@ export interface Data {
     url?: string;
 
     // Options Gosling internally use
-    // csv
-    quantitativeFields?: string[];
     assembly?: Assembly;
 
     // Option to filter datasets

--- a/src/data-fetcher/csv/higlass-csv-datafetcher.test.ts
+++ b/src/data-fetcher/csv/higlass-csv-datafetcher.test.ts
@@ -10,8 +10,7 @@ describe('CSV data fetcher', () => {
             url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/cytogenetic_band.csv',
             type: 'csv',
             chromosomeField: 'Chr.',
-            genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop'],
-            quantitativeFields: ['Band', 'Density']
+            genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop']
         }
     );
 

--- a/src/data-fetcher/csv/higlass-csv-datafetcher.ts
+++ b/src/data-fetcher/csv/higlass-csv-datafetcher.ts
@@ -74,7 +74,6 @@ function CSVDataFetcher(HGC: any, ...args: any): any {
                 url,
                 chromosomeField,
                 genomicFields,
-                quantitativeFields,
                 headerNames,
                 chromosomePrefix,
                 longToWideId,
@@ -141,10 +140,6 @@ function CSVDataFetcher(HGC: any, ...args: any): any {
                             // store row only when chromosome information is correctly parsed
                             return undefined;
                         }
-
-                        quantitativeFields?.forEach((q: string) => {
-                            row[q] = +row[q];
-                        });
 
                         return row;
                     });

--- a/src/data-fetcher/json/higlass-raw-datafetcher.test.ts
+++ b/src/data-fetcher/json/higlass-raw-datafetcher.test.ts
@@ -7,8 +7,7 @@ describe('CSV data fetcher', () => {
             type: 'csv',
             values: [{ chr: 'chr1', start: 1, end: 778094, id: 'peak1', peak: 4.38368 }],
             chromosomeField: 'Chr.',
-            genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop'],
-            quantitativeFields: ['Band', 'Density']
+            genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop']
         }
     );
 

--- a/src/data-fetcher/json/higlass-raw-datafetcher.ts
+++ b/src/data-fetcher/json/higlass-raw-datafetcher.ts
@@ -83,9 +83,6 @@ function RawDataFetcher(HGC: any, ...args: any): any {
                     return undefined;
                 }
 
-                this.dataConfig.quantitativeFields?.forEach((q: string) => {
-                    row[q] = +row[q];
-                });
                 return row;
             });
         }


### PR DESCRIPTION
This removes `quantitativeFields` entirely from `csv` and `json` data specs. This property was unnecessary since we generate `scale`s per visual channel, and the value type (i.e., quantitative vs. nominal) is determined at the time we generate scales, not at the time we parse data. More detailed discussions can be found at #579.

# Breaking Updates
If you were using `quantitativeFields` in the data properties, you just need to remove them from your spec:
```diff
data: {
    url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/cytogenetic_band.csv',
    type: 'csv',
    chromosomeField: 'Chr.',
    genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop'],
-   quantitativeFields: ['Band', 'Density']
},
```

Fix #579 