### PR TITLE
feat: use reactive rendering for responsive specs

### DIFF
--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -903,7 +903,7 @@ function Editor(props: any) {
                                             border={'none'}
                                             id={'goslig-component-root'}
                                             className={'goslig-component'}
-                                            experimental={{ reactive: false }}
+                                            experimental={{ reactive: true }}
                                             compiled={(g, h) => {
                                                 setHg(h);
                                             }}

--- a/editor/example/responsive.ts
+++ b/editor/example/responsive.ts
@@ -85,6 +85,7 @@ export const EX_SPEC_RESPONSIVE_MULTIVEC: GoslingSpec = {
             spacing: 1,
             tracks: [
                 {
+                    id: 'responsive-multivec',
                     alignment: 'overlay',
                     data: {
                         url: 'https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec',

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -123,6 +123,9 @@ export const GoslingComponent = forwardRef<
         compile();
     }, [props.spec, theme]);
 
+    const responsiveHeight =
+        typeof props.spec?.responsiveSize !== 'object' ? props.spec?.responsiveSize : props.spec.responsiveSize.height;
+
     // HiGlass component should be mounted only once
     const higlassComponent = useMemo(
         () => (
@@ -140,15 +143,12 @@ export const GoslingComponent = forwardRef<
                         typeof props.spec?.responsiveSize !== 'object'
                             ? props.spec?.responsiveSize
                             : props.spec.responsiveSize.width,
-                    responsiveHeight:
-                        typeof props.spec?.responsiveSize !== 'object'
-                            ? props.spec?.responsiveSize
-                            : props.spec.responsiveSize.height,
+                    responsiveHeight,
                     background: theme.root.background
                 }}
             />
         ),
-        [viewConfig, size, theme]
+        [viewConfig, size, theme, responsiveHeight]
     );
 
     return higlassComponent;

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -56,34 +56,6 @@ export const GoslingComponent = forwardRef<
         }
     }, [ref, hgRef, viewConfig, theme]);
 
-    const responsiveHeight =
-        typeof props.spec?.responsiveSize !== 'object' ? props.spec?.responsiveSize : props.spec.responsiveSize.height;
-
-    // HiGlass component should be mounted only once
-    const higlassComponent = useMemo(
-        () => (
-            <HiGlassComponentWrapper
-                ref={hgRef}
-                viewConfig={viewConfig}
-                size={size}
-                id={wrapperDivId}
-                className={props.className}
-                options={{
-                    padding: props.padding,
-                    border: props.border,
-                    margin: props.margin,
-                    responsiveWidth:
-                        typeof props.spec?.responsiveSize !== 'object'
-                            ? props.spec?.responsiveSize
-                            : props.spec.responsiveSize.width,
-                    responsiveHeight,
-                    background: theme.root.background
-                }}
-            />
-        ),
-        [viewConfig, size, theme, responsiveHeight]
-    );
-
     // TODO: add a `force` parameter since changing `linkingId` might not update vis
     const compile = useCallback(() => {
         if (props.spec) {
@@ -156,6 +128,34 @@ export const GoslingComponent = forwardRef<
     useEffect(() => {
         compile();
     }, [props.spec, theme]);
+
+    const responsiveHeight =
+        typeof props.spec?.responsiveSize !== 'object' ? props.spec?.responsiveSize : props.spec.responsiveSize.height;
+
+    // HiGlass component should be mounted only once
+    const higlassComponent = useMemo(
+        () => (
+            <HiGlassComponentWrapper
+                ref={hgRef}
+                viewConfig={viewConfig}
+                size={size}
+                id={wrapperDivId}
+                className={props.className}
+                options={{
+                    padding: props.padding,
+                    border: props.border,
+                    margin: props.margin,
+                    responsiveWidth:
+                        typeof props.spec?.responsiveSize !== 'object'
+                            ? props.spec?.responsiveSize
+                            : props.spec.responsiveSize.width,
+                    responsiveHeight,
+                    background: theme.root.background
+                }}
+            />
+        ),
+        [viewConfig, size, theme, responsiveHeight]
+    );
 
     return higlassComponent;
 });

--- a/src/core/higlass-component-wrapper.tsx
+++ b/src/core/higlass-component-wrapper.tsx
@@ -44,6 +44,7 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
         }, [props.id]);
 
         const viewConfig = props.viewConfig || {};
