### PR TITLE
feat: support brushes on color legends

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -462,6 +462,10 @@
           "minItems": 2,
           "type": "array"
         },
+        "title": {
+          "description": "Title of the legend. __Default__: `undefined`",
+          "type": "string"
+        },
         "type": {
           "description": "Specify the data type",
           "enum": [
@@ -7893,9 +7897,31 @@
           "description": "Name of the data field",
           "type": "string"
         },
+        "legend": {
+          "description": "Whether to display legend. __Default__: `false`",
+          "type": "boolean"
+        },
         "range": {
           "$ref": "#/definitions/Range",
           "description": "Ranges of visual channel values"
+        },
+        "scaleOffset": {
+          "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "title": {
+          "description": "Title of the legend. __Default__: `undefined`",
+          "type": "string"
         },
         "type": {
           "description": "Specify the data type",

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -448,6 +448,20 @@
           ],
           "type": "string"
         },
+        "scaleOffset": {
+          "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
         "type": {
           "description": "Specify the data type",
           "enum": [

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -638,8 +638,9 @@ export class GoslingTrackModel {
                     }
 
                     if (
-                        channelKey === 'color' ||
-                        (channelKey === 'stroke' && channel.type === 'quantitative' && !(channel as Color).scaleOffset)
+                        (channelKey === 'color' || channelKey === 'stroke') &&
+                        channel.type === 'quantitative' &&
+                        !(channel as Color).scaleOffset
                     ) {
                         (channel as Color | Stroke).scaleOffset = [0, 1];
                     }

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -6,7 +6,8 @@ import {
     ChannelValue,
     SingleTrack,
     Channel,
-    Color
+    Color,
+    Stroke
 } from './gosling.schema';
 import { validateTrack, getGenomicChannelFromTrack, getGenomicChannelKeyFromTrack } from './utils/validate';
 import {
@@ -636,8 +637,11 @@ export class GoslingTrackModel {
                         channel.domain = getNumericDomain(channel.domain);
                     }
 
-                    if (channelKey === 'color' && channel.type === 'quantitative' && !(channel as Color).scaleOffset) {
-                        (channel as Color).scaleOffset = [0, 1];
+                    if (
+                        channelKey === 'color' ||
+                        (channelKey === 'stroke' && channel.type === 'quantitative' && !(channel as Color).scaleOffset)
+                    ) {
+                        (channel as Color | Stroke).scaleOffset = [0, 1];
                     }
 
                     if (!channel.range) {

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -309,10 +309,8 @@ export class GoslingTrackModel {
                     const s = (this.channelScales[channelKey] as ScaleSequential<any>).copy();
                     const d = s.domain();
                     const e = d[1] - d[0];
-                    return s.domain([
-                        d[0] + e * ((channel as Color).scaleOffset ?? [0, 1])[0],
-                        d[0] + e * ((channel as Color).scaleOffset ?? [0, 1])[1]
-                    ])(value as number);
+                    const so = Array.from((channel as Color).scaleOffset ?? [0, 1]);
+                    return s.domain([d[0] + e * so.sort()[0], d[0] + e * so.sort()[1]])(value as number);
                 }
                 if (channelFieldType === 'nominal') {
                     return (this.channelScales[channelKey] as ScaleOrdinal<any, any>)(value as string);

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -296,14 +296,6 @@ export class GoslingTrackModel {
                 }
                 break;
             case 'stroke':
-                if (channelFieldType === 'quantitative') {
-                    return (this.channelScales[channelKey] as ScaleSequential<any>)(value as number);
-                }
-                if (channelFieldType === 'nominal') {
-                    return (this.channelScales[channelKey] as ScaleOrdinal<any, any>)(value as string);
-                }
-                /* genomic is not supported */
-                break;
             case 'color':
                 if (channelFieldType === 'quantitative') {
                     const s = (this.channelScales[channelKey] as ScaleSequential<any>).copy();

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -1,5 +1,13 @@
 import * as uuid from 'uuid';
-import { ChannelDeep, PREDEFINED_COLORS, ChannelTypes, ChannelValue, SingleTrack, Channel } from './gosling.schema';
+import {
+    ChannelDeep,
+    PREDEFINED_COLORS,
+    ChannelTypes,
+    ChannelValue,
+    SingleTrack,
+    Channel,
+    Color
+} from './gosling.schema';
 import { validateTrack, getGenomicChannelFromTrack, getGenomicChannelKeyFromTrack } from './utils/validate';
 import {
     ScaleLinear,
@@ -287,10 +295,24 @@ export class GoslingTrackModel {
                     return (this.channelScales[channelKey] as ScaleBand<any>)(value as string);
                 }
                 break;
-            case 'color':
             case 'stroke':
                 if (channelFieldType === 'quantitative') {
                     return (this.channelScales[channelKey] as ScaleSequential<any>)(value as number);
+                }
+                if (channelFieldType === 'nominal') {
+                    return (this.channelScales[channelKey] as ScaleOrdinal<any, any>)(value as string);
+                }
+                /* genomic is not supported */
+                break;
+            case 'color':
+                if (channelFieldType === 'quantitative') {
+                    const s = (this.channelScales[channelKey] as ScaleSequential<any>).copy();
+                    const d = s.domain();
+                    const e = d[1] - d[0];
+                    return s.domain([
+                        d[0] + e * ((channel as Color).scaleOffset ?? [0, 1])[0],
+                        d[0] + e * ((channel as Color).scaleOffset ?? [0, 1])[1]
+                    ])(value as number);
                 }
                 if (channelFieldType === 'nominal') {
                     return (this.channelScales[channelKey] as ScaleOrdinal<any, any>)(value as string);
@@ -622,6 +644,10 @@ export class GoslingTrackModel {
                         channel.domain = [min, max]; // TODO: what if data ranges in negative values
                     } else if (channel.type === 'genomic' && !IsDomainArray(channel.domain)) {
                         channel.domain = getNumericDomain(channel.domain);
+                    }
+
+                    if (channelKey === 'color' && channel.type === 'quantitative' && !(channel as Color).scaleOffset) {
+                        (channel as Color).scaleOffset = [0, 1];
                     }
 
                     if (!channel.range) {

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -579,6 +579,8 @@ export interface Color extends ChannelDeepCommon {
     legend?: boolean;
 
     scale?: 'linear' | 'log';
+    /** Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]` */
+    scaleOffset?: [number, number];
 }
 
 export interface Size extends ChannelDeepCommon {

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -575,6 +575,8 @@ export interface Color extends ChannelDeepCommon {
     domain?: ValueExtent;
     /** Determine the colors that should be bound to data value. Default properties are determined considering the field type. */
     range?: Range;
+    /** Title of the legend. __Default__: `undefined` */
+    title?: string;
     /** Whether to display legend. __Default__: `false` */
     legend?: boolean;
 
@@ -583,24 +585,30 @@ export interface Color extends ChannelDeepCommon {
     scaleOffset?: [number, number];
 }
 
-export interface Size extends ChannelDeepCommon {
-    type?: 'quantitative' | 'nominal';
-    domain?: ValueExtent;
-    range?: ValueExtent;
-    /** not supported: Whether to display legend. __Default__: `false` */
-    legend?: boolean;
-}
-
 export interface Stroke extends ChannelDeepCommon {
     type?: 'quantitative' | 'nominal';
     domain?: ValueExtent;
     range?: Range;
+    /** Title of the legend. __Default__: `undefined` */
+    title?: string;
+    /** Whether to display legend. __Default__: `false` */
+    legend?: boolean;
+    /** Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]` */
+    scaleOffset?: [number, number];
 }
 
 export interface StrokeWidth extends ChannelDeepCommon {
     type?: 'quantitative' | 'nominal';
     domain?: ValueExtent;
     range?: ValueExtent;
+}
+
+export interface Size extends ChannelDeepCommon {
+    type?: 'quantitative' | 'nominal';
+    domain?: ValueExtent;
+    range?: ValueExtent;
+    /** not supported: Whether to display legend. __Default__: `false` */
+    legend?: boolean;
 }
 
 export interface Opacity extends ChannelDeepCommon {

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -15,6 +15,11 @@ export function drawColorLegend(
     tm: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>
 ) {
+    if (!trackInfo.gMain) {
+        // We do not have enough components to draw legends
+        return;
+    }
+
     trackInfo.gMain.selectAll('.brush').remove();
 
     const spec = tm.spec();

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -90,13 +90,14 @@ export function drawColorLegendQuantitative(
     [...Array(colorBarDim.height).keys()].forEach(y => {
         // For each pixel, draw a small rectangle with different color
         let value;
-        if (y / colorBarDim.height >= scaleOffset[1]) {
+        const scaleOffsetSorted = Array.from(scaleOffset).sort();
+        if (y / colorBarDim.height >= scaleOffsetSorted[1]) {
             value = endValue;
-        } else if (y / colorBarDim.height <= scaleOffset[0]) {
+        } else if (y / colorBarDim.height <= scaleOffsetSorted[0]) {
             value = startValue;
         } else {
             const s1 = scaleLinear()
-                .domain([colorBarDim.height * scaleOffset[0], colorBarDim.height * scaleOffset[1]])
+                .domain([colorBarDim.height * scaleOffsetSorted[0], colorBarDim.height * scaleOffsetSorted[1]])
                 .range([0, colorBarDim.height]);
             const s2 = scaleLinear().domain([0, colorBarDim.height]).range([startValue, endValue]);
             value = s2(s1(y));
@@ -126,6 +127,7 @@ export function drawColorLegendQuantitative(
     trackInfo.gMain.selectAll('.brush').remove();
     trackInfo.colorBrushes = trackInfo.gMain
         .selectAll('.brush')
+        // We could consider using `_renderingId` to support multiple color legends in overlaid tracks.
         .data(
             scaleOffset.map((d, i) => {
                 return { y: d, id: i };

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -168,7 +168,7 @@ export function drawColorLegendQuantitative(
                         newScaleOffset[1] = Math.min(1, Math.max(0, newScaleOffset[1]));
                         trackInfo.updateScaleOffsetFromOriginalSpec(spec._renderingId, newScaleOffset);
                         trackInfo.shareScaleOffsetAcrossTracksAndTiles(newScaleOffset);
-                        trackInfo.draw(); // TODO: share across tile models
+                        trackInfo.draw();
                         trackInfo.startEvent = HGC.libraries.d3Selection.event.sourceEvent;
                     }
                 })

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -158,16 +158,18 @@ export function drawColorLegendQuantitative(
                     if (IsChannelDeep(spec.color) && spec.color.scaleOffset) {
                         const endEvent = HGC.libraries.d3Selection.event.sourceEvent;
                         const diffY = trackInfo.startEvent.clientY - endEvent.clientY;
+                        const newScaleOffset = [spec.color.scaleOffset[0], spec.color.scaleOffset[1]];
                         if (d.id === 0) {
-                            spec.color.scaleOffset[0] += diffY / colorBarDim.height;
+                            newScaleOffset[0] += diffY / colorBarDim.height;
                         } else {
-                            spec.color.scaleOffset[1] += diffY / colorBarDim.height;
+                            newScaleOffset[1] += diffY / colorBarDim.height;
                         }
-                        spec.color.scaleOffset[0] = Math.min(1, Math.max(0, spec.color.scaleOffset[0]));
-                        spec.color.scaleOffset[1] = Math.min(1, Math.max(0, spec.color.scaleOffset[1]));
-                        trackInfo.startEvent = HGC.libraries.d3Selection.event.sourceEvent;
-                        trackInfo.shareScaleOffsetAcrossTracksAndTiles(spec.color.scaleOffset);
+                        newScaleOffset[0] = Math.min(1, Math.max(0, newScaleOffset[0]));
+                        newScaleOffset[1] = Math.min(1, Math.max(0, newScaleOffset[1]));
+                        trackInfo.updateScaleOffsetFromOriginalSpec(spec._renderingId, newScaleOffset);
+                        trackInfo.shareScaleOffsetAcrossTracksAndTiles(newScaleOffset);
                         trackInfo.draw(); // TODO: share across tile models
+                        trackInfo.startEvent = HGC.libraries.d3Selection.event.sourceEvent;
                     }
                 })
         );

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -27,7 +27,7 @@ import { getTabularData } from './data-abstraction';
 import { BAMDataFetcher } from '../data-fetcher/bam';
 import { getRelativeGenomicPosition } from '../core/utils/assembly';
 import { getTextStyle } from '../core/utils/text-style';
-import { Is2DTrack, IsXAxis } from '../core/gosling.schema.guards';
+import { Is2DTrack, IsChannelDeep, IsXAxis } from '../core/gosling.schema.guards';
 import { spawn } from 'threads';
 
 import BamWorker from '../data-fetcher/bam/bam-worker.js?worker&inline';
@@ -117,6 +117,9 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             // Graphics for highlighting visual elements under the cursor
             this.mouseOverGraphics = new HGC.libraries.PIXI.Graphics();
             this.pMain.addChild(this.mouseOverGraphics);
+
+            // Brushes on the color legend
+            this.gMain = HGC.libraries.d3Selection.select(this.context.svgElement).append('g');
 
             // Enable click event
             this.pMask.interactive = true;
@@ -647,6 +650,23 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
                 // Store raw data
                 t.gos.raw = Array.from(t.tileData);
+            });
+        }
+
+        shareScaleOffsetAcrossTracksAndTiles(scaleOffset: [number, number]) {
+            const gms: GoslingTrackModel[] = [];
+            this.visibleAndFetchedTiles().forEach((tile: any) => {
+                gms.push(...tile.goslingModels);
+            });
+            gms.forEach(d => {
+                const colorChannel = d.spec().color;
+                if (IsChannelDeep(colorChannel)) {
+                    colorChannel.scaleOffset = scaleOffset;
+                }
+                const colorChannelOriginal = d.originalSpec().color;
+                if (IsChannelDeep(colorChannelOriginal)) {
+                    colorChannelOriginal.scaleOffset = scaleOffset;
+                }
             });
         }
 

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -308,6 +308,13 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             this.forceDraw();
         }
 
+        remove() {
+            super.remove();
+
+            if (this.gMain) {
+                this.gMain.selectAll('.brush').remove();
+            }
+        }
         /*
          * Rerender all tiles when track size is changed.
          * (Refer to https://github.com/higlass/higlass/blob/54f5aae61d3474f9e868621228270f0c90ef9343/app/scripts/PixiTrack.js#L186).

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -91,7 +91,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             context.dataFetcher.track = this;
             this.context = context;
 
-            // Temp. Add ids to each overalid tracks that will be rendered independently
+            // Temp. Add ids to each overlaid tracks that will be rendered independently
             if ('overlay' in this.options.spec) {
                 this.options.spec.overlay = (this.options.spec as OverlaidTrack).overlay.map(o => {
                     return { ...o, _renderingId: uuid.v1() };
@@ -102,7 +102,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
             this.tileSize = this.tilesetInfo?.tile_size ?? 1024;
 
-            // This tracks the xScale of an entire view, which is used when no tiling concepts are used
+            // This is tracking the xScale of an entire view, which is used when no tiling concepts are used
             this.drawnAtScale = HGC.libraries.d3Scale.scaleLinear();
             this.scalableGraphics = {};
 
@@ -650,6 +650,17 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
                 // Store raw data
                 t.gos.raw = Array.from(t.tileData);
+            });
+        }
+
+        updateScaleOffsetFromOriginalSpec(_renderingId: string, scaleOffset: [number, number]) {
+            resolveSuperposedTracks(this.options.spec).map(spec => {
+                if (spec._renderingId === _renderingId) {
+                    const color = spec.color;
+                    if (IsChannelDeep(color)) {
+                        color.scaleOffset = scaleOffset;
+                    }
+                }
             });
         }
 

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -653,30 +653,34 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             });
         }
 
-        updateScaleOffsetFromOriginalSpec(_renderingId: string, scaleOffset: [number, number]) {
+        updateScaleOffsetFromOriginalSpec(
+            _renderingId: string,
+            scaleOffset: [number, number],
+            channelKey: 'color' | 'stroke'
+        ) {
             resolveSuperposedTracks(this.options.spec).map(spec => {
                 if (spec._renderingId === _renderingId) {
-                    const color = spec.color;
-                    if (IsChannelDeep(color)) {
-                        color.scaleOffset = scaleOffset;
+                    const channel = spec[channelKey];
+                    if (IsChannelDeep(channel)) {
+                        channel.scaleOffset = scaleOffset;
                     }
                 }
             });
         }
 
-        shareScaleOffsetAcrossTracksAndTiles(scaleOffset: [number, number]) {
+        shareScaleOffsetAcrossTracksAndTiles(scaleOffset: [number, number], channelKey: 'color' | 'stroke') {
             const gms: GoslingTrackModel[] = [];
             this.visibleAndFetchedTiles().forEach((tile: any) => {
                 gms.push(...tile.goslingModels);
             });
             gms.forEach(d => {
-                const colorChannel = d.spec().color;
-                if (IsChannelDeep(colorChannel)) {
-                    colorChannel.scaleOffset = scaleOffset;
+                const channel = d.spec()[channelKey];
+                if (IsChannelDeep(channel)) {
+                    channel.scaleOffset = scaleOffset;
                 }
-                const colorChannelOriginal = d.originalSpec().color;
-                if (IsChannelDeep(colorChannelOriginal)) {
-                    colorChannelOriginal.scaleOffset = scaleOffset;
+                const channelOriginal = d.originalSpec()[channelKey];
+                if (IsChannelDeep(channelOriginal)) {
+                    channelOriginal.scaleOffset = scaleOffset;
                 }
             });
         }


### PR DESCRIPTION
Gosling also exposes `scaleOffset` (`[number, number]` default `[0, 1]`) which controls the position of the brush.

![Screen Shot 2022-04-21 at 11 53 28](https://user-images.githubusercontent.com/9922882/164502479-5ffcde6d-e084-4bf2-8139-2f9d56acb828.png)

```js
{
  "title": "Visual Encoding",
  "subtitle": "Gosling provides diverse visual encoding methods",
  "layout": "linear",
  "arrangement": "vertical",
  "centerRadius": 0.8,
  "xDomain": {"chromosome": "1", "interval": [1, 3000500]},
  "views": [
    {
      "tracks": [
        {
          "id": "track-1",
          "data": {
            "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
            "type": "multivec",
            "row": "sample",
            "column": "position",
            "value": "peak",
            "categories": ["sample 1", "sample 2", "sample 3", "sample 4"],
            "binSize": 4
          },
          "mark": "point",
          "x": {"field": "start", "type": "genomic", "axis": "top"},
          "xe": {"field": "end", "type": "genomic"},
          "y": {"field": "peak", "type": "quantitative", "legend": true},
          "size": {"field": "peak", "type": "quantitative" },
          "color": {"field": "peak", "type": "quantitative", "title": "color", "legend": true, "scaleOffset": [0, 0.4]},
          "stroke": {"field": "peak", "type": "quantitative", "title": "stroke", "legend": true, "scaleOffset": [0.3, 0.6]},
          "strokeWidth": {"value": 2},
          "width": 600,
          "height": 130
        }
      ]
    }
  ]
}
```