### PR TITLE
feat: support `yDomain` for 2D tracks

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -620,11 +620,26 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
           "type": "number"
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -993,11 +1008,26 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
           "type": "number"
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -1373,11 +1403,26 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
           "type": "number"
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -1829,7 +1874,8 @@
                   {
                     "$ref": "#/definitions/DomainChr"
                   }
-                ]
+                ],
+                "description": "Specify the visible region of genomic x-axis"
               },
               "xOffset": {
                 "description": "Specify the x offset of views in the unit of pixels",
@@ -1874,6 +1920,20 @@
                     "$ref": "#/definitions/ChannelValue"
                   }
                 ]
+              },
+              "yDomain": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/DomainInterval"
+                  },
+                  {
+                    "$ref": "#/definitions/DomainChrInterval"
+                  },
+                  {
+                    "$ref": "#/definitions/DomainChr"
+                  }
+                ],
+                "description": "Specify the visible region of genomic y-axis"
               },
               "yOffset": {
                 "description": "Specify the y offset of views in the unit of pixels",
@@ -2045,7 +2105,8 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
@@ -2090,6 +2151,20 @@
               "$ref": "#/definitions/ChannelValue"
             }
           ]
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -2362,7 +2437,8 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
@@ -2407,6 +2483,20 @@
               "$ref": "#/definitions/ChannelValue"
             }
           ]
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -2758,7 +2848,8 @@
                   {
                     "$ref": "#/definitions/DomainChr"
                   }
-                ]
+                ],
+                "description": "Specify the visible region of genomic x-axis"
               },
               "xOffset": {
                 "description": "Specify the x offset of views in the unit of pixels",
@@ -2803,6 +2894,20 @@
                     "$ref": "#/definitions/ChannelValue"
                   }
                 ]
+              },
+              "yDomain": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/DomainInterval"
+                  },
+                  {
+                    "$ref": "#/definitions/DomainChrInterval"
+                  },
+                  {
+                    "$ref": "#/definitions/DomainChr"
+                  }
+                ],
+                "description": "Specify the visible region of genomic y-axis"
               },
               "yOffset": {
                 "description": "Specify the y offset of views in the unit of pixels",
@@ -2977,7 +3082,8 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
@@ -3022,6 +3128,20 @@
               "$ref": "#/definitions/ChannelValue"
             }
           ]
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -3189,11 +3309,26 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
           "type": "number"
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -3463,7 +3598,8 @@
                 {
                   "$ref": "#/definitions/DomainChr"
                 }
-              ]
+              ],
+              "description": "Specify the visible region of genomic x-axis"
             },
             "xOffset": {
               "description": "Specify the x offset of views in the unit of pixels",
@@ -3508,6 +3644,20 @@
                   "$ref": "#/definitions/ChannelValue"
                 }
               ]
+            },
+            "yDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic y-axis"
             },
             "yOffset": {
               "description": "Specify the y offset of views in the unit of pixels",
@@ -3795,7 +3945,8 @@
                 {
                   "$ref": "#/definitions/DomainChr"
                 }
-              ]
+              ],
+              "description": "Specify the visible region of genomic x-axis"
             },
             "xOffset": {
               "description": "Specify the x offset of views in the unit of pixels",
@@ -3840,6 +3991,20 @@
                   "$ref": "#/definitions/ChannelValue"
                 }
               ]
