### PR TITLE
feat: add hot and pink color schemes

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -2442,7 +2442,9 @@
         "warm",
         "cividis",
         "bupu",
-        "rdbu"
+        "rdbu",
+        "hot",
+        "pink"
       ],
       "type": "string"
     },

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -42,7 +42,9 @@ import {
     interpolateCividis,
     interpolateBuPu,
     interpolateRdBu,
-    interpolateViridis
+    interpolateViridis,
+    interpolateYlOrBr,
+    interpolateRdPu
 } from 'd3-scale-chromatic';
 
 export const PREDEFINED_COLOR_STR_MAP: { [k: string]: (t: number) => string } = {
@@ -52,7 +54,9 @@ export const PREDEFINED_COLOR_STR_MAP: { [k: string]: (t: number) => string } = 
     spectral: interpolateSpectral,
     cividis: interpolateCividis,
     bupu: interpolateBuPu,
-    rdbu: interpolateRdBu
+    rdbu: interpolateRdBu,
+    hot: interpolateYlOrBr,
+    pink: interpolateRdPu
 };
 
 /**

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -578,7 +578,7 @@ export type ValueExtent = string[] | number[];
 export type GenomicDomain = DomainInterval | DomainChrInterval | DomainChr | DomainGene;
 export type Domain = ValueExtent | GenomicDomain;
 export type Range = ValueExtent | PREDEFINED_COLORS;
-export type PREDEFINED_COLORS = 'viridis' | 'grey' | 'spectral' | 'warm' | 'cividis' | 'bupu' | 'rdbu';
+export type PREDEFINED_COLORS = 'viridis' | 'grey' | 'spectral' | 'warm' | 'cividis' | 'bupu' | 'rdbu' | 'hot' | 'pink';
 
 export interface DomainChr {
     // For showing a certain chromosome


### PR DESCRIPTION
Added two new colors, i.e., `"hot"` and `"pink"`.

`interpolateYlOrBr` indeed seems to be the most similar color scheme compared with the HiGlass' default color. "pink" is added as well which is just my personal taste.

## "hot"
![hot](https://user-images.githubusercontent.com/9922882/151441148-a8c67bdf-a796-4466-9d6e-5e798765127c.png)

## "pink"
![pink](https://user-images.githubusercontent.com/9922882/151441206-3cb2d1d0-7769-4785-bf32-e843bff6935c.png)


