### PR TITLE
feat: use HiGlass `heatmap` for conventional 2D matrix

### DIFF
--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -104,8 +104,7 @@ export const examples: {
     },
     MATRIX_HFFC6: {
         name: 'Comparative Matrices (Micro-C vs. Hi-C)',
-        spec: EX_SPEC_MATRIX_HFFC6,
-        underDevelopment: true
+        spec: EX_SPEC_MATRIX_HFFC6
     },
     CIRCOS: {
         name: 'Circos',

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -130,7 +130,7 @@ export function goslingToHiGlass(
 
         // We use higlass 'heatmap' track instead of 'gosling-track' for rendering performance.
         // HiGlass is really well-optimized for matrix visualization, and rendering it in Gosling
-        // makes the zooming interaction slow.
+        // instead makes the zooming interaction slow.
         // See https://github.com/gosling-lang/gosling.js/pull/612#discussion_r771623844
         if (IsHiGlassMatrix(firstResolvedSpec)) {
             // By changing the track type, HiGlass uses its native heatmap track

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -136,7 +136,7 @@ export function goslingToHiGlass(
             // By changing the track type, HiGlass uses its native heatmap track
             hgTrack.type = 'heatmap';
             const colorStr =
-                IsChannelDeep(firstResolvedSpec.color) && typeof firstResolvedSpec.color === 'string'
+                IsChannelDeep(firstResolvedSpec.color) && typeof firstResolvedSpec.color.range === 'string'
                     ? firstResolvedSpec.color.range
                     : 'viridis';
             hgTrack.options.colorRange = getHiGlassColorRange(colorStr);

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -128,7 +128,7 @@ export function goslingToHiGlass(
             };
         }
 
-        // We use higlass 'matrix' track instead of 'gosling-track' for rendering performance.
+        // We use higlass 'heatmap' track instead of 'gosling-track' for rendering performance.
         // HiGlass is really well-optimized for matrix visualization, and rendering it in Gosling
         // makes the zooming interaction slow.
         // See https://github.com/gosling-lang/gosling.js/pull/612#discussion_r771623844

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -12,7 +12,8 @@ import {
     IsDataDeepTileset,
     Is2DTrack,
     IsXAxis,
-    IsHiGlassMatrix
+    IsHiGlassMatrix,
+    getHiGlassColorRange
 } from './gosling.schema.guards';
 import { DEWFAULT_TITLE_PADDING_ON_TOP_AND_BOTTOM } from './layout/defaults';
 import { CompleteThemeDeep } from './utils/theme';
@@ -134,8 +135,11 @@ export function goslingToHiGlass(
         if (IsHiGlassMatrix(firstResolvedSpec)) {
             // By changing the track type, HiGlass uses its native heatmap track
             hgTrack.type = 'heatmap';
-            // TODO: use consistent color scheme w/ Gosling
-            hgTrack.options.colorRange = ['white', 'rgba(245,166,35,1.0)', 'rgba(208,2,27,1.0)', 'black'];
+            const colorStr =
+                IsChannelDeep(firstResolvedSpec.color) && typeof firstResolvedSpec.color === 'string'
+                    ? firstResolvedSpec.color.range
+                    : 'viridis';
+            hgTrack.options.colorRange = getHiGlassColorRange(colorStr);
             hgTrack.options.trackBorderWidth = firstResolvedSpec.style?.outlineWidth ?? theme.track.outlineWidth;
             hgTrack.options.trackBorderColor = firstResolvedSpec.style?.outline ?? theme.track.outline;
             hgTrack.options.colorbarPosition = (firstResolvedSpec.color as any)?.legend ? 'topRight' : 'hidden';

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -127,6 +127,19 @@ export function Is2DTrack(track: Track) {
     );
 }
 
+/**
+ * Do we want to use HiGlass matrix to rendering the given visualization?
+ */
+export function IsHiGlassMatrix(track: SingleTrack) {
+    return (
+        Is2DTrack(track) &&
+        track.data.type === 'matrix' &&
+        (track.mark === 'bar' || track.mark === 'rect') &&
+        track.xe &&
+        track.ye
+    );
+}
+
 export function IsChannelValue(channel: ChannelDeep | ChannelValue | undefined | 'none'): channel is ChannelValue {
     return channel !== null && typeof channel === 'object' && 'value' in channel;
 }

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -55,6 +55,14 @@ export const PREDEFINED_COLOR_STR_MAP: { [k: string]: (t: number) => string } = 
     rdbu: interpolateRdBu
 };
 
+/**
+ * This returns an array of color strings that can be assigned to HiGlass' option, `colorRange`
+ */
+export function getHiGlassColorRange(colorStr = 'viridis', step = 100) {
+    const interpolate = PREDEFINED_COLOR_STR_MAP[colorStr] ?? PREDEFINED_COLOR_STR_MAP['viridis'];
+    return [...Array(step)].map((v, i) => interpolate((1 / step) * i));
+}
+
 export function IsFlatTracks(_: SingleView): _ is FlatTracks {
     return !('alignment' in _) && !_.tracks.find(d => (d as any).alignment === 'overlay' || 'tracks' in d);
 }
@@ -128,7 +136,7 @@ export function Is2DTrack(track: Track) {
 }
 
 /**
- * Do we want to use HiGlass matrix to rendering the given visualization?
+ * Do we want to use HiGlass matrix track (i.e., 'heatmap') to rendering the given visualization?
  */
 export function IsHiGlassMatrix(track: SingleTrack) {
     return (


### PR DESCRIPTION
This PR allows to use HiGlass `heatmap` tracks conditionally (i.e., for given user specs) so that the conventional 2D matrix, which is one of the most common use cases w/ Hi-C, can be displayed in an efficient way. All the rendering and data managing is handled by the [`heatmap` track](https://github.com/higlass/higlass/blob/develop/app/scripts/HeatmapTiledPixiTrack.js).

(Find more detailed discussion: https://github.com/gosling-lang/gosling.js/pull/612#discussion_r771623844)

https://user-images.githubusercontent.com/9922882/148417261-2b16d0bf-2f5a-4224-8621-6379d43cf06b.mov