+            },
+            "yDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic y-axis"
             },
             "yOffset": {
               "description": "Specify the y offset of views in the unit of pixels",
@@ -3933,11 +4098,26 @@
                 {
                   "$ref": "#/definitions/DomainChr"
                 }
-              ]
+              ],
+              "description": "Specify the visible region of genomic x-axis"
             },
             "xOffset": {
               "description": "Specify the x offset of views in the unit of pixels",
               "type": "number"
+            },
+            "yDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic y-axis"
             },
             "yOffset": {
               "description": "Specify the y offset of views in the unit of pixels",
@@ -4225,7 +4405,8 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
@@ -4270,6 +4451,20 @@
               "$ref": "#/definitions/ChannelValue"
             }
           ]
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -4645,7 +4840,8 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
@@ -4690,6 +4886,20 @@
               "$ref": "#/definitions/ChannelValue"
             }
           ]
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -5085,11 +5295,26 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
           "type": "number"
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -5310,7 +5535,14 @@
           ]
         },
         "domain": {
-          "$ref": "#/definitions/ValueExtent",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ValueExtent"
+            },
+            {
+              "$ref": "#/definitions/GenomicDomain"
+            }
+          ],
           "description": "Values of the data"
         },
         "field": {

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -846,7 +846,8 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
@@ -863,6 +864,20 @@
         },
         "y1e": {
           "$ref": "#/definitions/ChannelWithBase"
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -154,7 +154,7 @@ export function goslingToHiGlass(
                 .setViewOrientation(firstResolvedSpec.orientation) // TODO: Orientation should be assigned to 'individual' views
                 .setAssembly(assembly) // TODO: Assembly should be assigned to 'individual' views
                 .addDefaultView(firstResolvedSpec.id, assembly)
-                .setDomain(xDomain, Is2DTrack(firstResolvedSpec) ? yDomain : xDomain)
+                .setDomain(xDomain, yDomain ?? xDomain)
                 .adjustDomain(firstResolvedSpec.orientation, width, height)
                 .setMainTrack(hgTrack)
                 .addTrackSourceServers(server)

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -44,6 +44,7 @@ import {
     interpolateRdBu,
     interpolateViridis
 } from 'd3-scale-chromatic';
+import { resolveSuperposedTracks } from './utils/overlay';
 
 export const PREDEFINED_COLOR_STR_MAP: { [k: string]: (t: number) => string } = {
     viridis: interpolateViridis,
@@ -133,13 +134,10 @@ export function IsVerticalRule(track: Track) {
  * Is this 2D track, i.e., two genomic axes?
  */
 export function Is2DTrack(track: Track) {
-    return (
-        IsSingleTrack(track) &&
-        IsChannelDeep(track.x) &&
-        track.x.type === 'genomic' &&
-        IsChannelDeep(track.y) &&
-        track.y.type === 'genomic'
-    );
+    // If this is an overlaid tracks (e.g., matrix on top of rules),
+    // we get the first `SingleTrack` to check the type of two axes.
+    const t = IsSingleTrack(track) ? track : resolveSuperposedTracks(track)[0];
+    return IsChannelDeep(t.x) && t.x.type === 'genomic' && IsChannelDeep(t.y) && t.y.type === 'genomic';
 }
 
 /**

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -134,8 +134,8 @@ export function IsVerticalRule(track: Track) {
  * Is this 2D track, i.e., two genomic axes?
  */
 export function Is2DTrack(track: Track) {
-    // If this is an overlaid tracks (e.g., matrix on top of rules),
-    // we get the first `SingleTrack` to check the type of two axes.
+    // If this is an overlaid tracks (e.g., matrix w/ rules),
+    // we use the first `SingleTrack` to check the type of two axes.
     const t = IsSingleTrack(track) ? track : resolveSuperposedTracks(track)[0];
     return IsChannelDeep(t.x) && t.x.type === 'genomic' && IsChannelDeep(t.y) && t.y.type === 'genomic';
 }

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -89,8 +89,12 @@ export interface CommonViewDef {
      */
     assembly?: Assembly;
 
-    // TODO: Change to domain?
+    /** Specify the visible region of genomic x-axis */
     xDomain?: DomainInterval | DomainChrInterval | DomainChr;
+
+    /** Specify the visible region of genomic y-axis */
+    yDomain?: DomainInterval | DomainChrInterval | DomainChr;
+
     /** Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views) */
     linkingId?: string;
     /** not supported  */
@@ -488,8 +492,6 @@ export interface X extends AxisCommon {
 }
 
 export interface Y extends AxisCommon {
-    type?: 'quantitative' | 'nominal' | 'genomic';
-    domain?: ValueExtent;
     /** Custom baseline of the y-axis. __Default__: `0` */
     baseline?: string | number;
     /** Specify whether to use zero baseline. __Default__: `true`  */

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -150,6 +150,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
         if (spec.static === undefined) spec.static = parentDef.static !== undefined ? parentDef.static : false;
         if (spec.zoomLimits === undefined) spec.zoomLimits = parentDef.zoomLimits;
         if (spec.xDomain === undefined) spec.xDomain = parentDef.xDomain;
+        if (spec.yDomain === undefined) spec.yDomain = parentDef.yDomain;
         if (spec.linkingId === undefined) spec.linkingId = parentDef.linkingId;
         if (spec.centerRadius === undefined) spec.centerRadius = parentDef.centerRadius;
         if (spec.spacing === undefined && !('tracks' in spec)) spec.spacing = parentDef.spacing;
@@ -261,6 +262,19 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
             if (Is2DTrack(track)) {
                 // TODO: Add a test for this.
                 track.layout = 'linear';
+
+                /**
+                 * Add y-axis domain
+                 */
+                if ((IsSingleTrack(track) || IsOverlaidTrack(track)) && IsChannelDeep(track.y) && !track.y.domain) {
+                    track.y.domain = spec.yDomain;
+                } else if (IsOverlaidTrack(track)) {
+                    track.overlay.forEach(o => {
+                        if (IsChannelDeep(o.y) && !o.y.domain) {
+                            o.y.domain = spec.yDomain;
+                        }
+                    });
+                }
             }
 
             /**


### PR DESCRIPTION
## Usage of `x/yDomain`

```js
xDomain: { chromosome: "1" },
yDomain: { chromosome: "2" },

...

xDomain: { chromosome: "1", interval: [1000, 2000] },
yDomain: { chromosome: "2", interval: [1000, 2000] },

...

xDomain: { interval: [1000, 2000] },
yDomain: { interval: [1000, 2000] },

```

![gosling-visualization (4)](https://user-images.githubusercontent.com/9922882/151244281-87dd4ee1-4942-4082-9b03-024006bc44d2.png)

