### PR TITLE
feat: support checking `aspectRatio` to use responsive spec

### DIFF
--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -306,10 +306,7 @@ function Editor(props: any) {
                 >
                     {getIconSVG(ICONS.SCREEN, 16, 16)}
                 </span>
-                <span
-                    className="screen-size-dropdown"
-                    hidden={urlSpec !== null || urlGist !== null || urlExampleId !== ''}
-                >
+                <span className="screen-size-dropdown">
                     <select
                         onChange={e => {
                             const device = e.target.value;

--- a/editor/example/responsive.ts
+++ b/editor/example/responsive.ts
@@ -286,6 +286,12 @@ export const EX_SPEC_RESPONSIVE_MULTIVEC_CIRCULAR: GoslingSpec = {
     views: [
         {
             layout: 'circular',
+            responsiveSpec: [
+                {
+                    spec: { layout: 'linear' },
+                    selectivity: [{ measure: 'aspectRatio', operation: 'GT', threshold: 1.5 }]
+                }
+            ],
             spacing: 1,
             tracks: [
                 {
@@ -331,7 +337,7 @@ export const EX_SPEC_RESPONSIVE_MULTIVEC_CIRCULAR: GoslingSpec = {
                                     target: 'track',
                                     measure: 'height',
                                     operation: 'GTET',
-                                    threshold: TotalChartSizes[0] + 200
+                                    threshold: TotalChartSizes[0] + 100
                                 }
                             ]
                         },
@@ -344,13 +350,13 @@ export const EX_SPEC_RESPONSIVE_MULTIVEC_CIRCULAR: GoslingSpec = {
                                     target: 'track',
                                     measure: 'height',
                                     operation: 'LT',
-                                    threshold: TotalChartSizes[0] + 200
+                                    threshold: TotalChartSizes[0] + 100
                                 },
                                 {
                                     target: 'track',
                                     measure: 'height',
                                     operation: 'GT',
-                                    threshold: TotalChartSizes[1] + 200
+                                    threshold: TotalChartSizes[1] + 100
                                 }
                             ]
                         },
@@ -363,13 +369,13 @@ export const EX_SPEC_RESPONSIVE_MULTIVEC_CIRCULAR: GoslingSpec = {
                                     target: 'track',
                                     measure: 'height',
                                     operation: 'LT',
-                                    threshold: TotalChartSizes[0] + 200
+                                    threshold: TotalChartSizes[0] + 100
                                 },
                                 {
                                     target: 'track',
                                     measure: 'height',
                                     operation: 'GT',
-                                    threshold: TotalChartSizes[1] + 200
+                                    threshold: TotalChartSizes[1] + 100
                                 }
                             ]
                         },
@@ -382,13 +388,13 @@ export const EX_SPEC_RESPONSIVE_MULTIVEC_CIRCULAR: GoslingSpec = {
                                     target: 'track',
                                     measure: 'height',
                                     operation: 'LT',
-                                    threshold: TotalChartSizes[0] + 200
+                                    threshold: TotalChartSizes[0] + 100
                                 },
                                 {
                                     target: 'track',
                                     measure: 'height',
                                     operation: 'GT',
-                                    threshold: TotalChartSizes[1] + 200
+                                    threshold: TotalChartSizes[1] + 100
                                 }
                             ]
                         },
@@ -401,13 +407,13 @@ export const EX_SPEC_RESPONSIVE_MULTIVEC_CIRCULAR: GoslingSpec = {
                                     target: 'track',
                                     measure: 'height',
                                     operation: 'LT',
-                                    threshold: TotalChartSizes[0] + 200
+                                    threshold: TotalChartSizes[0] + 100
                                 },
                                 {
                                     target: 'track',
                                     measure: 'height',
                                     operation: 'GT',
-                                    threshold: TotalChartSizes[1] + 200
+                                    threshold: TotalChartSizes[1] + 100
                                 }
                             ]
                         },
@@ -422,7 +428,7 @@ export const EX_SPEC_RESPONSIVE_MULTIVEC_CIRCULAR: GoslingSpec = {
                                     target: 'track',
                                     measure: 'height',
                                     operation: 'LTET',
-                                    threshold: TotalChartSizes[1] + 200
+                                    threshold: TotalChartSizes[1] + 100
                                 }
                             ]
                         }

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -5404,7 +5404,8 @@
         "measure": {
           "enum": [
             "width",
-            "height"
+            "height",
+            "aspectRatio"
           ],
           "type": "string"
         },

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -30,7 +30,7 @@ export type SingleView = (OverlaidTracks | StackedTracks | FlatTracks) & Respons
 
 export type SelectivityCondition = {
     operation: LogicalOperation;
-    measure: 'width' | 'height';
+    measure: 'width' | 'height' | 'aspectRatio';
     threshold: number;
 };
 

--- a/src/core/responsive.ts
+++ b/src/core/responsive.ts
@@ -11,7 +11,9 @@ export function manageResponsiveSpecs(spec: GoslingSpec | SingleView, wFactor: n
 
     const { responsiveSpec } = spec;
 
-    const size = { width: spec._assignedWidth * wFactor, height: spec._assignedHeight * hFactor };
+    const width = spec._assignedWidth * wFactor;
+    const height = spec._assignedHeight * hFactor;
+    const dimensions = { width, height, aspectRatio: width / height };
 
     // Check whether any alternative specs fullfil the condition
     if (responsiveSpec) {
@@ -19,7 +21,7 @@ export function manageResponsiveSpecs(spec: GoslingSpec | SingleView, wFactor: n
         responsiveSpec.forEach((specAndCondition: any) => {
             const { spec: alternativeSpec, selectivity } = specAndCondition;
 
-            if (isSelectResponsiveSpec(selectivity, size) && !replaced) {
+            if (isSelectResponsiveSpec(selectivity, dimensions) && !replaced) {
                 // Override this alternative spec in this view
                 Object.keys(alternativeSpec).forEach(k => {
                     (spec as any)[k] = (alternativeSpec as any)[k];
@@ -47,12 +49,12 @@ export function manageResponsiveSpecs(spec: GoslingSpec | SingleView, wFactor: n
 /**
  * Test if given conditions are all `true`.
  * @param conditions
- * @param assignedSize
+ * @param assignedDimensions
  * @returns
  */
 function isSelectResponsiveSpec(
     conditions: SelectivityCondition[],
-    assignedSize: { width: number; height: number }
+    assignedDimensions: { width: number; height: number; aspectRatio: number }
 ): boolean {
     if (conditions.length === 0) return false;
 
@@ -60,7 +62,7 @@ function isSelectResponsiveSpec(
 
     conditions.forEach(condition => {
         const { measure, operation, threshold } = condition;
-        isSelect = isSelect && logicalComparison(assignedSize[measure], operation, threshold) === 1;
+        isSelect = isSelect && logicalComparison(assignedDimensions[measure], operation, threshold) === 1;
     });
 
     return isSelect;


### PR DESCRIPTION
```js
"layout": "circular",
"responsiveSpec": [
  {
    "spec": {"layout": "linear"},
    "selectivity": [
      {"measure": "aspectRatio", "operation": "GT", "threshold": 1.5}
    ]
  }
],
```

An example will be available upon merge via https://gosling.js.org/?example=RESPONSIVE_MULTIVEC_CIRCULAR