### PR TITLE
feat(editor): add options to change screen dimensions

### DIFF
--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -209,6 +209,7 @@ function Editor(props: any) {
     // whether to show widgets for responsive window
     const [isResponsive, setIsResponsive] = useState<boolean>(true);
     const [screenSize, setScreenSize] = useState<undefined | { width: number; height: number }>();
+    const [visibleScreenSize, setVisibleScreenSize] = useState<undefined | { width: number; height: number }>();
 
     // whether to show data preview on the right-bottom
     const [isShowDataPreview, setIsShowDataPreview] = useState<boolean>(false);
@@ -294,7 +295,6 @@ function Editor(props: any) {
                     lineHeight: '20px'
                 }}
             >
-                {/* {'Screen Size: '} */}
                 <span
                     style={{
                         marginRight: 10,
@@ -315,6 +315,7 @@ function Editor(props: any) {
                             const device = e.target.value;
                             if (Object.keys(deviceToResolution).includes(device)) {
                                 setScreenSize((deviceToResolution as any)[device]);
+                                setVisibleScreenSize((deviceToResolution as any)[device]);
                             }
                         }}
                     >
@@ -334,11 +335,12 @@ function Editor(props: any) {
                     <span style={{ marginRight: 10, color: '#EEBF4D' }}>{getIconSVG(ICONS.RULER, 12, 12)}</span>
                     <input
                         type="number"
-                        min="300"
+                        min="350"
                         max="3000"
-                        value={screenSize?.width}
+                        value={visibleScreenSize?.width}
                         onChange={e => {
-                            const width = +e.target.value >= 300 ? +e.target.value : 300;
+                            const width = +e.target.value >= 350 ? +e.target.value : 350;
+                            setVisibleScreenSize({ width: +e.target.value, height: screenSize?.height ?? 1000 });
                             setScreenSize({ width, height: screenSize?.height ?? 1000 });
                         }}
                     />
@@ -347,9 +349,10 @@ function Editor(props: any) {
                         type="number"
                         min="100"
                         max="3000"
-                        value={screenSize?.height}
+                        value={visibleScreenSize?.height}
                         onChange={e => {
                             const height = +e.target.value >= 100 ? +e.target.value : 100;
+                            setVisibleScreenSize({ width: screenSize?.width ?? 1000, height: +e.target.value });
                             setScreenSize({ width: screenSize?.width ?? 1000, height });
                         }}
                     />
@@ -436,6 +439,7 @@ function Editor(props: any) {
                 : false;
         if (newIsResponsive !== isResponsive && newIsResponsive) {
             setScreenSize(undefined); // reset the screen
+            setVisibleScreenSize(undefined);
         }
         setIsResponsive(newIsResponsive);
     }, [goslingSpec]);

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -294,7 +294,10 @@ function Editor(props: any) {
                     lineHeight: '20px'
                 }}
             >
-                {'Screen Size: '}
+                {/* {'Screen Size: '} */}
+                <span style={{ marginRight: 10, color: 'gray', verticalAlign: 'middle' }}>
+                    {getIconSVG(ICONS.SCREEN, 16, 16)}
+                </span>
                 <span
                     className="screen-size-dropdown"
                     hidden={urlSpec !== null || urlGist !== null || urlExampleId !== ''}
@@ -320,9 +323,10 @@ function Editor(props: any) {
                     </select>
                 </span>
                 <span style={{ marginLeft: '20px', visibility: screenSize ? 'visible' : 'collapse' }}>
+                    <span style={{ marginRight: 10, color: '#EEBF4D' }}>{getIconSVG(ICONS.RULER, 12, 12)}</span>
                     <input
                         type="number"
-                        min="100"
+                        min="300"
                         max="3000"
                         value={screenSize?.width}
                         onChange={e => {
@@ -333,11 +337,11 @@ function Editor(props: any) {
                     {' x '}
                     <input
                         type="number"
-                        min="300"
+                        min="100"
                         max="3000"
                         value={screenSize?.height}
                         onChange={e => {
-                            const height = +e.target.value >= 300 ? +e.target.value : 300;
+                            const height = +e.target.value >= 100 ? +e.target.value : 100;
                             setScreenSize({ width: screenSize?.width ?? 1000, height });
                         }}
                     />

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -307,11 +307,16 @@ function Editor(props: any) {
                             }
                         }}
                     >
-                        {Object.keys(deviceToResolution).map(d => (
-                            <option key={d} value={d}>
-                                {d}
-                            </option>
-                        ))}
+                        {[...Object.keys(deviceToResolution)].map(d =>
+                            // https://stackoverflow.com/questions/899148/html-select-option-separator
+                            d !== '-' ? (
+                                <option key={d} value={d}>
+                                    {d}
+                                </option>
+                            ) : (
+                                <optgroup label="──────────"></optgroup>
+                            )
+                        )}
                     </select>
                 </span>
                 <span style={{ marginLeft: '20px', visibility: screenSize ? 'visible' : 'collapse' }}>

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -295,7 +295,15 @@ function Editor(props: any) {
                 }}
             >
                 {/* {'Screen Size: '} */}
-                <span style={{ marginRight: 10, color: 'gray', verticalAlign: 'middle' }}>
+                <span
+                    style={{
+                        marginRight: 10,
+                        color: 'gray',
+                        verticalAlign: 'middle',
+                        display: 'inline-block',
+                        marginTop: '2px'
+                    }}
+                >
                     {getIconSVG(ICONS.SCREEN, 16, 16)}
                 </span>
                 <span

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -308,12 +308,12 @@ function Editor(props: any) {
                         }}
                     >
                         {[...Object.keys(deviceToResolution)].map(d =>
-                            // https://stackoverflow.com/questions/899148/html-select-option-separator
                             d !== '-' ? (
                                 <option key={d} value={d}>
                                     {d}
                                 </option>
                             ) : (
+                                // separator (https://stackoverflow.com/questions/899148/html-select-option-separator)
                                 <optgroup label="──────────"></optgroup>
                             )
                         )}
@@ -414,15 +414,18 @@ function Editor(props: any) {
      * Things to do upon spec change
      */
     useEffect(() => {
-        setIsResponsive(
+        const newIsResponsive =
             typeof goslingSpec?.responsiveSize === 'undefined'
                 ? false
                 : typeof goslingSpec?.responsiveSize === 'boolean'
                 ? goslingSpec?.responsiveSize === true
                 : typeof goslingSpec?.responsiveSize === 'object'
                 ? goslingSpec?.responsiveSize.width === true || goslingSpec?.responsiveSize.height === true
-                : false
-        );
+                : false;
+        if (newIsResponsive !== isResponsive && newIsResponsive) {
+            setScreenSize(undefined); // reset the screen
+        }
+        setIsResponsive(newIsResponsive);
     }, [goslingSpec]);
 
     /**
@@ -851,8 +854,11 @@ function Editor(props: any) {
                                     {isResponsive && !IS_SMALL_SCREEN ? ResponsiveWidget : null}
                                     <div
                                         style={{
-                                            width: screenSize?.width ?? '100%',
-                                            height: screenSize?.height ?? 'calc(100% - 50px)',
+                                            width: isResponsive && screenSize?.width ? screenSize.width : '100%',
+                                            height:
+                                                isResponsive && screenSize?.height
+                                                    ? screenSize.height
+                                                    : 'calc(100% - 50px)',
                                             background: isResponsive ? 'white' : 'none'
                                         }}
                                     >

--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -116,7 +116,8 @@ export const examples: {
     RESPONSIVE_COMPARATIVE_VIEWS: {
         name: 'Responsive Visualization: Comparative Views',
         spec: EX_SPEC_RESPONSIVE_COMPARATIVE_VIEWS,
-        underDevelopment: true
+        underDevelopment: true,
+        forceShow: true
     },
     RESPONSIVE_ALIGNMENT: {
         name: 'Responsive Visualization: Alignment Views',

--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -116,8 +116,7 @@ export const examples: {
     RESPONSIVE_COMPARATIVE_VIEWS: {
         name: 'Responsive Visualization: Comparative Views',
         spec: EX_SPEC_RESPONSIVE_COMPARATIVE_VIEWS,
-        underDevelopment: true,
-        forceShow: true
+        underDevelopment: true
     },
     RESPONSIVE_ALIGNMENT: {
         name: 'Responsive Visualization: Alignment Views',

--- a/editor/icon.ts
+++ b/editor/icon.ts
@@ -123,6 +123,16 @@ export const ICONS: { [k: string]: ICON_INFO } = {
         stroke: 'none',
         fill: 'currentColor'
     },
+    RULER: {
+        width: 16,
+        height: 16,
+        viewBox: '0 0 16 16',
+        path: [
+            'M1 0a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h5v-1H2v-1h4v-1H4v-1h2v-1H2v-1h4V9H4V8h2V7H2V6h4V2h1v4h1V4h1v2h1V2h1v4h1V4h1v2h1V2h1v4h1V1a1 1 0 0 0-1-1H1z'
+        ],
+        stroke: 'none',
+        fill: 'currentColor'
+    },
     TABLE: {
         width: 20,
         height: 20,
@@ -161,6 +171,17 @@ export const ICONS: { [k: string]: ICON_INFO } = {
         viewBox: '0 0 16 16',
         path: [
             'M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z'
+        ],
+        stroke: 'none',
+        fill: 'currentColor'
+    },
+    SCREEN: {
+        width: 16,
+        height: 16,
+        viewBox: '0 0 16 16',
+        path: [
+            'M2.5 4a.5.5 0 1 0 0-1 .5.5 0 0 0 0 1zm2-.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0zm1 .5a.5.5 0 1 0 0-1 .5.5 0 0 0 0 1z',
+            'M2 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2H2zm13 2v2H1V3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1zM2 14a1 1 0 0 1-1-1V6h14v7a1 1 0 0 1-1 1H2z'
         ],
         stroke: 'none',
         fill: 'currentColor'

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -32,8 +32,12 @@ export function compile(
     const { size } = trackInfosAndSize;
 
     // Handle responsive specs, either remove them or replace original specs w/ them
-    const wFactor = curSize ? curSize?.width / size.width : 1;
-    const hFactor = curSize ? curSize?.height / size.height : 1;
+    const isResponsiveWidth =
+        (typeof spec.responsiveSize === 'object' && spec.responsiveSize?.width) || spec.responsiveSize;
+    const isResponsiveHeight =
+        (typeof spec.responsiveSize === 'object' && spec.responsiveSize?.height) || spec.responsiveSize;
+    const wFactor = isResponsiveWidth && curSize ? curSize?.width / size.width : 1;
+    const hFactor = isResponsiveHeight && curSize ? curSize?.height / size.height : 1;
     const replaced = manageResponsiveSpecs(specCopy, wFactor, hFactor);
 
     // Do the downstream-fix and track arrangement again using the updated spec


### PR DESCRIPTION
If a `responsiveSize` option is being used (e.g., `responsiveSize: true` or `responsiveSize: { width: true}`), a widget for changing screen dimensions appear.

![Screen Shot 2022-02-07 at 16 12 40](https://user-images.githubusercontent.com/9922882/152872753-0c1639c8-bbe7-4e3a-bc30-07e6f0489b85.png)


![Screen Shot 2022-02-07 at 12 12 45](https://user-images.githubusercontent.com/9922882/152838018-8a31c151-3c21-4fb2-bee9-133177823a14.png)
![Screen Shot 2022-02-07 at 12 12 50](https://user-images.githubusercontent.com/9922882/152838019-982f9d0a-c0c4-44bf-a251-ced555f0782e.png)
![Screen Shot 2022-02-07 at 12 12 55](https://user-images.githubusercontent.com/9922882/152838021-7964c9f4-5de4-46b2-8ea9-a421bc16cbe5.png)


