### PR TITLE
feat: allow checking the container size or aspect ratio for using responsive spec

### DIFF
--- a/editor/example/responsive-track-wise-comparison.ts
+++ b/editor/example/responsive-track-wise-comparison.ts
@@ -26,7 +26,7 @@ const tracks: (type: 1 | 2, compact?: boolean) => SingleTrack[] = (type, compact
         strokeWidth: { value: 0.2 },
         style: { background: 'lightgray', backgroundOpacity: type === 1 || !compact ? 0 : 0.2 },
         width: 700,
-        height: 40
+        height: 100
     },
     {
         id: `${type}-2`,
@@ -47,7 +47,7 @@ const tracks: (type: 1 | 2, compact?: boolean) => SingleTrack[] = (type, compact
         strokeWidth: { value: 0.2 },
         style: { background: 'lightgray', backgroundOpacity: type === 1 || !compact ? 0 : 0.2 },
         width: 700,
-        height: 40
+        height: 100
     },
     {
         id: `${type}-3`,
@@ -68,7 +68,7 @@ const tracks: (type: 1 | 2, compact?: boolean) => SingleTrack[] = (type, compact
         strokeWidth: { value: 0.2 },
         style: { background: 'lightgray', backgroundOpacity: type === 1 || !compact ? 0 : 0.2 },
         width: 700,
-        height: 40
+        height: 100
     }
 ];
 
@@ -110,7 +110,7 @@ export const gene: (type: 1 | 2, compact?: boolean) => TemplateTrack = (type, co
         },
         style: { background: 'lightgray', backgroundOpacity: type === 1 || !compact ? 0 : 0.1 },
         width: 700,
-        height: 20
+        height: 100
     };
 };
 
@@ -244,7 +244,7 @@ const _gene: (type: 1 | 2, compact?: boolean) => OverlaidTracks = (type, compact
         style: { background: 'lightgray', backgroundOpacity: type === 1 || !compact ? 0 : 0.2 },
         opacity: { value: 0.8 },
         width: 700,
-        height: 20
+        height: 100
     };
 };
 
@@ -254,12 +254,10 @@ const xDomain: (type: 1 | 2) => DomainChrInterval = type => {
 };
 
 export const EX_SPEC_RESPONSIVE_TRACK_WISE_COMPARISON: GoslingSpec = {
-    description: 'TODO: do not bound height; instead just check the screen size.',
-    responsiveSize: { width: false, height: true },
     spacing: 30,
     responsiveSpec: [
         {
-            selectivity: [{ measure: 'height', operation: 'LT', threshold: 1000 }],
+            selectivity: [{ measure: 'height', operation: 'LT', threshold: 1000, target: 'container' }],
             spec: {
                 spacing: 0,
                 views: [

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -5446,6 +5446,14 @@
         "operation": {
           "$ref": "#/definitions/LogicalOperation"
         },
+        "target": {
+          "description": "Does the condition applied to the visualization itself or its container? __Default__: `'self'`",
+          "enum": [
+            "self",
+            "container"
+          ],
+          "type": "string"
+        },
         "threshold": {
           "type": "number"
         }

--- a/src/core/compile.test.ts
+++ b/src/core/compile.test.ts
@@ -6,7 +6,7 @@ import { GoslingSpec } from '../index';
 describe('compile', () => {
     it('compile should not touch the original spec of users', () => {
         const spec = JSON.parse(JSON.stringify(EX_SPEC_VISUAL_ENCODING));
-        compile(spec, () => {}, [], getTheme());
+        compile(spec, () => {}, [], getTheme(), {});
         expect(JSON.stringify(spec)).toEqual(JSON.stringify(EX_SPEC_VISUAL_ENCODING));
     });
 });
@@ -35,7 +35,8 @@ describe('gosling track.id => higlass view.uid', () => {
                 expect(h.views[0].uid).toEqual('track-id');
             },
             [],
-            getTheme()
+            getTheme(),
+            {}
         );
     });
 });

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -12,7 +12,10 @@ export function compile(
     setHg: (hg: HiGlassSpec, size: Size, gs: GoslingSpec) => void,
     templates: TemplateTrackDef[],
     theme: Required<CompleteThemeDeep>,
-    curSize?: { width: number; height: number }
+    containerStatus: {
+        containerSize?: { width: number; height: number };
+        containerParentSize?: { width: number; height: number };
+    }
 ) {
     // Make sure to keep the original spec as-is
     const specCopy = JSON.parse(JSON.stringify(spec));
@@ -36,9 +39,17 @@ export function compile(
         (typeof spec.responsiveSize === 'object' && spec.responsiveSize?.width) || spec.responsiveSize;
     const isResponsiveHeight =
         (typeof spec.responsiveSize === 'object' && spec.responsiveSize?.height) || spec.responsiveSize;
-    const wFactor = isResponsiveWidth && curSize ? curSize?.width / size.width : 1;
-    const hFactor = isResponsiveHeight && curSize ? curSize?.height / size.height : 1;
-    const replaced = manageResponsiveSpecs(specCopy, wFactor, hFactor);
+    const wFactor =
+        isResponsiveWidth && containerStatus.containerSize ? containerStatus.containerSize.width / size.width : 1;
+    const hFactor =
+        isResponsiveHeight && containerStatus.containerSize ? containerStatus.containerSize.height / size.height : 1;
+    const pWidth = containerStatus.containerParentSize
+        ? containerStatus.containerParentSize.width
+        : Number.MAX_SAFE_INTEGER;
+    const pHeight = containerStatus.containerParentSize
+        ? containerStatus.containerParentSize.height
+        : Number.MAX_SAFE_INTEGER;
+    const replaced = manageResponsiveSpecs(specCopy, wFactor, hFactor, pWidth, pHeight);
 
     // Do the downstream-fix and track arrangement again using the updated spec
     if (replaced) {

--- a/src/core/gosling-embed.ts
+++ b/src/core/gosling-embed.ts
@@ -83,7 +83,8 @@ export function embed(element: HTMLElement, spec: GoslingSpec, opts: GoslingEmbe
                 resolve(api);
             },
             [...GoslingTemplates],
-            theme
+            theme,
+            {} // TODO: properly specify this
         );
     });
 }

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -30,6 +30,10 @@ export type SingleView = (OverlaidTracks | StackedTracks | FlatTracks) & Respons
 
 export type SelectivityCondition = {
     operation: LogicalOperation;
+    /**
+     * Does the condition applied to the visualization itself or its container? __Default__: `'self'`
+     */
+    target?: 'self' | 'container';
     measure: 'width' | 'height' | 'aspectRatio';
     threshold: number;
 };