+        const pixelPreciseMarginPadding = !props.options.responsiveHeight;
         const higlassComponent = useMemo(
             () => (
                 <HiGlassComponent
@@ -53,7 +54,7 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
                         // Since using this disallows responsive resizing of track heights in HiGlass,
                         // we need to use this only when users do not want to use responsive height.
                         // (See https://github.com/higlass/higlass/blob/2a3786e13c2415a52abc1227f75512f128e784a0/app/scripts/HiGlassComponent.js#L2199)
-                        pixelPreciseMarginPadding: !props.options.responsiveHeight,
+                        pixelPreciseMarginPadding,
 
                         containerPaddingX: 0,
                         containerPaddingY: 0,
@@ -71,7 +72,7 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
                     viewConfig={viewConfig}
                 />
             ),
-            [viewConfig]
+            [viewConfig, pixelPreciseMarginPadding]
         );
 
         // Styling

--- a/src/core/higlass-component-wrapper.tsx
+++ b/src/core/higlass-component-wrapper.tsx
@@ -44,7 +44,7 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
         }, [props.id]);
 
         const viewConfig = props.viewConfig || {};
-        const pixelPreciseMarginPadding = !props.options.responsiveHeight;
+        const pixelPreciseMarginPadding = false; // !props.options.responsiveHeight;
         const higlassComponent = useMemo(
             () => (
                 <HiGlassComponent

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -303,7 +303,7 @@ export class HiGlassModel {
 
         const widthOrHeight = position === 'left' || position === 'right' ? 'width' : 'height';
         const axisTrackTemplate: Track = {
-            uid: options.id ?? uuid.v1(),
+            // uid: options.id ?? uuid.v1(), // TODO: turning this on makes some tick labels hidden
             type: 'axis-track',
             chromInfoPath: this.hg.chromInfoPath,
             options: {

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -120,8 +120,9 @@ export function getRelativeTrackInfo(
         size.height = size.height + (8 - (size.height % 8));
     }
 
-    const pixelPreciseMarginPadding =
-        typeof spec.responsiveSize !== 'object' ? !spec.responsiveSize : !spec.responsiveSize.height;
+    const pixelPreciseMarginPadding = !(typeof spec.responsiveSize !== 'object'
+        ? spec.responsiveSize
+        : spec.responsiveSize.height);
 
     // Calculate `layout`s for React Grid Layout (RGL).
     trackInfos.forEach(_ => {


### PR DESCRIPTION
Current Issue
- [x] when responsive height (e.g., `responsiveSize.height`) was used and then turned off, the track height does not revert back to the original height that is specified in the spec
  - Potential source of this: https://github.com/higlass/higlass/blob/2a3786e13c2415a52abc1227f75512f128e784a0/app/scripts/HiGlassComponent.js#L2199


https://user-images.githubusercontent.com/9922882/155395921-fa97e458-8073-48cb-be93-5be44e356410.mov



<details>
```
Previous comment by Alex:

I am trying to insert a track into a viewconf using the setViewConfig  API function. It works, but the height of the view is not adjusted (I am using the default size mode). If I open the viewconf editor and close it again, the height seems to be recomputed and I can see all the tracks. Is there a way to force Higlass to recompute the view height?

FYI: I got it to work with

hgc.api.setViewConfig(resp.viewconfig, true).then((v) => {
     const settings = {
          viewId: viewId,
          trackId: resp.viewconfig.views[1].tracks.top[0].uid
      }
      hgc.trackDimensionsModifiedHandlerBound(settings)
  });
This calls adjustLayoutToTrackSizes  internally. Probably not the most elegant solution, but it works.

```
</details>