### PR TITLE
chore: add alignment example with and without responsive functions

### DIFF
--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -12,6 +12,7 @@ import {
     EX_SPEC_RESPONSIVE_MULTIVEC,
     EX_SPEC_RESPONSIVE_MULTIVEC_CIRCULAR
 } from './responsive';
+import { EX_SPEC_ALIGNMENT_CHART, EX_SPEC_RESPONSIVE_ALIGNMENT_CHART } from './responsive-alignment';
 import { EX_SPEC_MARK_DISPLACEMENT } from './mark-displacement';
 import { EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL } from './circular-overview-linear-detail-views';
 import { EX_SPEC_SARS_COV_2 } from './sars-cov-2';
@@ -115,6 +116,11 @@ export const examples: {
     RESPONSIVE_COMPARATIVE_VIEWS: {
         name: 'Responsive Visualization: Comparative Views',
         spec: EX_SPEC_RESPONSIVE_COMPARATIVE_VIEWS,
+        underDevelopment: true
+    },
+    RESPONSIVE_ALIGNMENT: {
+        name: 'Responsive Visualization: Alignment Views',
+        spec: EX_SPEC_RESPONSIVE_ALIGNMENT_CHART,
         underDevelopment: true,
         forceShow: true
     },
@@ -142,6 +148,10 @@ export const examples: {
     SARS_COV_2: {
         name: 'SARS-CoV-2',
         spec: EX_SPEC_SARS_COV_2
+    },
+    ALIGNMENT: {
+        name: 'Alignment Chart',
+        spec: EX_SPEC_ALIGNMENT_CHART
     },
     CORCES_ET_AL: {
         name: 'Corces et al. 2020',

--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -121,8 +121,7 @@ export const examples: {
     RESPONSIVE_ALIGNMENT: {
         name: 'Responsive Visualization: Alignment Views',
         spec: EX_SPEC_RESPONSIVE_ALIGNMENT_CHART,
-        underDevelopment: true,
-        forceShow: true
+        underDevelopment: true
     },
     CYTOBANDS: {
         name: 'Ideograms',

--- a/editor/example/responsive-alignment.ts
+++ b/editor/example/responsive-alignment.ts
@@ -76,7 +76,7 @@ export const alignmentWithText: (prop: AlignmentProp) => OverlaidTracks = prop =
                 x: { field: 'start', type: 'genomic' },
                 xe: { field: 'end', type: 'genomic' },
                 color: { value: 'black' },
-                size: { value: 24 },
+                size: { value: 12 },
                 visibility: [
                     {
                         measure: 'zoomLevel',

--- a/editor/example/responsive-alignment.ts
+++ b/editor/example/responsive-alignment.ts
@@ -1,0 +1,231 @@
+import { OverlaidTracks, SingleTrack, SingleView } from '@gosling.schema';
+import type { GoslingSpec } from 'gosling.js';
+import { CHANNEL_DEFAULTS } from '../../src/core/channel';
+
+type GapBarProp = {
+    title: boolean;
+    width: number;
+    height: number;
+    yAxis: boolean;
+};
+export const gapBar: (prop: GapBarProp) => SingleTrack = prop => {
+    return {
+        title: prop.title ? 'Gap' : undefined,
+        data: {
+            url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/alignment_viewer_p53.gap.csv',
+            type: 'csv',
+            genomicFields: ['pos'],
+            sampleLength: 99999
+        },
+        mark: 'bar',
+        x: { field: 'start', type: 'genomic', axis: 'none' },
+        xe: { field: 'end', type: 'genomic', axis: 'none' },
+        y: { field: 'gap', type: 'quantitative', axis: prop.yAxis ? 'right' : 'none' },
+        color: { value: 'gray' },
+        stroke: { value: 'white' },
+        strokeWidth: { value: 0 },
+        width: prop.width,
+        height: prop.height
+    };
+};
+
+type ConservationBarProp = GapBarProp;
+export const conservationBar: (prop: ConservationBarProp) => SingleTrack = prop => {
+    return {
+        title: prop.title ? 'Conservation' : undefined,
+        data: {
+            url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/alignment_viewer_p53.conservation.csv',
+            type: 'csv',
+            genomicFields: ['pos'],
+            sampleLength: 99999
+        },
+        mark: 'bar',
+        x: { field: 'start', type: 'genomic', axis: 'none' },
+        xe: { field: 'end', type: 'genomic', axis: 'none' },
+        y: { field: 'conservation', type: 'quantitative', axis: prop.yAxis ? 'right' : 'none' },
+        color: { field: 'conservation', type: 'quantitative' },
+        stroke: { value: 'white' },
+        strokeWidth: { value: 0 },
+        width: prop.width,
+        height: prop.height
+    };
+};
+
+type AlignmentProp = {
+    width: number;
+    height: number;
+    xAxis: boolean;
+    rowLegend: boolean;
+    colorLegend: boolean;
+};
+export const alignmentWithText: (prop: AlignmentProp) => OverlaidTracks = prop => {
+    return {
+        alignment: 'overlay',
+        data: {
+            url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/alignment_viewer_p53.fasta.csv',
+            type: 'csv',
+            genomicFields: ['pos'],
+            sampleLength: 99999
+        },
+        tracks: [
+            {
+                mark: 'rect'
+            },
+            {
+                mark: 'text',
+                x: { field: 'start', type: 'genomic' },
+                xe: { field: 'end', type: 'genomic' },
+                color: { value: 'black' },
+                size: { value: 24 },
+                visibility: [
+                    {
+                        measure: 'zoomLevel',
+                        target: 'track',
+                        threshold: 10,
+                        operation: 'LT',
+                        transitionPadding: 100
+                    }
+                ]
+            }
+        ],
+        x: { field: 'pos', type: 'genomic', axis: prop.xAxis ? 'bottom' : 'none' },
+        row: { field: 'name', type: 'nominal', legend: prop.rowLegend },
+        color: {
+            field: 'base',
+            type: 'nominal',
+            range: CHANNEL_DEFAULTS.NOMINAL_COLOR_EXTENDED.slice(0, 20),
+            legend: prop.colorLegend
+        },
+        stroke: { value: 'white' },
+        strokeWidth: { value: 0 },
+        text: { field: 'base', type: 'nominal' },
+        width: prop.width,
+        height: prop.height
+    };
+};
+
+export const alignmentWithoutText: (prop: AlignmentProp) => SingleTrack = prop => {
+    return {
+        data: {
+            url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/alignment_viewer_p53.fasta.csv',
+            type: 'csv',
+            genomicFields: ['pos'],
+            sampleLength: 99999
+        },
+        mark: 'rect',
+        x: { field: 'pos', type: 'genomic', axis: prop.xAxis ? 'bottom' : 'none' },
+        row: { field: 'name', type: 'nominal', legend: prop.rowLegend },
+        color: {
+            field: 'base',
+            type: 'nominal',
+            range: CHANNEL_DEFAULTS.NOMINAL_COLOR_EXTENDED.slice(0, 20),
+            legend: prop.colorLegend
+        },
+        stroke: { value: 'white' },
+        strokeWidth: { value: 0 },
+        text: { field: 'base', type: 'nominal' },
+        width: prop.width,
+        height: prop.height
+    };
+};
+
+export const EX_SPEC_ALIGNMENT_CHART: GoslingSpec = {
+    // responsiveSize: true,
+    description: 'reference: https://dash.plotly.com/dash-bio/alignmentchart',
+    zoomLimits: [1, 396],
+    xDomain: { interval: [350, 396] },
+    assembly: 'unknown',
+    style: { outline: 'lightgray' },
+    views: [
+        {
+            linkingId: '-',
+            spacing: 30,
+            tracks: [
+                gapBar({ title: true, width: 800, height: 100, yAxis: true }),
+                conservationBar({ title: true, width: 800, height: 150, yAxis: true }),
+                alignmentWithText({ width: 800, height: 500, xAxis: true, rowLegend: true, colorLegend: true })
+            ]
+        },
+        {
+            static: true,
+            xDomain: { interval: [0, 396] },
+            alignment: 'overlay',
+            tracks: [
+                alignmentWithoutText({ width: 800, height: 150, xAxis: false, rowLegend: false, colorLegend: false }),
+                conservationBar({ title: false, width: 800, height: 150, yAxis: false }),
+                gapBar({ title: false, width: 800, height: 150, yAxis: false }),
+                {
+                    mark: 'brush',
+                    x: { linkingId: '-' },
+                    color: { value: 'black' },
+                    stroke: { value: 'black' },
+                    strokeWidth: { value: 1 },
+                    opacity: { value: 0.3 }
+                }
+            ],
+            width: 800,
+            height: 150
+        }
+    ]
+};
+
+const mainView: SingleView = {
+    linkingId: '-',
+    spacing: 30,
+    tracks: [
+        gapBar({ title: true, width: 800, height: 100, yAxis: true }),
+        conservationBar({ title: true, width: 800, height: 150, yAxis: true }),
+        alignmentWithText({ width: 800, height: 500, xAxis: true, rowLegend: true, colorLegend: true })
+    ]
+};
+const compactMainView: SingleView = {
+    linkingId: '-',
+    spacing: 30,
+    tracks: [alignmentWithText({ width: 800, height: 500, xAxis: false, rowLegend: false, colorLegend: false })]
+};
+const overview: SingleView = {
+    static: true,
+    xDomain: { interval: [0, 396] },
+    alignment: 'overlay',
+    tracks: [
+        alignmentWithoutText({ width: 800, height: 150, xAxis: false, rowLegend: false, colorLegend: false }),
+        conservationBar({ title: false, width: 800, height: 150, yAxis: false }),
+        gapBar({ title: false, width: 800, height: 150, yAxis: false }),
+        {
+            mark: 'brush',
+            x: { linkingId: '-' },
+            color: { value: 'black' },
+            stroke: { value: 'black' },
+            strokeWidth: { value: 1 },
+            opacity: { value: 0.3 }
+        }
+    ],
+    width: 800,
+    height: 150
+};
+export const EX_SPEC_RESPONSIVE_ALIGNMENT_CHART: GoslingSpec = {
+    responsiveSize: true,
+    description: 'reference: https://dash.plotly.com/dash-bio/alignmentchart',
+    zoomLimits: [1, 396],
+    xDomain: { interval: [350, 396] },
+    assembly: 'unknown',
+    style: { outline: 'lightgray' },
+    views: [mainView, overview],
+    responsiveSpec: [
+        {
+            selectivity: [
+                { measure: 'width', operation: 'LT', threshold: 600 },
+                { measure: 'height', operation: 'LT', threshold: 600 }
+            ],
+            spec: { xDomain: { interval: [0, 396] }, views: [{ ...compactMainView, layout: 'circular' }] }
+        },
+        {
+            selectivity: [{ measure: 'height', operation: 'LT', threshold: 800 }],
+            spec: { xDomain: { interval: [0, 396] }, views: [mainView] }
+        },
+        {
+            selectivity: [{ measure: 'height', operation: 'LT', threshold: 600 }],
+            spec: { xDomain: { interval: [0, 396] }, views: [compactMainView] }
+        }
+    ]
+};

--- a/src/core/responsive.ts
+++ b/src/core/responsive.ts
@@ -19,7 +19,7 @@ export function manageResponsiveSpecs(spec: GoslingSpec | SingleView, wFactor: n
         responsiveSpec.forEach((specAndCondition: any) => {
             const { spec: alternativeSpec, selectivity } = specAndCondition;
 
-            if (isSelectResponsiveSpec(selectivity, size)) {
+            if (isSelectResponsiveSpec(selectivity, size) && !replaced) {
                 // Override this alternative spec in this view
                 Object.keys(alternativeSpec).forEach(k => {
                     (spec as any)[k] = (alternativeSpec as any)[k];

--- a/src/gosling-genomic-axis/axis-track.ts
+++ b/src/gosling-genomic-axis/axis-track.ts
@@ -460,6 +460,10 @@ function AxisTrack(HGC: any, ...args: any[]): any {
                 ropePoints.push(new HGC.libraries.PIXI.Point(p.x, p.y));
             }
 
+            if (ropePoints.length === 0) {
+                return null;
+            }
+
             textObj.updateText();
             const rope = new HGC.libraries.PIXI.SimpleRope(textObj.texture, ropePoints);
             return rope;
@@ -536,7 +540,9 @@ function AxisTrack(HGC: any, ...args: any[]): any {
                 let rope;
                 if (circular) {
                     rope = this.addCurvedText(chrText, viewportMidX);
-                    this.pTicksCircular.addChild(rope);
+                    if (rope) {
+                        this.pTicksCircular.addChild(rope);
+                    }
                 } else {
                     chrText.x = viewportMidX;
                     chrText.y = this.dimensions[1] - yPadding;


### PR DESCRIPTION
# Alignment Chart in Gosling
## Spec
```ts
views: [mainView, overview],
responsiveSpec: [
    {
        selectivity: [
            { measure: 'width', operation: 'LT', threshold: 600 },
            { measure: 'height', operation: 'LT', threshold: 600 }
        ],
        spec: { views: [{ ...mainView, layout: 'circular' }] }
    },
    {
        selectivity: [{ measure: 'height', operation: 'LT', threshold: 800 }],
        spec: { views: [mainView] }
    }
]
```


## 1. Main View + Overview (Regular Screen)
![1](https://user-images.githubusercontent.com/9922882/151879338-3fe44b00-8ed7-4581-82c2-92be3a364be7.png)

---

## 2. Main View (Small Screen)
![2](https://user-images.githubusercontent.com/9922882/151879340-fdf5fdcf-bd4c-4768-a383-53dc85516b1f.png)

---

## 3. Circular Main View (Smaller Screen)
![3](https://user-images.githubusercontent.com/9922882/151879342-72642e66-1685-45b4-ab2c-21436f32ec51.png)

---

# Reference (Dash Bio)
![Screen Shot 2022-01-31 at 16 52 14](https://user-images.githubusercontent.com/9922882/151879587-2422106e-6eb1-4a10-b541-8264190b9291.png)