--- a/src/core/responsive.test.ts
+++ b/src/core/responsive.test.ts
@@ -4,18 +4,20 @@ import { manageResponsiveSpecs } from './responsive';
 describe('ResponsiveSpec', () => {
     it('Spec without sufficient information should not be replaced', () => {
         {
-            const replaced = manageResponsiveSpecs({ views: [] }, 1, 1);
+            const replaced = manageResponsiveSpecs({ views: [] }, 1, 1, 100, 100);
             expect(replaced).toBe(false);
         }
         {
-            const replaced = manageResponsiveSpecs({ views: [], responsiveSpec: [] }, 1, 1);
+            const replaced = manageResponsiveSpecs({ views: [], responsiveSpec: [] }, 1, 1, 100, 100);
             expect(replaced).toBe(false);
         }
         {
             const replaced = manageResponsiveSpecs(
                 { views: [], responsiveSpec: [{ spec: {}, selectivity: [] }] },
                 1,
-                1
+                1,
+                1000,
+                1000
             );
             expect(replaced).toBe(false);
         }
@@ -28,7 +30,9 @@ describe('ResponsiveSpec', () => {
                     ]
                 },
                 1,
-                1
+                1,
+                1000,
+                1000
             );
             expect(replaced).toBe(false); // no `_assignedWidth`
         }
@@ -47,7 +51,24 @@ describe('ResponsiveSpec', () => {
                     }
                 ]
             };
-            const replaced = manageResponsiveSpecs(spec, 1, 1);
+            const replaced = manageResponsiveSpecs(spec, 1, 1, 100, 100);
+            expect(replaced).toBe(true);
+            expect(spec.layout).toBe('linear');
+        }
+        {
+            const spec: GoslingSpec = {
+                _assignedWidth: 100,
+                _assignedHeight: 100,
+                layout: 'circular',
+                views: [],
+                responsiveSpec: [
+                    {
+                        spec: { layout: 'linear' },
+                        selectivity: [{ measure: 'width', threshold: 1000, operation: 'LT', target: 'container' }]
+                    }
+                ]
+            };
+            const replaced = manageResponsiveSpecs(spec, 1, 1, 100, 100);
             expect(replaced).toBe(true);
             expect(spec.layout).toBe('linear');
         }


### PR DESCRIPTION
```ts
responsiveSpec: [
  {
    // if the height of the gosling component container is less than 1,000px, change spec
    selectivity: [{ 
      measure: 'height', 
      operation: 'LT', 
      threshold: 1000, 
      target: 'container' // default: 'self'
    }],
    spec: { /* some alternative spec here */ }
  }
]

```

This allows defining/applying alternative specs without using `responsiveSize`