### PR TITLE
feat: add responsive sizing options

### DIFF
--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -1,6 +1,11 @@
 import type { GoslingSpec } from 'gosling.js';
+import {
+    EX_SPEC_VISUAL_ENCODING,
+    EX_SPEC_VISUAL_ENCODING_CIRCULAR,
+    EX_SPEC_RESPONSIVE,
+    EX_SPEC_RULE
+} from './visual-encoding';
 import { EX_SPEC_LAYOUT_AND_ARRANGEMENT_1, EX_SPEC_LAYOUT_AND_ARRANGEMENT_2 } from './layout-and-arrangement';
-import { EX_SPEC_VISUAL_ENCODING, EX_SPEC_VISUAL_ENCODING_CIRCULAR, EX_SPEC_RULE } from './visual-encoding';
 import { EX_SPEC_MATRIX } from './matrix';
 import { EX_SPEC_CANCER_VARIANT_PROTOTYPE } from './cancer-variant';
 import { EX_SPEC_MATRIX_HFFC6 } from './matrix-hffc6';
@@ -45,6 +50,11 @@ export const examples: {
     VISUAL_ENCODING_CIRCULAR: {
         name: 'Basic Example: Circular Visual Encoding',
         spec: EX_SPEC_VISUAL_ENCODING_CIRCULAR
+    },
+    RESPONSIVE_SIZE: {
+        name: 'Basic Example: Responsive Size',
+        spec: EX_SPEC_RESPONSIVE,
+        forceShow: true
     },
     BAND: {
         name: 'Basic Example: Band Connection',

--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -101,8 +101,7 @@ export const examples: {
     },
     RESPONSIVE_ENCODING: {
         name: 'Responsive Encoding',
-        spec: EX_SPEC_RESPONSIVE,
-        forceShow: true
+        spec: EX_SPEC_RESPONSIVE
     },
     CYTOBANDS: {
         name: 'Ideograms',

--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -51,11 +51,6 @@ export const examples: {
         name: 'Basic Example: Circular Visual Encoding',
         spec: EX_SPEC_VISUAL_ENCODING_CIRCULAR
     },
-    RESPONSIVE_SIZE: {
-        name: 'Basic Example: Responsive Size',
-        spec: EX_SPEC_RESPONSIVE,
-        forceShow: true
-    },
     BAND: {
         name: 'Basic Example: Band Connection',
         spec: EX_SPEC_BAND
@@ -103,6 +98,11 @@ export const examples: {
     SEMANTIC_ZOOM: {
         name: 'Multi-Scale Clinvar Lollipop Plot',
         spec: EX_SPEC_CLINVAR_LOLLIPOP
+    },
+    RESPONSIVE_ENCODING: {
+        name: 'Responsive Encoding',
+        spec: EX_SPEC_RESPONSIVE,
+        forceShow: true
     },
     CYTOBANDS: {
         name: 'Ideograms',

--- a/editor/example/visual-encoding.ts
+++ b/editor/example/visual-encoding.ts
@@ -4,7 +4,6 @@ import { GOSLING_PUBLIC_DATA } from './gosling-data';
 export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
     title: 'Visual Encoding',
     subtitle: 'Gosling provides diverse visual encoding methods',
-    responsive: true,
     layout: 'linear',
     arrangement: 'vertical',
     centerRadius: 0.8,

--- a/editor/example/visual-encoding.ts
+++ b/editor/example/visual-encoding.ts
@@ -876,38 +876,59 @@ export const EX_SPEC_RULE: GoslingSpec = {
 };
 
 export const EX_SPEC_RESPONSIVE: GoslingSpec = {
-    title: 'Basic Example: Responsive Sizing',
-    subtitle: 'Use a "responsive" option to make the size of Gosling visualization bound to its parent element',
-    responsive: { width: true, height: true },
+    // title: 'Responsive Visualization',
+    // subtitle: 'Resize your browser to see visualization changes...',
+    responsiveSize: { width: true, height: true },
     xDomain: { chromosome: '1', interval: [1, 3000500] },
     views: [
         {
             tracks: [
                 {
+                    alignment: 'overlay',
                     data: {
                         url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec',
                         type: 'multivec',
                         row: 'sample',
                         column: 'position',
                         value: 'peak',
-                        categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4'],
+                        categories: [
+                            'sample 1',
+                            'sample 2',
+                            'sample 3',
+                            'sample 4',
+                            'sample 5',
+                            'sample 6',
+                            'sample 7',
+                            'sample 8'
+                        ],
                         binSize: 4
                     },
-                    mark: 'rect',
-                    x: { field: 'start', type: 'genomic', axis: 'top' },
-                    xe: { field: 'end', type: 'genomic' },
-                    row: { field: 'sample', type: 'nominal', legend: true },
-                    color: { field: 'peak', type: 'quantitative', legend: true },
-                    tooltip: [
-                        { field: 'start', type: 'genomic', alt: 'Start Position' },
-                        { field: 'end', type: 'genomic', alt: 'End Position' },
+                    mark: 'line',
+                    x: { field: 'position', type: 'genomic' },
+                    y: { field: 'peak', type: 'quantitative', axis: 'right' },
+                    color: { field: 'sample', type: 'nominal' },
+                    tracks: [
                         {
-                            field: 'peak',
-                            type: 'quantitative',
-                            alt: 'Value',
-                            format: '.2'
+                            row: { field: 'sample', type: 'nominal', legend: true },
+                            visibility: [
+                                {
+                                    target: 'track',
+                                    measure: 'height',
+                                    operation: 'GT',
+                                    threshold: 8 * 10
+                                }
+                            ]
                         },
-                        { field: 'sample', type: 'nominal', alt: 'Sample' }
+                        {
+                            visibility: [
+                                {
+                                    target: 'track',
+                                    measure: 'height',
+                                    operation: 'LT',
+                                    threshold: 8 * 10
+                                }
+                            ]
+                        }
                     ],
                     width: 600,
                     height: 130

--- a/editor/example/visual-encoding.ts
+++ b/editor/example/visual-encoding.ts
@@ -4,6 +4,7 @@ import { GOSLING_PUBLIC_DATA } from './gosling-data';
 export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
     title: 'Visual Encoding',
     subtitle: 'Gosling provides diverse visual encoding methods',
+    responsive: true,
     layout: 'linear',
     arrangement: 'vertical',
     centerRadius: 0.8,
@@ -871,6 +872,48 @@ export const EX_SPEC_RULE: GoslingSpec = {
             ],
             width: 500,
             height: 200
+        }
+    ]
+};
+
+export const EX_SPEC_RESPONSIVE: GoslingSpec = {
+    title: 'Basic Example: Responsive Sizing',
+    subtitle: 'Use a "responsive" option to make the size of Gosling visualization bound to its parent element',
+    responsive: { width: true, height: true },
+    xDomain: { chromosome: '1', interval: [1, 3000500] },
+    views: [
+        {
+            tracks: [
+                {
+                    data: {
+                        url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec',
+                        type: 'multivec',
+                        row: 'sample',
+                        column: 'position',
+                        value: 'peak',
+                        categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4'],
+                        binSize: 4
+                    },
+                    mark: 'rect',
+                    x: { field: 'start', type: 'genomic', axis: 'top' },
+                    xe: { field: 'end', type: 'genomic' },
+                    row: { field: 'sample', type: 'nominal', legend: true },
+                    color: { field: 'peak', type: 'quantitative', legend: true },
+                    tooltip: [
+                        { field: 'start', type: 'genomic', alt: 'Start Position' },
+                        { field: 'end', type: 'genomic', alt: 'End Position' },
+                        {
+                            field: 'peak',
+                            type: 'quantitative',
+                            alt: 'Value',
+                            format: '.2'
+                        },
+                        { field: 'sample', type: 'nominal', alt: 'Sample' }
+                    ],
+                    width: 600,
+                    height: 130
+                }
+            ]
         }
     ]
 };

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -3092,11 +3092,9 @@
           "additionalProperties": false,
           "properties": {
             "height": {
-              "const": true,
               "type": "boolean"
             },
             "width": {
-              "const": true,
               "type": "boolean"
             }
           },

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -3083,6 +3083,27 @@
       ],
       "type": "object"
     },
+    "Responsive": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "height": {
+              "const": true,
+              "type": "boolean"
+            },
+            "width": {
+              "const": true,
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
     "RootSpecWithMultipleViews": {
       "additionalProperties": false,
       "properties": {
@@ -3118,6 +3139,9 @@
         "orientation": {
           "$ref": "#/definitions/Orientation",
           "description": "Specify the orientation."
+        },
+        "responsive": {
+          "$ref": "#/definitions/Responsive"
         },
         "spacing": {
           "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
@@ -3292,6 +3316,9 @@
               "additionalProperties": false,
               "description": "internal",
               "type": "object"
+            },
+            "responsive": {
+              "$ref": "#/definitions/Responsive"
             },
             "row": {
               "anyOf": [
@@ -3614,6 +3641,9 @@
               "description": "internal",
               "type": "object"
             },
+            "responsive": {
+              "$ref": "#/definitions/Responsive"
+            },
             "row": {
               "anyOf": [
                 {
@@ -3858,6 +3888,9 @@
             "orientation": {
               "$ref": "#/definitions/Orientation",
               "description": "Specify the orientation."
+            },
+            "responsive": {
+              "$ref": "#/definitions/Responsive"
             },
             "spacing": {
               "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -3083,7 +3083,7 @@
       ],
       "type": "object"
     },
-    "Responsive": {
+    "ResponsiveSize": {
       "anyOf": [
         {
           "type": "boolean"
@@ -3138,8 +3138,9 @@
           "$ref": "#/definitions/Orientation",
           "description": "Specify the orientation."
         },
-        "responsive": {
-          "$ref": "#/definitions/Responsive"
+        "responsiveSize": {
+          "$ref": "#/definitions/ResponsiveSize",
+          "description": "Determine whether to make the size of `GoslingComponent` bound to its parent element. __Default__: `false`"
         },
         "spacing": {
           "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
@@ -3315,8 +3316,9 @@
               "description": "internal",
               "type": "object"
             },
-            "responsive": {
-              "$ref": "#/definitions/Responsive"
+            "responsiveSize": {
+              "$ref": "#/definitions/ResponsiveSize",
+              "description": "Determine whether to make the size of `GoslingComponent` bound to its parent element. __Default__: `false`"
             },
             "row": {
               "anyOf": [
@@ -3639,8 +3641,9 @@
               "description": "internal",
               "type": "object"
             },
-            "responsive": {
-              "$ref": "#/definitions/Responsive"
+            "responsiveSize": {
+              "$ref": "#/definitions/ResponsiveSize",
+              "description": "Determine whether to make the size of `GoslingComponent` bound to its parent element. __Default__: `false`"
             },
             "row": {
               "anyOf": [
@@ -3887,8 +3890,9 @@
               "$ref": "#/definitions/Orientation",
               "description": "Specify the orientation."
             },
-            "responsive": {
-              "$ref": "#/definitions/Responsive"
+            "responsiveSize": {
+              "$ref": "#/definitions/ResponsiveSize",
+              "description": "Determine whether to make the size of `GoslingComponent` bound to its parent element. __Default__: `false`"
             },
             "spacing": {
               "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -11,7 +11,7 @@ interface GoslingCompProps {
     spec?: gosling.GoslingSpec;
     compiled?: (goslingSpec: gosling.GoslingSpec, higlassSpec: gosling.HiGlassSpec) => void;
     padding?: number;
-    margin?: number | string;
+    margin?: number;
     border?: string;
     id?: string;
     className?: string;
@@ -92,6 +92,14 @@ export const GoslingComponent = forwardRef<
                     padding: props.padding,
                     border: props.border,
                     margin: props.margin,
+                    responsiveWidth:
+                        typeof props.spec?.responsive !== 'object'
+                            ? props.spec?.responsive
+                            : props.spec.responsive.width,
+                    responsiveHeight:
+                        typeof props.spec?.responsive !== 'object'
+                            ? props.spec?.responsive
+                            : props.spec.responsive.height,
                     background: theme.root.background
                 }}
             />

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -93,13 +93,13 @@ export const GoslingComponent = forwardRef<
                     border: props.border,
                     margin: props.margin,
                     responsiveWidth:
-                        typeof props.spec?.responsive !== 'object'
-                            ? props.spec?.responsive
-                            : props.spec.responsive.width,
+                        typeof props.spec?.responsiveSize !== 'object'
+                            ? props.spec?.responsiveSize
+                            : props.spec.responsiveSize.width,
                     responsiveHeight:
-                        typeof props.spec?.responsive !== 'object'
-                            ? props.spec?.responsive
-                            : props.spec.responsive.height,
+                        typeof props.spec?.responsiveSize !== 'object'
+                            ? props.spec?.responsiveSize
+                            : props.spec.responsiveSize.height,
                     background: theme.root.background
                 }}
             />

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -3,7 +3,7 @@ import { Chromosome } from './utils/chrom-size';
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
 
-export type Responsive = boolean | { width?: true; height?: true };
+export type Responsive = boolean | { width?: boolean; height?: boolean };
 
 export type RootSpecWithSingleView = SingleView & {
     title?: string;

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -3,20 +3,22 @@ import { Chromosome } from './utils/chrom-size';
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
 
-export type Responsive = boolean | { width?: boolean; height?: boolean };
+export type ResponsiveSize = boolean | { width?: boolean; height?: boolean };
 
 export type RootSpecWithSingleView = SingleView & {
     title?: string;
     subtitle?: string;
     description?: string;
-    responsive?: Responsive;
+    /** Determine whether to make the size of `GoslingComponent` bound to its parent element. __Default__: `false` */
+    responsiveSize?: ResponsiveSize;
 };
 
 export interface RootSpecWithMultipleViews extends MultipleViews {
     title?: string;
     subtitle?: string;
     description?: string;
-    responsive?: Responsive;
+    /** Determine whether to make the size of `GoslingComponent` bound to its parent element. __Default__: `false` */
+    responsiveSize?: ResponsiveSize;
 }
 
 /* ----------------------------- VIEW ----------------------------- */

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -3,16 +3,20 @@ import { Chromosome } from './utils/chrom-size';
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec = RootSpecWithSingleView | RootSpecWithMultipleViews;
 
+export type Responsive = boolean | { width?: true; height?: true };
+
 export type RootSpecWithSingleView = SingleView & {
     title?: string;
     subtitle?: string;
     description?: string;
+    responsive?: Responsive;
 };
 
 export interface RootSpecWithMultipleViews extends MultipleViews {
     title?: string;
     subtitle?: string;
     description?: string;
+    responsive?: Responsive;
 }
 
 /* ----------------------------- VIEW ----------------------------- */

--- a/src/core/higlass-component-wrapper.tsx
+++ b/src/core/higlass-component-wrapper.tsx
@@ -66,7 +66,6 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
                         viewPaddingLeft: 0,
                         viewPaddingRight: 0,
                         sizeMode: 'bounded',
-                        bounded: true,
                         rangeSelectionOnAlt: true // this allows switching between `selection` and `zoom&pan` mode
                     }}
                     viewConfig={viewConfig}

--- a/src/core/higlass-component-wrapper.tsx
+++ b/src/core/higlass-component-wrapper.tsx
@@ -25,9 +25,11 @@ export interface HiGlassComponentWrapperProps {
     viewConfig?: HiGlassSpec;
     options: {
         padding?: number;
-        margin?: number | string;
+        margin?: number;
         border?: string;
         background?: string;
+        responsiveWidth?: boolean;
+        responsiveHeight?: boolean;
     };
     id?: string;
     className?: string;
@@ -47,7 +49,12 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
                 <HiGlassComponent
                     ref={ref}
                     options={{
-                        pixelPreciseMarginPadding: true, // this uses `rowHeight: 1` in react-grid-layout
+                        // This uses `rowHeight: 1` in react-grid-layout, allowing to set height precisely.
+                        // Since using this disallows responsive resizing of track heights in HiGlass,
+                        // we need to use this only when users do not want to use responsive height.
+                        // (See https://github.com/higlass/higlass/blob/2a3786e13c2415a52abc1227f75512f128e784a0/app/scripts/HiGlassComponent.js#L2199)
+                        pixelPreciseMarginPadding: !props.options.responsiveHeight,
+
                         containerPaddingX: 0,
                         containerPaddingY: 0,
                         viewMarginTop: 0,
@@ -59,6 +66,7 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
                         viewPaddingLeft: 0,
                         viewPaddingRight: 0,
                         sizeMode: 'bounded',
+                        bounded: true,
                         rangeSelectionOnAlt: true // this allows switching between `selection` and `zoom&pan` mode
                     }}
                     viewConfig={viewConfig}
@@ -80,8 +88,7 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
                         margin: margin,
                         border: border,
                         background: background,
-                        width: props.size.width,
-                        height: props.size.height,
+                        height: props.options.responsiveHeight ? `calc(100% - ${padding * 2}px)` : props.size.height,
                         textAlign: 'left'
                     }}
                 >
@@ -95,8 +102,8 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
                             background: background,
                             margin: 0,
                             padding: 0, // non-zero padding acts unexpectedly w/ HiGlassComponent
-                            width: props.size.width,
-                            height: props.size.height
+                            width: props.options.responsiveWidth ? '100%' : props.size.width,
+                            height: props.options.responsiveHeight ? '100%' : props.size.height
                         }}
                         // onClick={(e) => {
                         //     PubSub.publish('gosling.click', {

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -11,6 +11,7 @@ import exampleHg from './example/hg-view-config-1';
 import { insertItemToArray } from './utils/array';
 
 export const HIGLASS_AXIS_SIZE = 30;
+
 const getViewTemplate = (assembly?: string) => {
     return {
         genomePositionSearchBoxVisible: false,

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -116,13 +116,15 @@ export function getRelativeTrackInfo(spec: GoslingSpec, theme: CompleteThemeDeep
         size.height = size.height + (8 - (size.height % 8));
     }
 
+    const pixelPreciseMarginPadding = typeof spec.responsive !== 'object' ? !spec.responsive : !spec.responsive.height;
+
     // Calculate `layout`s for React Grid Layout (RGL).
     trackInfos.forEach(_ => {
         _.layout.x = (_.boundingBox.x / size.width) * 12;
         _.layout.w = (_.boundingBox.width / size.width) * 12;
-        // Because we set `pixelPreciseMarginPadding` `true`, we use actual values for `y` and `height`
-        _.layout.y = _.boundingBox.y;
-        _.layout.h = _.boundingBox.height;
+        // If we set `pixelPreciseMarginPadding` `true`, we need to use actual values for `y` and `height`
+        _.layout.y = pixelPreciseMarginPadding ? _.boundingBox.y : (_.boundingBox.y / size.height) * 12;
+        _.layout.h = pixelPreciseMarginPadding ? _.boundingBox.height : (_.boundingBox.height / size.height) * 12;
     });
 
     // console.log(trackInfos);

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -116,7 +116,8 @@ export function getRelativeTrackInfo(spec: GoslingSpec, theme: CompleteThemeDeep
         size.height = size.height + (8 - (size.height % 8));
     }
 
-    const pixelPreciseMarginPadding = typeof spec.responsive !== 'object' ? !spec.responsive : !spec.responsive.height;
+    const pixelPreciseMarginPadding =
+        typeof spec.responsiveSize !== 'object' ? !spec.responsiveSize : !spec.responsiveSize.height;
 
     // Calculate `layout`s for React Grid Layout (RGL).
     trackInfos.forEach(_ => {

--- a/src/gosling-genomic-axis/axis-track.ts
+++ b/src/gosling-genomic-axis/axis-track.ts
@@ -423,7 +423,8 @@ function AxisTrack(HGC: any, ...args: any[]): any {
         }
 
         addCurvedText(textObj: any, cx: number) {
-            const { innerRadius, outerRadius, startAngle, endAngle, width, height } = this.options;
+            const [width, height] = this.dimensions;
+            const { innerRadius, outerRadius, startAngle, endAngle } = this.options;
 
             const r = (outerRadius + innerRadius) / 2.0;
             const centerPos = cartesianToPolar(cx, width, r, width / 2.0, height / 2.0, startAngle, endAngle);

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -32,6 +32,7 @@ import { spawn } from 'threads';
 
 import BamWorker from '../data-fetcher/bam/bam-worker.js?worker&inline';
 import { InteractionEvent } from 'pixi.js';
+import { HIGLASS_AXIS_SIZE } from '../core/higlass-model';
 
 // Set `true` to print in what order each function is called
 export const PRINT_RENDERING_CYCLE = false;
@@ -801,7 +802,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
             const spec = JSON.parse(JSON.stringify(this.options.spec));
 
-            // const [trackWidth, trackHeight] = this.dimensions; // actual size of a track
+            const [trackWidth, trackHeight] = this.dimensions; // actual size of a track
 
             resolveSuperposedTracks(spec).forEach(resolved => {
                 if (resolved.mark === 'brush') {
@@ -898,9 +899,8 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 }
 
                 // Replace width and height information with the actual values
-                // TODO: we don't need this?
-                // resolved.width = trackWidth;
-                // resolved.height = trackHeight;
+                resolved.width = trackWidth;
+                resolved.height = trackHeight + HIGLASS_AXIS_SIZE; // Why the axis size must be added here?
 
                 // Construct separate gosling models for individual tiles
                 const gm = new GoslingTrackModel(resolved, tile.gos.tabularDataFiltered, this.options.theme);

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -245,26 +245,13 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             tile.graphics.clear();
             tile.graphics.removeChildren();
 
-            /* Embellishment before rendering marks */
-            if (tile.goslingModels && tile.goslingModels[0]) {
-                const tm = tile.goslingModels[0];
-
-                // check visibility condition
-                const trackWidth = this.dimensions[1];
-                const zoomLevel = this._xScale.invert(trackWidth) - this._xScale.invert(0);
-                if (!tm.trackVisibility({ zoomLevel })) {
-                    return;
-                }
-
-                drawPreEmbellishment(HGC, this, tile, tm, this.options.theme);
-            }
-
-            /* Mark */
-            // A single tile contains one track or multiple tracks overlaid
+            // !! A single tile contains one track or multiple tracks overlaid
+            /* Render marks and embellishments */
             tile.goslingModels.forEach((tm: GoslingTrackModel) => {
                 // check visibility condition
-                const trackWidth = this.dimensions[1];
+                const trackWidth = this.dimensions[0];
                 const zoomLevel = this._xScale.invert(trackWidth) - this._xScale.invert(0);
+
                 if (!tm.trackVisibility({ zoomLevel })) {
                     return;
                 }
@@ -276,22 +263,10 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 //     return;
                 // }
 
+                drawPreEmbellishment(HGC, this, tile, tm, this.options.theme);
                 drawMark(HGC, this, tile, tm);
-            });
-
-            /* Embellishment after rendering marks */
-            if (tile.goslingModels && tile.goslingModels[0]) {
-                const tm = tile.goslingModels[0];
-
-                // check visibility condition
-                const trackWidth = this.dimensions[1];
-                const zoomLevel = this._xScale.invert(trackWidth) - this._xScale.invert(0);
-                if (!tm.trackVisibility({ zoomLevel })) {
-                    return;
-                }
-
                 drawPostEmbellishment(HGC, this, tile, tm, this.options.theme);
-            }
+            });
 
             this.forceDraw();
         }


### PR DESCRIPTION
# Examples

```js
{
   title: "gosling visualization",
   responsiveSize: true, // <-- the size of Gosling component is bound to the size of its container
   views: [...]
}
```

or

```js
{
   title: "gosling visualization",
   responsiveSize: { height: false, width: true }, // <-- stretch only the width and use fixed height
   views: [...]
}
```


https://user-images.githubusercontent.com/9922882/150166310-cbd2fbed-98a2-446d-ac6a-8e05cc2e7ebe.mov

Fix #550 