### PR TITLE
feat!: add `style.linkStyle` and `style.linkMinHeight` to allow customizing links

### DIFF
--- a/editor/example/cancer-variant.ts
+++ b/editor/example/cancer-variant.ts
@@ -546,7 +546,7 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                 { field: 'end2', type: 'genomic' },
                                 { field: 'svclass', type: 'nominal' }
                             ],
-                            style: { legendTitle: 'SV Class', svWithinLink: true },
+                            style: { legendTitle: 'SV Class', withinLinkStyle: 'sv' },
                             width: 1000,
                             height: 200
                         }

--- a/editor/example/cancer-variant.ts
+++ b/editor/example/cancer-variant.ts
@@ -546,7 +546,7 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                 { field: 'end2', type: 'genomic' },
                                 { field: 'svclass', type: 'nominal' }
                             ],
-                            style: { legendTitle: 'SV Class', linkStyle: 'sv' },
+                            style: { legendTitle: 'SV Class', linkStyle: 'elliptical' },
                             width: 1000,
                             height: 200
                         }

--- a/editor/example/cancer-variant.ts
+++ b/editor/example/cancer-variant.ts
@@ -546,7 +546,7 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                 { field: 'end2', type: 'genomic' },
                                 { field: 'svclass', type: 'nominal' }
                             ],
-                            style: { legendTitle: 'SV Class', withinLinkStyle: 'sv' },
+                            style: { legendTitle: 'SV Class', linkStyle: 'sv' },
                             width: 1000,
                             height: 200
                         }

--- a/editor/example/cancer-variant.ts
+++ b/editor/example/cancer-variant.ts
@@ -546,7 +546,7 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                                 { field: 'end2', type: 'genomic' },
                                 { field: 'svclass', type: 'nominal' }
                             ],
-                            style: { legendTitle: 'SV Class', bezierLink: true },
+                            style: { legendTitle: 'SV Class', svWithinLink: true },
                             width: 1000,
                             height: 200
                         }

