### PR TITLE
feat: support horizontal rules on matrix

### DIFF
--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -62,7 +62,8 @@ export const examples: {
     MATRIX: {
         name: 'Basic Example: Hi-C Matrix',
         spec: EX_SPEC_MATRIX,
-        underDevelopment: true
+        underDevelopment: true,
+        forceShow: true
     },
     LINKING: {
         name: 'Basic Example: Visual Linking',

--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -61,8 +61,7 @@ export const examples: {
     },
     MATRIX: {
         name: 'Basic Example: Hi-C Matrix',
-        spec: EX_SPEC_MATRIX,
-        underDevelopment: true
+        spec: EX_SPEC_MATRIX
     },
     LINKING: {
         name: 'Basic Example: Visual Linking',

--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -62,8 +62,7 @@ export const examples: {
     MATRIX: {
         name: 'Basic Example: Hi-C Matrix',
         spec: EX_SPEC_MATRIX,
-        underDevelopment: true,
-        forceShow: true
+        underDevelopment: true
     },
     LINKING: {
         name: 'Basic Example: Visual Linking',

--- a/editor/example/matrix.ts
+++ b/editor/example/matrix.ts
@@ -9,44 +9,46 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
             linkingId: 'all',
             spacing: 0,
             views: [
-                // {
-                //     tracks: [
-                //         {
-                //             data: {
-                //                 url: GOSLING_PUBLIC_DATA.multivec,
-                //                 type: 'multivec',
-                //                 row: 'sample',
-                //                 column: 'position',
-                //                 value: 'peak',
-                //                 categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4']
-                //             },
-                //             mark: 'bar',
-                //             x: {
-                //                 field: 'position',
-                //                 type: 'genomic',
-                //                 axis: 'top'
-                //             },
-                //             y: { field: 'peak', type: 'quantitative' },
-                //             color: { field: 'sample', type: 'nominal' },
-                //             width: 600,
-                //             height: 50
-                //         }
-                //     ]
-                // },
+                {
+                    xOffset: 30,
+                    tracks: [
+                        {
+                            data: {
+                                url: GOSLING_PUBLIC_DATA.multivec,
+                                type: 'multivec',
+                                row: 'sample',
+                                column: 'position',
+                                value: 'peak',
+                                categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4']
+                            },
+                            mark: 'bar',
+                            x: { field: 'position', type: 'genomic', axis: 'top' },
+                            y: { field: 'peak', type: 'quantitative' },
+                            color: { field: 'sample', type: 'nominal' },
+                            width: 600,
+                            height: 50
+                        }
+                    ]
+                },
                 {
                     alignment: 'overlay',
                     tracks: [
                         {
                             data: {
-                                url: GOSLING_PUBLIC_DATA.matrix,
+                                url: GOSLING_PUBLIC_DATA.matrixHiC,
                                 type: 'matrix'
                             },
                             mark: 'bar',
                             x: { field: 'xs', type: 'genomic', axis: 'none' },
                             xe: { field: 'xe', type: 'genomic', axis: 'none' },
-                            y: { field: 'ys', type: 'genomic', axis: 'none' },
-                            ye: { field: 'ye', type: 'genomic', axis: 'none' },
-                            color: { field: 'value', type: 'quantitative', range: 'grey', legend: true },
+                            y: { field: 'ys', type: 'genomic', axis: 'left' },
+                            ye: { field: 'ye', type: 'genomic' },
+                            color: {
+                                field: 'value',
+                                type: 'quantitative',
+                                range: 'grey',
+                                legend: true
+                            },
                             style: { background: 'lightgray' }
                         },
                         {
@@ -77,14 +79,14 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                                 genomicFields: ['p']
                             },
                             mark: 'rule',
-                            y: { field: 'p', type: 'genomic', axis: 'none' },
+                            y: { field: 'p', type: 'genomic' },
                             strokeWidth: { value: 2 },
                             color: { value: 'blue' }
                         }
                     ],
                     width: 600,
                     height: 600,
-                    style: { dashed: [3, 3] }
+                    style: { dashed: [6, 3] }
                 }
             ]
         }

--- a/editor/example/matrix.ts
+++ b/editor/example/matrix.ts
@@ -9,30 +9,30 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
             linkingId: 'all',
             spacing: 0,
             views: [
-                {
-                    tracks: [
-                        {
-                            data: {
-                                url: GOSLING_PUBLIC_DATA.multivec,
-                                type: 'multivec',
-                                row: 'sample',
-                                column: 'position',
-                                value: 'peak',
-                                categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4']
-                            },
-                            mark: 'bar',
-                            x: {
-                                field: 'position',
-                                type: 'genomic',
-                                axis: 'top'
-                            },
-                            y: { field: 'peak', type: 'quantitative' },
-                            color: { field: 'sample', type: 'nominal' },
-                            width: 600,
-                            height: 50
-                        }
-                    ]
-                },
+                // {
+                //     tracks: [
+                //         {
+                //             data: {
+                //                 url: GOSLING_PUBLIC_DATA.multivec,
+                //                 type: 'multivec',
+                //                 row: 'sample',
+                //                 column: 'position',
+                //                 value: 'peak',
+                //                 categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4']
+                //             },
+                //             mark: 'bar',
+                //             x: {
+                //                 field: 'position',
+                //                 type: 'genomic',
+                //                 axis: 'top'
+                //             },
+                //             y: { field: 'peak', type: 'quantitative' },
+                //             color: { field: 'sample', type: 'nominal' },
+                //             width: 600,
+                //             height: 50
+                //         }
+                //     ]
+                // },
                 {
                     alignment: 'overlay',
                     tracks: [
@@ -46,16 +46,16 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                             xe: { field: 'xe', type: 'genomic', axis: 'none' },
                             y: { field: 'ys', type: 'genomic', axis: 'none' },
                             ye: { field: 'ye', type: 'genomic', axis: 'none' },
-                            color: { field: 'value', type: 'quantitative', legend: true },
+                            color: { field: 'value', type: 'quantitative', range: 'grey', legend: true },
                             style: { background: 'lightgray' }
                         },
                         {
                             data: {
                                 type: 'json',
                                 values: [
-                                    { c: 'chr2', p: 100000, v: 0.002 },
-                                    { c: 'chr5', p: 100000, v: 0.004 },
-                                    { c: 'chr10', p: 100000, v: 0.009 }
+                                    { c: 'chr2', p: 100000 },
+                                    { c: 'chr5', p: 100000 },
+                                    { c: 'chr10', p: 100000 }
                                 ],
                                 chromosomeField: 'c',
                                 genomicFields: ['p']
@@ -64,6 +64,22 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
                             x: { field: 'p', type: 'genomic', axis: 'none' },
                             strokeWidth: { value: 2 },
                             color: { value: 'red' }
+                        },
+                        {
+                            data: {
+                                type: 'json',
+                                values: [
+                                    { c: 'chr2', p: 100000 },
+                                    { c: 'chr5', p: 100000 },
+                                    { c: 'chr10', p: 100000 }
+                                ],
+                                chromosomeField: 'c',
+                                genomicFields: ['p']
+                            },
+                            mark: 'rule',
+                            y: { field: 'p', type: 'genomic', axis: 'none' },
+                            strokeWidth: { value: 2 },
+                            color: { value: 'blue' }
                         }
                     ],
                     width: 600,

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -210,7 +210,7 @@ export function goslingToHiGlass(
             ) {
                 const narrowType = getAxisNarrowType(c as any, gosTrack.orientation, bb.width, bb.height);
                 hgModel.setAxisTrack(channel.axis, narrowType, {
-                    id: `${firstResolvedSpec.id}-axis`,
+                    id: `${firstResolvedSpec.id}-${channel.axis}-axis`,
                     layout: firstResolvedSpec.layout,
                     innerRadius:
                         channel.axis === 'top'

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -123,6 +123,13 @@ export function IsTemplateTrack(track: Partial<Track>): track is TemplateTrack {
 }
 
 /**
+ * Is this a vertical rule, i.e., y genomic axis?
+ */
+export function IsVerticalRule(track: Track) {
+    return IsSingleTrack(track) && !IsChannelDeep(track.x) && IsChannelDeep(track.y) && track.y.type === 'genomic';
+}
+
+/**
  * Is this 2D track, i.e., two genomic axes?
  */
 export function Is2DTrack(track: Track) {

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -288,3 +288,20 @@ export function IsXAxis(_: Track) {
     }
     return false;
 }
+
+export function IsYAxis(_: Track) {
+    if ((IsSingleTrack(_) || IsOverlaidTrack(_)) && IsChannelDeep(_.y) && _.y.axis && _.y.axis !== 'none') {
+        return true;
+    } else if (IsOverlaidTrack(_)) {
+        let isFound = false;
+        _.overlay.forEach(t => {
+            if (isFound) return;
+
+            if (IsChannelDeep(t.y) && t.y.axis && t.y.axis !== 'none') {
+                isFound = true;
+            }
+        });
+        return isFound;
+    }
+    return false;
+}

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -338,11 +338,11 @@ export class HiGlassModel {
                 }
                 this.getLastView().tracks.left = insertItemToArray(this.getLastView().tracks.left, 0, axisTrack);
             } else if (position === 'right') {
-                if (this.getLastView().tracks.left.filter(d => d.type === 'axis-track').length !== 0) {
+                if (this.getLastView().tracks.right.filter(d => d.type === 'axis-track').length !== 0) {
                     // we already have an axis
                     return this;
                 }
-                this.getLastView().tracks.left.push(axisTrack);
+                this.getLastView().tracks.right.push(axisTrack);
             } else {
                 if (this.getLastView().tracks[position].filter(d => d.type === 'axis-track').length !== 0) {
                     // we already have an axis

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -17,7 +17,7 @@ import { drawCircularYAxis, drawLinearYAxis } from './axis';
 import { drawCircularOutlines } from './outline-circular';
 import { drawBackground } from './background';
 import { CompleteThemeDeep } from '../utils/theme';
-import { Is2DTrack } from '../gosling.schema.guards';
+import { Is2DTrack, IsVerticalRule } from '../gosling.schema.guards';
 
 /**
  * Visual channels currently supported for visual encoding.
@@ -69,7 +69,7 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
         // }
     });
 
-    if (Is2DTrack(model.spec())) {
+    if (Is2DTrack(model.spec()) || IsVerticalRule(model.spec())) {
         // Since small numbers are positioned on the top in the y axis, we reverse the domain, making it consistent to regular y scale.
         const yScale = trackInfo._yScale.copy();
         yScale.range([yScale.range()[1], yScale.range()[0]]);

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -214,7 +214,7 @@ function traverseAndCollectTrackInfo(
                 }
             });
         } else {
-            // This is a horizontal, so use the largest `width` for this view.
+            // This is a horizontal view, so use the largest `width` for this view.
             cumWidth = Math.max(...tracks.map(d => d.width)); //forceWidth ? forceWidth : spec.tracks[0]?.width;
             tracks.forEach((track, i, array) => {
                 // let scaledHeight = track.height;

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -1,5 +1,5 @@
 import { MultipleViews, CommonViewDef, GoslingSpec, Track, SingleView } from '../gosling.schema';
-import { IsOverlaidTrack, IsXAxis } from '../gosling.schema.guards';
+import { Is2DTrack, IsOverlaidTrack, IsXAxis, IsYAxis } from '../gosling.schema.guards';
 import { HIGLASS_AXIS_SIZE } from '../higlass-model';
 import {
     DEFAULT_CIRCULAR_VIEW_PADDING,
@@ -7,6 +7,7 @@ import {
     DEFAULT_VIEW_SPACING,
     DEWFAULT_TITLE_PADDING_ON_TOP_AND_BOTTOM
 } from '../layout/defaults';
+import { resolveSuperposedTracks } from './overlay';
 import { traverseTracksAndViews, traverseViewArrangements } from './spec-preprocess';
 import { CompleteThemeDeep } from './theme';
 
@@ -213,13 +214,18 @@ function traverseAndCollectTrackInfo(
                 }
             });
         } else {
-            // This is a horizontal view, so use the largest `width` for this view.
+            // This is a horizontal, so use the largest `width` for this view.
             cumWidth = Math.max(...tracks.map(d => d.width)); //forceWidth ? forceWidth : spec.tracks[0]?.width;
             tracks.forEach((track, i, array) => {
                 // let scaledHeight = track.height;
 
                 if (getNumOfXAxes([track]) === 1) {
                     track.height += HIGLASS_AXIS_SIZE;
+                }
+
+                if (Is2DTrack(resolveSuperposedTracks(track)[0]) && getNumOfYAxes([track]) === 1) {
+                    // If this is a 2D track (e.g., matrix), we need to reserve a space for the y-axis track
+                    cumWidth += HIGLASS_AXIS_SIZE;
                 }
 
                 track.width = cumWidth;
@@ -358,6 +364,10 @@ function traverseAndCollectTrackInfo(
 
 export function getNumOfXAxes(tracks: Track[]): number {
     return tracks.filter(t => IsXAxis(t)).length;
+}
+
+export function getNumOfYAxes(tracks: Track[]): number {
+    return tracks.filter(t => IsYAxis(t)).length;
 }
 
 /**


### PR DESCRIPTION
Allows using vertical rules overlaid on top of a matrix (see below example). This PR also fixes an issue that the x and y axes were not correctly shown in matrix visualization (e.g., left axis being shown on the right or top axis being hidden).

Follow up on #615

```js
{
    alignment: 'overlay',
    tracks: [
        {
            data: {
                url: GOSLING_PUBLIC_DATA.matrix,
                type: 'matrix'
            },
            mark: 'bar',
            x: { field: 'xs', type: 'genomic', axis: 'none' },
            xe: { field: 'xe', type: 'genomic', axis: 'none' },
            y: { field: 'ys', type: 'genomic', axis: 'none' },
            ye: { field: 'ye', type: 'genomic', axis: 'none' },
            color: { field: 'value', type: 'quantitative', range: 'grey', legend: true },
            style: { background: 'lightgray' }
        },
        {
            data: {
                type: 'json',
                values: [
                    { c: 'chr2', p: 100000 },
                    { c: 'chr5', p: 100000 },
                    { c: 'chr10', p: 100000 }
                ],
                chromosomeField: 'c',
                genomicFields: ['p']
            },
            mark: 'rule',
            x: { field: 'p', type: 'genomic', axis: 'none' },
            strokeWidth: { value: 2 },
            color: { value: 'red' }
        },
        {
            data: {
                type: 'json',
                values: [
                    { c: 'chr2', p: 100000 },
                    { c: 'chr5', p: 100000 },
                    { c: 'chr10', p: 100000 }
                ],
                chromosomeField: 'c',
                genomicFields: ['p']
            },
            mark: 'rule',
            y: { field: 'p', type: 'genomic', axis: 'none' },
            strokeWidth: { value: 2 },
            color: { value: 'blue' }
        }
    ],
    width: 600,
    height: 600,
    style: { dashed: [3, 3] }
}
```
![gosling-visualization (2)](https://user-images.githubusercontent.com/9922882/150594494-0667e860-c46d-4b5b-b726-864f94e7bd65.png)