--- a/editor/example/gremlin.ts
+++ b/editor/example/gremlin.ts
@@ -2,7 +2,7 @@ import type { GoslingSpec } from 'gosling.js';
 
 export const EX_SPEC_GREMLIN: GoslingSpec = {
     title: "Gremlin (O'Brien et al. 2010)",
-    style: { linkStyle: 'bezier' },
+    style: { linkStyle: 'elliptical' },
     views: [
         {
             linkingId: 'view1',

--- a/editor/example/gremlin.ts
+++ b/editor/example/gremlin.ts
@@ -2,7 +2,7 @@ import type { GoslingSpec } from 'gosling.js';
 
 export const EX_SPEC_GREMLIN: GoslingSpec = {
     title: "Gremlin (O'Brien et al. 2010)",
-    style: { bezierLink: true },
+    style: { linkStyle: 'bezier' },
     views: [
         {
             linkingId: 'view1',

--- a/editor/example/sashimi.ts
+++ b/editor/example/sashimi.ts
@@ -47,7 +47,7 @@ export const EX_SPEC_SASHIMI: GoslingSpec = {
                     stroke: { value: '#FFC153' },
                     strokeWidth: { field: 'score', type: 'quantitative', range: [1, 4] },
                     opacity: { value: 0.8 },
-                    style: { flatWithinLink: true },
+                    style: { linkStyle: 'sashimi' },
                     width: 800,
                     height: 80
                 },

--- a/editor/example/sashimi.ts
+++ b/editor/example/sashimi.ts
@@ -47,7 +47,7 @@ export const EX_SPEC_SASHIMI: GoslingSpec = {
                     stroke: { value: '#FFC153' },
                     strokeWidth: { field: 'score', type: 'quantitative', range: [1, 4] },
                     opacity: { value: 0.8 },
-                    style: { linkStyle: 'sashimi' },
+                    style: { linkStyle: 'elliptical' },
                     width: 800,
                     height: 80
                 },

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -7925,10 +7925,6 @@
         "backgroundOpacity": {
           "type": "number"
         },
-        "bezierLink": {
-          "description": "Specify whether to use bezier curves for the `link` marks.",
-          "type": "boolean"
-        },
         "curve": {
           "description": "Specify the curve of `rule` marks.",
           "enum": [
@@ -7963,10 +7959,6 @@
         },
         "enableSmoothPath": {
           "description": "Whether to enable smooth paths when drawing curves.\n\n__Default__: `false`",
-          "type": "boolean"
-        },
-        "flatWithinLink": {
-          "description": "Specify whether to use a flat within-links, such as the one in Sashimi plots. __Default__: `false`",
           "type": "boolean"
         },
         "inlineLegend": {
@@ -8007,6 +7999,16 @@
           ],
           "type": "string"
         },
+        "linkStyle": {
+          "description": "Specify the style of link marks. __Default__: `'regular'`",
+          "enum": [
+            "regular",
+            "bezier",
+            "sashimi",
+            "sv"
+          ],
+          "type": "string"
+        },
         "outline": {
           "type": "string"
         },
@@ -8041,16 +8043,6 @@
         "textStrokeWidth": {
           "description": "Specify the stroke width of `text` marks. Can also be specified using the `strokeWidth` channel option of `text` marks.",
           "type": "number"
-        },
-        "withinLinkStyle": {
-          "description": "Experimental: Specify which style of `withinLink` to use. __Default__: `'regular'`",
-          "enum": [
-            "regular",
-            "bezier",
-            "flat",
-            "sv"
-          ],
-          "type": "string"
         }
       },
       "type": "object"

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -7965,10 +7965,6 @@
         "outlineWidth": {
           "type": "number"
         },
-        "svWithinLink": {
-          "description": "Specify whether to use within-links that are more flat than bezier link. __Default__: `false`",
-          "type": "boolean"
-        },
         "textAnchor": {
           "description": "Specify the alignment of `text` marks to a given point.",
           "enum": [
@@ -7997,6 +7993,16 @@
         "textStrokeWidth": {
           "description": "Specify the stroke width of `text` marks. Can also be specified using the `strokeWidth` channel option of `text` marks.",
           "type": "number"
+        },
+        "withinLinkStyle": {
+          "description": "Experimental: Specify which style of `withinLink` to use. __Default__: `'regular'`",
+          "enum": [
+            "regular",
+            "bezier",
+            "flat",
+            "sv"
+          ],
+          "type": "string"
         }
       },
       "type": "object"

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1029,6 +1029,9 @@
               "$ref": "#/definitions/Assembly",
               "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
             },
+            "baselineY": {
+              "type": "number"
+            },
             "centerRadius": {
               "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
               "type": "number"
@@ -1158,6 +1161,9 @@
                       "assembly": {
                         "$ref": "#/definitions/Assembly",
                         "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
                       },
                       "centerRadius": {
                         "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -1749,6 +1755,9 @@
               "$ref": "#/definitions/Assembly",
               "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
             },
+            "baselineY": {
+              "type": "number"
+            },
             "centerRadius": {
               "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
               "type": "number"
@@ -1878,6 +1887,9 @@
                       "assembly": {
                         "$ref": "#/definitions/Assembly",
                         "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
                       },
                       "centerRadius": {
                         "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -2522,6 +2534,9 @@
                       "assembly": {
                         "$ref": "#/definitions/Assembly",
                         "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
                       },
                       "centerRadius": {
                         "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -3694,6 +3709,9 @@
           "$ref": "#/definitions/Assembly",
           "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
         },
+        "baselineY": {
+          "type": "number"
+        },
         "centerRadius": {
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
           "type": "number"
@@ -3789,6 +3807,9 @@
               "assembly": {
                 "$ref": "#/definitions/Assembly",
                 "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+              },
+              "baselineY": {
+                "type": "number"
               },
               "centerRadius": {
                 "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -4335,6 +4356,9 @@
           "$ref": "#/definitions/Assembly",
           "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
         },
+        "baselineY": {
+          "type": "number"
+        },
         "centerRadius": {
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
           "type": "number"
@@ -4685,6 +4709,9 @@
           "$ref": "#/definitions/Assembly",
           "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
         },
+        "baselineY": {
+          "type": "number"
+        },
         "centerRadius": {
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
           "type": "number"
@@ -4786,6 +4813,9 @@
               "assembly": {
                 "$ref": "#/definitions/Assembly",
                 "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+              },
+              "baselineY": {
+                "type": "number"
               },
               "centerRadius": {
                 "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -5445,6 +5475,9 @@
           "$ref": "#/definitions/Assembly",
           "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
         },
+        "baselineY": {
+          "type": "number"
+        },
         "centerRadius": {
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
           "type": "number"
@@ -5781,6 +5814,9 @@
               "$ref": "#/definitions/Assembly",
               "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
             },
+            "baselineY": {
+              "type": "number"
+            },
             "centerRadius": {
               "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
               "type": "number"
@@ -5903,6 +5939,9 @@
                       "assembly": {
                         "$ref": "#/definitions/Assembly",
                         "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
                       },
                       "centerRadius": {
                         "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -6494,6 +6533,9 @@
               "$ref": "#/definitions/Assembly",
               "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
             },
+            "baselineY": {
+              "type": "number"
+            },
             "centerRadius": {
               "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
               "type": "number"
@@ -6616,6 +6658,9 @@
                       "assembly": {
                         "$ref": "#/definitions/Assembly",
                         "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
                       },
                       "centerRadius": {
                         "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -7253,6 +7298,9 @@
                       "assembly": {
                         "$ref": "#/definitions/Assembly",
                         "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
                       },
                       "centerRadius": {
                         "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -7999,13 +7999,16 @@
           ],
           "type": "string"
         },
+        "linkMinHeight": {
+          "description": "The minimum height of `withinLink` and `betweenLink` marks. Unit is a percentagle. __Default__: `0.5`",
+          "type": "number"
+        },
         "linkStyle": {
-          "description": "Specify the style of link marks. __Default__: `'regular'`",
+          "description": "The style of `withinLink` and `betweenLink` marks. __Default__: `'circular'` `'elliptical'` will be used as a default option.",
           "enum": [
-            "regular",
-            "bezier",
-            "sashimi",
-            "sv"
+            "elliptical",
+            "circular",
+            "_bezier_deprecated_"
           ],
           "type": "string"
         },

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -7965,6 +7965,10 @@
         "outlineWidth": {
           "type": "number"
         },
+        "svWithinLink": {
+          "description": "Specify whether to use within-links that are more flat than bezier link. __Default__: `false`",
+          "type": "boolean"
+        },
         "textAnchor": {
           "description": "Specify the alignment of `text` marks to a given point.",
           "enum": [

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -554,10 +554,6 @@
         "backgroundOpacity": {
           "type": "number"
         },
-        "bezierLink": {
-          "description": "Specify whether to use bezier curves for the `link` marks.",
-          "type": "boolean"
-        },
         "curve": {
           "description": "Specify the curve of `rule` marks.",
           "enum": [
@@ -592,10 +588,6 @@
         },
         "enableSmoothPath": {
           "description": "Whether to enable smooth paths when drawing curves.\n\n__Default__: `false`",
-          "type": "boolean"
-        },
-        "flatWithinLink": {
-          "description": "Specify whether to use a flat within-links, such as the one in Sashimi plots. __Default__: `false`",
           "type": "boolean"
         },
         "inlineLegend": {
@@ -636,6 +628,16 @@
           ],
           "type": "string"
         },
+        "linkStyle": {
+          "description": "Specify the style of link marks. __Default__: `'regular'`",
+          "enum": [
+            "regular",
+            "bezier",
+            "sashimi",
+            "sv"
+          ],
+          "type": "string"
+        },
         "outline": {
           "type": "string"
         },
@@ -670,16 +672,6 @@
         "textStrokeWidth": {
           "description": "Specify the stroke width of `text` marks. Can also be specified using the `strokeWidth` channel option of `text` marks.",
           "type": "number"
-        },
-        "withinLinkStyle": {
-          "description": "Experimental: Specify which style of `withinLink` to use. __Default__: `'regular'`",
-          "enum": [
-            "regular",
-            "bezier",
-            "flat",
-            "sv"
-          ],
-          "type": "string"
         }
       },
       "type": "object"

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -628,13 +628,16 @@
           ],
           "type": "string"
         },
+        "linkMinHeight": {
+          "description": "The minimum height of `withinLink` and `betweenLink` marks. Unit is a percentagle. __Default__: `0.5`",
+          "type": "number"
+        },
         "linkStyle": {
-          "description": "Specify the style of link marks. __Default__: `'regular'`",
+          "description": "The style of `withinLink` and `betweenLink` marks. __Default__: `'circular'` `'elliptical'` will be used as a default option.",
           "enum": [
-            "regular",
-            "bezier",
-            "sashimi",
-            "sv"
+            "elliptical",
+            "circular",
+            "_bezier_deprecated_"
           ],
           "type": "string"
         },

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -642,10 +642,6 @@
         "outlineWidth": {
           "type": "number"
         },
-        "svWithinLink": {
-          "description": "Specify whether to use within-links that are more flat than bezier link. __Default__: `false`",
-          "type": "boolean"
-        },
         "textAnchor": {
           "description": "Specify the alignment of `text` marks to a given point.",
           "enum": [
@@ -674,6 +670,16 @@
         "textStrokeWidth": {
           "description": "Specify the stroke width of `text` marks. Can also be specified using the `strokeWidth` channel option of `text` marks.",
           "type": "number"
+        },
+        "withinLinkStyle": {
+          "description": "Experimental: Specify which style of `withinLink` to use. __Default__: `'regular'`",
+          "enum": [
+            "regular",
+            "bezier",
+            "flat",
+            "sv"
+          ],
+          "type": "string"
         }
       },
       "type": "object"

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -642,6 +642,10 @@
         "outlineWidth": {
           "type": "number"
         },
+        "svWithinLink": {
+          "description": "Specify whether to use within-links that are more flat than bezier link. __Default__: `false`",
+          "type": "boolean"
+        },
         "textAnchor": {
           "description": "Specify the alignment of `text` marks to a given point.",
           "enum": [

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -228,7 +228,7 @@ export class GoslingTrackModel {
         if (this.originalSpec().y === undefined) {
             const y = this.spec().y;
             const rowCategories = this.getChannelDomainArray('row');
-            if (y && IsChannelValue(y) && rowCategories) {
+            if (y && IsChannelValue(y) && rowCategories && this.spec().mark !== 'withinLink') {
                 y.value = (this.spec().height as number) / rowCategories.length / 2.0;
             }
         }
@@ -561,10 +561,10 @@ export class GoslingTrackModel {
                             value = (spec.width as number) / 2.0;
                             break;
                         case 'y':
-                            value = rowHeight / 2.0;
+                            if (spec.mark === 'withinLink') value = 0;
+                            else value = rowHeight / 2.0;
                             break;
                         case 'size':
-                            // TODO: make as an object
                             if (spec.mark === 'line') value = this.theme.line.size;
                             else if (spec.mark === 'bar') value = undefined;
                             else if (spec.mark === 'rect') value = undefined;

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -561,7 +561,7 @@ export class GoslingTrackModel {
                             value = (spec.width as number) / 2.0;
                             break;
                         case 'y':
-                            if (spec.mark === 'withinLink') value = 0;
+                            if (spec.mark === 'withinLink') value = rowHeight;
                             else value = rowHeight / 2.0;
                             break;
                         case 'size':

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -132,7 +132,7 @@ export interface CommonViewDef {
      * __Default:__ `0.3`
      * @Range [0, 1]
      */
-    centerRadius?: number; // [0, 1] (default: 0.3)
+    centerRadius?: number;
 
     /**
      * Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views.
@@ -347,9 +347,16 @@ export interface Style {
     dy?: number;
 
     /**
-     * Specify the style of link marks. __Default__: `'regular'`
+     * The style of `withinLink` and `betweenLink` marks. __Default__: `'circular'`
+     * `'elliptical'` will be used as a default option.
      */
-    linkStyle?: 'regular' | 'bezier' | 'sashimi' | 'sv';
+    linkStyle?: 'elliptical' | 'circular' | '_bezier_deprecated_';
+
+    /**
+     * The minimum height of `withinLink` and `betweenLink` marks. Unit is a percentagle. __Default__: `0.5`
+     * @Range [0, 1]
+     */
+    linkMinHeight?: number;
 
     /**
      * Specify whether to show legend in a single horizontal line?

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -353,8 +353,8 @@ export interface Style {
     /** Specify whether to use a flat within-links, such as the one in Sashimi plots. __Default__: `false` */
     flatWithinLink?: boolean;
 
-    /** Specify whether to use within-links that are more flat than bezier link. __Default__: `false` */
-    svWithinLink?: boolean;
+    /** Experimental: Specify which style of `withinLink` to use. __Default__: `'regular'` */
+    withinLinkStyle?: 'regular' | 'bezier' | 'flat' | 'sv';
 
     /**
      * Specify whether to show legend in a single horizontal line?

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -248,6 +248,7 @@ interface SingleTrackBase extends CommonTrackDef {
 
     // Experimental
     flipY?: boolean; // This is only supported for `link` marks.
+    baselineY?: number; // This is only supported for `link` marks.
     stretch?: boolean; // Stretch the size to the given range? (e.g., [x, xe])
     overrideTemplate?: boolean; // Override a spec template that is defined for a given data type.
 }

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -353,6 +353,9 @@ export interface Style {
     /** Specify whether to use a flat within-links, such as the one in Sashimi plots. __Default__: `false` */
     flatWithinLink?: boolean;
 
+    /** Specify whether to use within-links that are more flat than bezier link. __Default__: `false` */
+    svWithinLink?: boolean;
+
     /**
      * Specify whether to show legend in a single horizontal line?
      */

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -345,17 +345,11 @@ export interface Style {
      * This property is currently only supported for `text` marks.
      */
     dy?: number;
+
     /**
-     *  Specify whether to use bezier curves for the `link` marks.
+     * Specify the style of link marks. __Default__: `'regular'`
      */
-    bezierLink?: boolean;
-
-    // TODO: betweenLinkStyle: 'regular' | 'bezier' | 'flat'
-    /** Specify whether to use a flat within-links, such as the one in Sashimi plots. __Default__: `false` */
-    flatWithinLink?: boolean;
-
-    /** Experimental: Specify which style of `withinLink` to use. __Default__: `'regular'` */
-    withinLinkStyle?: 'regular' | 'bezier' | 'flat' | 'sv';
+    linkStyle?: 'regular' | 'bezier' | 'sashimi' | 'sv';
 
     /**
      * Specify whether to show legend in a single horizontal line?

--- a/src/core/mark/betweenLink.ts
+++ b/src/core/mark/betweenLink.ts
@@ -1,0 +1,462 @@
+import * as PIXI from 'pixi.js';
+import { GoslingTrackModel } from '../gosling-track-model';
+import { Channel } from '../gosling.schema';
+import { IsChannelDeep, getValueUsingChannel, Is2DTrack } from '../gosling.schema.guards';
+import { cartesianToPolar, positionToRadian } from '../utils/polar';
+import colorToHex from '../utils/color-to-hex';
+import { Bezier } from 'bezier-js';
+import { TooltipData } from '../../gosling-tooltip';
+
+// TODO: This code is taken from `link.ts` which is for withinLink marks. Large parts should be removed.
+export function drawBetweenLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackModel) {
+    /* track spec */
+    const spec = model.spec();
+
+    if (!spec.width || !spec.height) {
+        console.warn('Size of a track is not properly determined, so visual mark cannot be rendered');
+        return;
+    }
+
+    /* data */
+    const data = model.data();
+
+    /* track size */
+    const [trackWidth, trackHeight] = trackInfo.dimensions;
+
+    /* circular parameters */
+    const circular = spec.layout === 'circular';
+    const trackInnerRadius = spec.innerRadius ?? 220;
+    const trackOuterRadius = spec.outerRadius ?? 300;
+    const startAngle = spec.startAngle ?? 0;
+    const endAngle = spec.endAngle ?? 360;
+    const trackRingSize = trackOuterRadius - trackInnerRadius;
+    const tcx = trackWidth / 2.0;
+    const tcy = trackHeight / 2.0;
+
+    /* row separation */
+    const rowCategories: string[] = (model.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
+    const rowHeight = trackHeight / rowCategories.length;
+
+    // TODO: Can row be actually used for circular layouts?
+    /* render */
+    rowCategories.forEach(rowCategory => {
+        const rowPosition = model.encodedValue('row', rowCategory);
+
+        data.filter(
+            d =>
+                !getValueUsingChannel(d, spec.row as Channel) ||
+                (getValueUsingChannel(d, spec.row as Channel) as string) === rowCategory
+        ).forEach(d => {
+            let x = model.encodedPIXIProperty('x', d);
+            let xe = model.encodedPIXIProperty('xe', d);
+            let x1 = model.encodedPIXIProperty('x1', d);
+            let x1e = model.encodedPIXIProperty('x1e', d);
+            const y = model.encodedPIXIProperty('y', d);
+            const stroke = model.encodedPIXIProperty('stroke', d);
+            const strokeWidth = model.encodedPIXIProperty('strokeWidth', d);
+            const color = model.encodedPIXIProperty('color', d);
+            const opacity = model.encodedPIXIProperty('opacity', d);
+
+            // sort properly
+            if (typeof xe !== 'undefined') {
+                [x, xe] = [x, xe].sort((a, b) => a - b);
+            }
+            if (typeof x1 !== 'undefined' && typeof x1e !== 'undefined') {
+                [x1, x1e] = [x1, x1e].sort((a, b) => a - b);
+            }
+
+            // Is this band or line?
+            const isRibon =
+                typeof xe !== 'undefined' &&
+                typeof x1 !== 'undefined' &&
+                typeof x1e !== 'undefined' &&
+                // This means the strokeWidth of a band is too small, so we just need to draw a line instead
+                Math.abs(x - xe) > 0.1 &&
+                Math.abs(x1 - x1e) > 0.1;
+
+            // TODO: This correction can be moved to the compile process
+            if (!isRibon && xe === undefined && !Is2DTrack(spec)) {
+                // We need to use a valid value to draw lines, so lets find alternative one.
+                if (x1 === undefined && x1e === undefined) {
+                    // We do not have a valid ones.
+                    return;
+                }
+                xe = x1 !== undefined ? x1 : x1e;
+            }
+
+            if (!isRibon && Math.abs(x - xe) <= 0.1 && Math.abs(x1 - x1e) <= 0.1) {
+                // Put the larger value on `xe` so that it can be used in line connection
+                x = (x + xe) / 2.0;
+                xe = (x1 + x1e) / 2.0;
+            }
+
+            // stroke
+            g.lineStyle(
+                strokeWidth,
+                colorToHex(stroke),
+                opacity, // alpha
+                0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+            );
+
+            const flipY = (IsChannelDeep(spec.y) && spec.y.flip) || spec.flipY;
+            const baseY = spec.baselineY ?? rowPosition + (flipY ? 0 : rowHeight);
+
+            if (isRibon) {
+                g.beginFill(color === 'none' ? colorToHex('white') : colorToHex(color), color === 'none' ? 0 : opacity);
+
+                let [_x1, _x2, _x3, _x4] = [x, xe, x1, x1e];
+
+                // Sort values to safely draw bands
+                if (spec.mark === 'betweenLink') {
+                    [_x1, _x2] = [_x1, _x2].sort((a, b) => a - b);
+                    [_x3, _x4] = [_x3, _x4].sort((a, b) => a - b);
+                } else {
+                    [_x1, _x2, _x3, _x4] = [_x1, _x2, _x3, _x4].sort((a, b) => a - b);
+                }
+
+                if (_x1 > trackWidth || _x4 < 0 || Math.abs(_x4 - _x1) < 0.5) {
+                    // Do not draw very small visual marks
+                    return;
+                }
+
+                if (circular) {
+                    if (_x1 < 0 || _x4 > trackWidth) {
+                        // Do not show bands that are partly outside of the current domain
+                        return;
+                    }
+
+                    // https://pixijs.download/dev/docs/PIXI.Graphics.html#bezierCurveTo
+                    const r = trackOuterRadius - (rowPosition / trackHeight) * trackRingSize;
+                    const posX = cartesianToPolar(_x1, trackWidth, r, tcx, tcy, startAngle, endAngle);
+                    const posXE = cartesianToPolar(_x2, trackWidth, r, tcx, tcy, startAngle, endAngle);
+                    const posX1 = cartesianToPolar(_x3, trackWidth, r, tcx, tcy, startAngle, endAngle);
+                    const posX1E = cartesianToPolar(_x4, trackWidth, r, tcx, tcy, startAngle, endAngle);
+
+                    g.moveTo(posX.x, posX.y);
+
+                    // outer curve
+                    g.bezierCurveTo(tcx, tcy, tcx, tcy, posX1E.x, posX1E.y);
+
+                    g.arc(
+                        tcx,
+                        tcy,
+                        trackOuterRadius,
+                        positionToRadian(posX1E.x, posX1E.y, tcx, tcy),
+                        positionToRadian(posX1.x, posX1.y, tcx, tcy),
+                        false
+                    );
+
+                    // inner curve
+                    g.bezierCurveTo(tcx, tcy, tcx, tcy, posXE.x, posXE.y);
+
+                    g.arc(
+                        tcx,
+                        tcy,
+                        trackOuterRadius,
+                        positionToRadian(posXE.x, posXE.y, tcx, tcy),
+                        positionToRadian(posX.x, posX.y, tcx, tcy),
+                        false
+                    );
+                    g.endFill();
+                } else {
+                    // Linear mark
+
+                    // Experimental
+                    if (spec.mark === 'betweenLink') {
+                        g.moveTo(_x1, rowPosition);
+                        g.lineTo(_x2, rowPosition);
+                        g.lineTo(_x4, rowPosition + rowHeight);
+                        g.lineTo(_x3, rowPosition + rowHeight);
+                        g.lineTo(_x1, rowPosition);
+                        g.closePath();
+                        return;
+                    }
+
+                    g.moveTo(_x1, baseY);
+
+                    if (!spec.style?.linkStyle || spec.style?.linkStyle === 'circular') {
+                        g.arc(
+                            (_x1 + _x4) / 2.0, // cx
+                            baseY, // cy
+                            (_x4 - _x1) / 2.0, // radius
+                            -Math.PI, // start angle
+                            Math.PI, // end angle
+                            false
+                        );
+                        g.arc((_x2 + _x3) / 2.0, baseY, (_x3 - _x2) / 2.0, Math.PI, -Math.PI, true);
+                        g.closePath();
+                    } else {
+                        g.lineTo(_x3, rowPosition + rowHeight);
+                        g.bezierCurveTo(
+                            _x3 + (_x2 - _x3) / 3.0,
+                            // rowPosition + (x1 - x),
+                            rowPosition + rowHeight - (_x2 - _x3) / 2.0, //Math.min(rowHeight - (x1 - x), (xe - x1) / 2.0),
+                            _x3 + ((_x2 - _x3) / 3.0) * 2,
+                            // rowPosition + (x1 - x),
+                            rowPosition + rowHeight - (_x2 - _x3) / 2.0, //Math.min(rowHeight - (x1 - x), (xe - x1) / 2.0),
+                            _x2,
+                            rowPosition + rowHeight
+                        );
+                        g.lineTo(_x4, rowPosition + rowHeight);
+                        g.bezierCurveTo(
+                            _x1 + ((_x4 - _x1) / 3.0) * 2,
+                            // rowPosition,
+                            rowPosition + rowHeight - (_x4 - _x1) / 2.0, //Math.min(rowHeight, (x1e - x) / 2.0),
+                            _x1 + (_x4 - _x1) / 3.0,
+                            // rowPosition,
+                            rowPosition + rowHeight - (_x4 - _x1) / 2.0, //Math.min(rowHeight, (x1e - x) / 2.0),
+                            _x1,
+                            rowPosition + rowHeight
+                        );
+                        g.endFill();
+                    }
+                }
+            } else {
+                /* Line Connection */
+
+                // Experimental
+                if (Is2DTrack(spec) && spec.mark === 'betweenLink') {
+                    if (spec.style?.linkConnectionType === 'curve') {
+                        g.moveTo(x, 0);
+                        g.bezierCurveTo(
+                            (x / 5.0) * 4,
+                            (rowPosition + rowHeight - y) / 2.0,
+                            x / 2.0,
+                            ((rowPosition + rowHeight - y) / 5.0) * 4,
+                            0,
+                            rowPosition + rowHeight - y
+                        );
+                    } else if (spec.style?.linkConnectionType === 'straight') {
+                        g.moveTo(x, 0);
+                        g.lineTo(0, rowPosition + rowHeight - y);
+                    } else {
+                        // spec.style?.linkConnectionType === 'corner'
+                        g.moveTo(x, 0);
+                        g.lineTo(x, rowPosition + rowHeight - y);
+                        g.lineTo(0, rowPosition + rowHeight - y);
+                    }
+                    return;
+                }
+
+                if (spec.mark === 'betweenLink' && circular) {
+                    /* Original lines */
+                    // const r = trackOuterRadius - (rowPosition / trackHeight) * trackRingSize;
+                    // const posX = cartesianToPolar(x, trackWidth, r, tcx, tcy, startAngle, endAngle);
+                    // const posXE = cartesianToPolar(xe, trackWidth, trackInnerRadius, tcx, tcy, startAngle, endAngle);
+                    // g.lineStyle(
+                    //     1,
+                    //     colorToHex('red'),
+                    //     1, // alpha
+                    //     0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+                    // );
+                    // g.moveTo(posX.x, posX.y);
+                    // g.lineTo(posXE.x, posXE.y);
+
+                    // https://www.tessellationtech.io/tutorial-circular-sankey/
+                    let prevX, prevY;
+                    for (let t = 0; t <= 1; t += 0.02) {
+                        const logodds = (t: number) => Math.log(t / (1 - t));
+                        const movingRadius = (t: number) =>
+                            trackOuterRadius - (1 / (1 + Math.exp(logodds(t)))) * trackRingSize + 3;
+                        const getRadian = (t: number, s: number, e: number) => ((e - s) * t + s) / trackWidth;
+                        const _x = tcx + movingRadius(t) * Math.cos(-getRadian(t, x, xe) * 2 * Math.PI - Math.PI / 2.0);
+                        const _y = tcy + movingRadius(t) * Math.sin(-getRadian(t, x, xe) * 2 * Math.PI - Math.PI / 2.0);
+                        if (prevX && prevY) {
+                            g.lineStyle(
+                                strokeWidth,
+                                colorToHex(stroke),
+                                opacity, // alpha
+                                0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+                            );
+                            g.moveTo(prevX, prevY);
+                            g.lineTo(_x, _y);
+                        }
+                        prevX = _x;
+                        prevY = _y;
+                    }
+
+                    return;
+                }
+
+                // Experimental
+                if (spec.mark === 'betweenLink') {
+                    g.moveTo(xe, rowPosition + rowHeight);
+                    g.lineTo(x, rowPosition);
+                    return;
+                }
+
+                const midX = (x + xe) / 2.0;
+
+                // Must not fill color for `line`, just use `stroke`
+                g.beginFill(colorToHex('white'), 0);
+
+                if (circular) {
+                    if (x < 0 || xe > trackWidth) {
+                        // Do not show bands that are partly outside of the current domain
+                        return;
+                    }
+
+                    const IS_ELLIPTICAL_READY = false;
+                    if (IS_ELLIPTICAL_READY && spec.style?.linkStyle === 'elliptical') {
+                        // !! Not ready to use
+                        const morePoints: { x: number; y: number }[] = [];
+
+                        // https://github.com/gosling-lang/gosling.js/issues/634
+                        const numSteps = 1000;
+                        for (let step = 0; step <= numSteps; step++) {
+                            const theta = (Math.PI * step) / numSteps;
+                            const mx = ((xe - x) / 2.0) * Math.cos(theta) + (x + xe) / 2.0;
+                            const my =
+                                baseY -
+                                (((rowHeight - y) *
+                                    Math.sin(theta) *
+                                    Math.min(xe - x + trackWidth * 0.5, trackWidth * 1.5)) /
+                                    trackWidth /
+                                    1.5) *
+                                    (flipY ? -1 : 1);
+
+                            const r = trackOuterRadius - (my / trackHeight) * trackRingSize;
+                            const cmx = cartesianToPolar(mx, trackWidth, r, tcx, tcy, startAngle, endAngle);
+
+                            if (step % 20 === 0 || step === numSteps) {
+                                // we draw less points than the hidden points for mouse events
+                                if (step === 0) {
+                                    g.moveTo(cmx.x, cmx.y);
+                                } else {
+                                    g.lineTo(cmx.x, cmx.y);
+                                }
+                            }
+                            morePoints.push({ ...cmx });
+                        }
+
+                        if (spec.tooltip) {
+                            trackInfo.tooltips.push({
+                                datum: d,
+                                isMouseOver: (mouseX: number, mouseY: number) =>
+                                    morePoints.findIndex(
+                                        d => Math.sqrt((d.x - mouseX) ** 2 + (d.y - mouseY) ** 2) < 5
+                                    ) !== -1,
+                                markInfo: {}
+                            } as TooltipData);
+                        }
+                    } else {
+                        const r = trackOuterRadius - (rowPosition / trackHeight) * trackRingSize;
+                        const posS = cartesianToPolar(x, trackWidth, r, tcx, tcy, startAngle, endAngle);
+                        const posE = cartesianToPolar(xe, trackWidth, r, tcx, tcy, startAngle, endAngle);
+
+                        const x1 = posS.x;
+                        const y1 = posS.y;
+                        const x2 = posS.x;
+                        const y2 = posS.y;
+                        const x3 = trackWidth / 2.0;
+                        const y3 = trackHeight / 2.0;
+                        const x4 = posE.x;
+                        const y4 = posE.y;
+
+                        g.moveTo(x1, y1);
+
+                        const bezier = new Bezier(x1, y1, x2, y2, x3, y3, x4, y4);
+                        const points = bezier.getLUT(14);
+                        points.forEach(d => g.lineTo(d.x, d.y));
+
+                        /* click event data */
+                        const morePoints = bezier.getLUT(1000);
+                        if (spec.tooltip) {
+                            trackInfo.tooltips.push({
+                                datum: d,
+                                isMouseOver: (mouseX: number, mouseY: number) =>
+                                    morePoints.findIndex(
+                                        d => Math.sqrt((d.x - mouseX) ** 2 + (d.y - mouseY) ** 2) < 5
+                                    ) !== -1,
+                                markInfo: {}
+                            } as TooltipData);
+                        }
+                    }
+                } else {
+                    // linear line connection
+
+                    if (spec.style?.linkStyle === 'elliptical') {
+                        if (!(0 <= x && x <= trackWidth) && !(0 <= xe && xe <= trackWidth)) {
+                            // not within this window
+                            return;
+                        }
+
+                        const morePoints: { x: number; y: number }[] = [];
+
+                        // https://github.com/gosling-lang/gosling.js/issues/634
+                        const numSteps = 1000;
+                        const constantY = IsChannelDeep(spec.y);
+                        for (let step = 0; step <= numSteps; step++) {
+                            const theta = Math.PI * (step / numSteps);
+                            const mx = ((xe - x) / 2.0) * Math.cos(theta) + (x + xe) / 2.0;
+                            const my =
+                                baseY -
+                                y *
+                                    Math.sin(theta) *
+                                    (constantY
+                                        ? 1
+                                        : Math.min(xe - x + trackWidth * 0.5, trackWidth * 1.5) / trackWidth / 1.5) *
+                                    (flipY ? -1 : 1);
+
+                            if (step % 20 === 0 || step === numSteps) {
+                                // we draw less points than the hidden points that captures mouse events
+                                if (step === 0) {
+                                    g.moveTo(mx, my);
+                                } else {
+                                    g.lineTo(mx, my);
+                                }
+                            }
+                            morePoints.push({ x: mx, y: my });
+                        }
+
+                        if (spec.tooltip) {
+                            trackInfo.tooltips.push({
+                                datum: d,
+                                isMouseOver: (mouseX: number, mouseY: number) =>
+                                    morePoints.findIndex(
+                                        d => Math.sqrt((d.x - mouseX) ** 2 + (d.y - mouseY) ** 2) < 5
+                                    ) !== -1,
+                                markInfo: {}
+                            } as TooltipData);
+                        }
+                    } else if (spec.style?.linkStyle === '_bezier_deprecated_') {
+                        const x1 = x;
+                        const y1 = baseY;
+                        const x2 = x + (xe - x) / 3.0;
+                        const y2 =
+                            baseY + Math.max(rowHeight / 2.0, Math.min(rowHeight, (xe - x) / 2.0)) * (flipY ? 1 : -1);
+                        const x3 = x + ((xe - x) / 3.0) * 2;
+                        const y3 =
+                            baseY + Math.max(rowHeight / 2.0, Math.min(rowHeight, (xe - x) / 2.0)) * (flipY ? 1 : -1);
+                        const x4 = xe;
+                        const y4 = baseY;
+
+                        const bezier = new Bezier(x1, y1, x2, y2, x3, y3, x4, y4);
+                        const points = bezier.getLUT(14);
+                        points.forEach(d => g.lineTo(d.x, d.y));
+
+                        /* click event data */
+                        const morePoints = bezier.getLUT(1000);
+                        if (spec.tooltip) {
+                            trackInfo.tooltips.push({
+                                datum: d,
+                                isMouseOver: (mouseX: number, mouseY: number) =>
+                                    morePoints.findIndex(
+                                        d => Math.sqrt((d.x - mouseX) ** 2 + (d.y - mouseY) ** 2) < 5
+                                    ) !== -1,
+                                markInfo: {}
+                            } as TooltipData);
+                        }
+                    } else {
+                        if (xe < 0 || x > trackWidth) {
+                            // Q: Do we really need this?
+                            return;
+                        }
+                        g.arc(midX, baseY, (xe - x) / 2.0, -Math.PI, Math.PI);
+                        g.closePath();
+                    }
+                }
+            }
+        });
+    });
+}

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -8,7 +8,7 @@ import { ChannelTypes } from '../gosling.schema';
 import { drawTriangle } from './triangle';
 import { drawText } from './text';
 import { drawRule } from './rule';
-import { drawLink } from './link';
+import { drawWithinLink } from './withinLink';
 import { drawGrid } from './grid';
 import { drawCircularTitle } from './title';
 import { drawChartOutlines } from './outline';
@@ -18,6 +18,7 @@ import { drawCircularOutlines } from './outline-circular';
 import { drawBackground } from './background';
 import { CompleteThemeDeep } from '../utils/theme';
 import { Is2DTrack, IsVerticalRule } from '../gosling.schema.guards';
+import { drawBetweenLink } from './betweenLink';
 
 /**
  * Visual channels currently supported for visual encoding.
@@ -115,8 +116,10 @@ export function drawMark(HGC: any, trackInfo: any, tile: any, model: GoslingTrac
             drawRule(HGC, trackInfo, tile, model);
             break;
         case 'betweenLink':
+            drawBetweenLink(tile.graphics, trackInfo, model);
+            break;
         case 'withinLink':
-            drawLink(tile.graphics, trackInfo, model);
+            drawWithinLink(tile.graphics, trackInfo, model);
             break;
         default:
             console.warn('Unsupported mark type');

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -98,7 +98,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
             );
 
             const flipY = (IsChannelDeep(spec.y) && spec.y.flip) || spec.flipY;
-            const baseY = rowPosition + (flipY ? 0 : rowHeight);
+            const baseY = spec.baselineY ?? rowPosition + (flipY ? 0 : rowHeight);
 
             if (isBand) {
                 g.beginFill(color === 'none' ? colorToHex('white') : colorToHex(color), color === 'none' ? 0 : opacity);
@@ -296,6 +296,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                     }
 
                     if (spec.style?.withinLinkStyle === 'sv') {
+                        // !! Not ready to use
                         const morePoints: { x: number; y: number }[] = [];
 
                         // https://github.com/gosling-lang/gosling.js/issues/634
@@ -304,20 +305,24 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                             const theta = (Math.PI * step) / numSteps;
                             const mx = ((xe - x) / 2.0) * Math.cos(theta) + (x + xe) / 2.0;
                             const my =
-                                (rowHeight - 4) *
-                                Math.sin(theta) *
-                                Math.max(
-                                    0.05,
-                                    Math.min(Math.log10(xe - x), Math.log10(trackWidth)) / Math.log10(trackWidth)
-                                );
+                                baseY -
+                                (((rowHeight - y) *
+                                    Math.sin(theta) *
+                                    Math.min(xe - x + trackWidth * 0.5, trackWidth * 1.5)) /
+                                    trackWidth /
+                                    1.5) *
+                                    (flipY ? -1 : 1);
 
                             const r = trackOuterRadius - (my / trackHeight) * trackRingSize;
                             const cmx = cartesianToPolar(mx, trackWidth, r, tcx, tcy, startAngle, endAngle);
 
-                            if (step % 10 === 0 || step === numSteps) {
+                            if (step % 20 === 0 || step === numSteps) {
                                 // we draw less points than the hidden points for mouse events
-                                if (step === 0) g.moveTo(cmx.x, cmx.y);
-                                else g.lineTo(cmx.x, cmx.y);
+                                if (step === 0) {
+                                    g.moveTo(cmx.x, cmx.y);
+                                } else {
+                                    g.lineTo(cmx.x, cmx.y);
+                                }
                             }
                             morePoints.push({ ...cmx });
                         }
@@ -383,12 +388,11 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                             const mx = ((xe - x) / 2.0) * Math.cos(theta) + (x + xe) / 2.0;
                             const my =
                                 baseY -
-                                (rowHeight - y) *
+                                (((rowHeight - y) *
                                     Math.sin(theta) *
-                                    Math.max(
-                                        0.0,
-                                        Math.min(Math.log10(xe - x), Math.log10(trackWidth)) / Math.log10(trackWidth)
-                                    ) *
+                                    Math.min(xe - x + trackWidth * 0.5, trackWidth * 1.5)) /
+                                    trackWidth /
+                                    1.5) *
                                     (flipY ? -1 : 1);
 
                             if (step % 20 === 0 || step === numSteps) {

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -329,22 +329,24 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                     // linear line connection
 
                     g.moveTo(x, baseY);
-                    const morePoints: { x: number; y: number }[] = [];
+
                     if (spec.style?.svWithinLink) {
+                        const morePoints: { x: number; y: number }[] = [];
+
                         // https://github.com/gosling-lang/gosling.js/issues/634
                         const numSteps = 1000;
-                        const topY = rowPosition + rowHeight;
                         for (let step = 0; step <= numSteps; step++) {
                             const theta = (Math.PI * step) / numSteps;
                             const mx = ((xe - x) / 2.0) * Math.cos(theta) + (x + xe) / 2.0;
                             const my =
-                                topY -
+                                baseY -
                                 (rowHeight - 4) *
                                     Math.sin(theta) *
                                     Math.max(
                                         0.05,
                                         Math.min(Math.log10(xe - x), Math.log10(trackWidth)) / Math.log10(trackWidth)
-                                    );
+                                    ) *
+                                    (flipY ? -1 : 1);
 
                             if (step % 10 === 0 || step === numSteps) {
                                 // we draw less points than the hidden points for mouse events

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -173,7 +173,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
 
                     g.moveTo(_x1, baseY);
 
-                    if (!spec.style?.bezierLink) {
+                    if (spec.style?.linkStyle !== 'bezier') {
                         g.arc(
                             (_x1 + _x4) / 2.0, // cx
                             baseY, // cy
@@ -295,7 +295,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                         return;
                     }
 
-                    if (spec.style?.withinLinkStyle === 'sv') {
+                    if (spec.style?.linkStyle === 'sv') {
                         // !! Not ready to use
                         const morePoints: { x: number; y: number }[] = [];
 
@@ -373,7 +373,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                 } else {
                     // linear line connection
 
-                    if (spec.style?.withinLinkStyle === 'sv') {
+                    if (spec.style?.linkStyle === 'sv') {
                         if (!(0 <= x && x <= trackWidth) && !(0 <= xe && xe <= trackWidth)) {
                             // not within this window
                             return;
@@ -416,7 +416,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                                 markInfo: {}
                             } as TooltipData);
                         }
-                    } else if (spec.style?.bezierLink) {
+                    } else if (spec.style?.linkStyle === 'bezier') {
                         const x1 = x;
                         const y1 = baseY;
                         const x2 = x + (xe - x) / 3.0;
@@ -444,7 +444,7 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                                 markInfo: {}
                             } as TooltipData);
                         }
-                    } else if (spec.style?.flatWithinLink) {
+                    } else if (spec.style?.linkStyle === 'sashimi') {
                         const arcWidth = xe - x;
                         const radius = Math.min(10, arcWidth / 2.0);
                         const topY = rowPosition + rowHeight - y;

--- a/src/core/mark/link.ts
+++ b/src/core/mark/link.ts
@@ -385,13 +385,13 @@ export function drawLink(g: PIXI.Graphics, trackInfo: any, model: GoslingTrackMo
                                 baseY -
                                 (rowHeight - y) *
                                     Math.sin(theta) *
-                                    // Math.max(
-                                    //     0.5,
-                                    //     Math.min(Math.log10(xe - x), Math.log10(trackWidth)) / Math.log10(trackWidth)
-                                    // ) *
+                                    Math.max(
+                                        0.0,
+                                        Math.min(Math.log10(xe - x), Math.log10(trackWidth)) / Math.log10(trackWidth)
+                                    ) *
                                     (flipY ? -1 : 1);
 
-                            if (step % 10 === 0 || step === numSteps) {
+                            if (step % 20 === 0 || step === numSteps) {
                                 // we draw less points than the hidden points for mouse events
                                 if (step === 0) {
                                     g.moveTo(mx, my);

--- a/src/core/mark/withinLink.test.ts
+++ b/src/core/mark/withinLink.test.ts
@@ -2,7 +2,7 @@ import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { SingleTrack } from '../gosling.schema';
 import { getTheme } from '../utils/theme';
-import { drawLink } from './link';
+import { drawWithinLink } from './withinLink';
 
 describe('Rendering link', () => {
     const g = new PIXI.Graphics();
@@ -24,7 +24,7 @@ describe('Rendering link', () => {
             { x: 111, x1: 222, xe: 333, x1e: 444 }
         ];
         const model = new GoslingTrackModel(t, d, getTheme());
-        drawLink(g, trackInfo, model);
+        drawWithinLink(g, trackInfo, model);
     });
     it('Circular Band', () => {
         const t: SingleTrack = {
@@ -44,7 +44,7 @@ describe('Rendering link', () => {
             { x: 111, x1: 222, xe: 333, x1e: 444 }
         ];
         const model = new GoslingTrackModel(t, d, getTheme());
-        drawLink(g, trackInfo, model);
+        drawWithinLink(g, trackInfo, model);
     });
     it('Linear line', () => {
         const t: SingleTrack = {
@@ -62,7 +62,7 @@ describe('Rendering link', () => {
             { x: 111, x1: 222, xe: 333, x1e: 444 }
         ];
         const model = new GoslingTrackModel(t, d, getTheme());
-        drawLink(g, trackInfo, model);
+        drawWithinLink(g, trackInfo, model);
     });
     it('Circular line', () => {
         const t: SingleTrack = {
@@ -80,6 +80,6 @@ describe('Rendering link', () => {
             { x: 111, x1: 222, xe: 333, x1e: 444 }
         ];
         const model = new GoslingTrackModel(t, d, getTheme());
-        drawLink(g, trackInfo, model);
+        drawWithinLink(g, trackInfo, model);
     });
 });


### PR DESCRIPTION
```diff
"style": { 
  "linkStyle": "elliptical", // or "circular" (Default)
  "linkMinHeight": 0.3, // specify the min height of arc if `y` is not encoded with data
- "bezierLink": true // removed!
- "flatWithinLink": true // removed!
}
```

![Screen Shot 2022-02-18 at 11 48 12](https://user-images.githubusercontent.com/9922882/154726280-c7f91683-fb79-44b0-9ac0-b7fc673a4b1d.png)

<details>

<summary>
Circular needs additional work
</summary>

![gosling-visualization (1)](https://user-images.githubusercontent.com/9922882/153514446-4a066a18-23ec-4372-a602-f4b84fdea68a.png)

</details>


<a href="https://gosling-lang.github.io/gosling.js/?full=false&spec=(%0A%20BcenterRadiusJ0.5%2C%0A%5E(%0A*%2F%2FBlayoutJBcircular'%2C%0A*%5E*(%0A**%20Btracks%7F9(9%20BdataJ(9*'url!Bhttps%3A%2F%2Fs3.amazonaws.com%2Fgosling-lang.org%2Fdata%2FSV%2Ffc8edf46-2005-1af4-e040-11ac0d481414.pcawg_consensus_1.6.161022.somatic.sv.bedpe'X'type!Bcsv'X'separator!B%5Ct'X%7BToConvert%7F9*%261%2B1%3Eend1'%5D9*K)X%262%2B2%3Eend2'%5D9*K)9*%5D9K)qmark!BwithinLink'qalignment!Boverlay'qtracks%7F9*(9*KjQ%20)9%251G'%402GKBflipYJtrue%24~baselineYJ100XKB%7C%3C9*KjQ%20)9%251GKB%401GKBmark!Bbar'%24XKBsizeJ(B%3C9*KjQ%20)9%252GKB%402GKBmark!Bbar'%24XKBsizeJ(B%3C9**'flipYJtrueX*'xJ(Zstart1G*'%402GKjQ%2CBnotJtrue%20)9*K%20%5DX*'%7CvalueJ2)%24%2CBbaselineYJ09*)9%5DqcolorJ(9*Z%60'X'%3BX'rang%22%3D9%7DX*'DEL'X%3F9*%5D%2C%209*'legendJtrue9K)qstrokeJ(9*Z%60'X'%3BX'rang%22%3D9%7DX*'DEL'X%3F9*%5D9K)qopacityJ('valueJ0.4)qtooltip%7F9*(Zstart1G(Zend2G(Z%60%3E%3B)9K%5DqstyleJ('inlineLegendJtrue%2CBlinkStyleJBelliptical%3ElinkMinHeightJ0.5%20)qwidthJ1000qheightJ2009)%0A**K%5D%0A**)%0A*K%5D%0A*)%0AK%5D%0A)*KK9%0A***B%20'G%3Etype!Bgenomic')XJ!%20K%20%20Qype!Bfilter%3Efield!B%60%3EoneOf%7F'TRA'%5DX%2C9*Z'field!BjBdataTransform%7F9***(%20Btq%2C9%20B%22e%7F'lightgrey%3E%234C75A2%3E%23DA5456%3E%23EA8A2A'%2C%24XKByJ(BvalueJ100%20)%25*K%20%5DXKBxJ(Zstart%26K(9**'chromosomeField!Bchrom%2B'X*%7B%7F'start%3Btype!Bnominal'%3CvalueJ2)9*)X(%3DBgreen'%5DX'domain%7F%3E'%2CB%3F*'t2tINV'X*'h2hINV'%40xeJ(Zend%5E%20Bviews%7F%0A*%60svclass%7B'genomicFields%7CstrokeWidthJ('%7D**'TRA'X*'DUP'%7FJ%5B%01%7F%7D%7C%7B%60%5E%40%3F%3E%3D%3C%3B%2B%26%25%24%22qjZXQKJGB9*_">demo</a>

Fix #634 
Fix #633