### PR TITLE
feat: add data transform to infer sv types

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -705,6 +705,9 @@
           "$ref": "#/definitions/GenomicLengthTransform"
         },
         {
+          "$ref": "#/definitions/SvTypeTransform"
+        },
+        {
           "$ref": "#/definitions/CoverageTransform"
         },
         {
@@ -8110,6 +8113,67 @@
           "type": "number"
         }
       },
+      "type": "object"
+    },
+    "SvTypeTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "firstBp": {
+          "additionalProperties": false,
+          "description": "Based on the BEDPE, infer SV types.  SV types are specified as one of the following strings: DUP, TRA, DEL, t2tINV, h2hINV.",
+          "properties": {
+            "chrField": {
+              "type": "string"
+            },
+            "posField": {
+              "type": "string"
+            },
+            "strandField": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "chrField",
+            "posField",
+            "strandField"
+          ],
+          "type": "object"
+        },
+        "newField": {
+          "type": "string"
+        },
+        "secondBp": {
+          "additionalProperties": false,
+          "description": "Based on the BEDPE, infer SV types.  SV types are specified as one of the following strings: DUP, TRA, DEL, t2tINV, h2hINV.",
+          "properties": {
+            "chrField": {
+              "type": "string"
+            },
+            "posField": {
+              "type": "string"
+            },
+            "strandField": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "chrField",
+            "posField",
+            "strandField"
+          ],
+          "type": "object"
+        },
+        "type": {
+          "const": "svType",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "firstBp",
+        "secondBp",
+        "newField"
+      ],
       "type": "object"
     },
     "TemplateTrack": {

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -224,6 +224,27 @@
             }
           ]
         },
+        "firstBp": {
+          "additionalProperties": false,
+          "description": "Based on the BEDPE, infer SV types.  SV types are specified as one of the following strings: DUP, TRA, DEL, t2tINV, h2hINV.",
+          "properties": {
+            "chrField": {
+              "type": "string"
+            },
+            "posField": {
+              "type": "string"
+            },
+            "strandField": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "chrField",
+            "posField",
+            "strandField"
+          ],
+          "type": "object"
+        },
         "flag": {
           "additionalProperties": false,
           "properties": {
@@ -317,6 +338,27 @@
           },
           "type": "array"
         },
+        "secondBp": {
+          "additionalProperties": false,
+          "description": "Based on the BEDPE, infer SV types.  SV types are specified as one of the following strings: DUP, TRA, DEL, t2tINV, h2hINV.",
+          "properties": {
+            "chrField": {
+              "type": "string"
+            },
+            "posField": {
+              "type": "string"
+            },
+            "strandField": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "chrField",
+            "posField",
+            "strandField"
+          ],
+          "type": "object"
+        },
         "separator": {
           "type": "string"
         },
@@ -332,6 +374,7 @@
             "displace",
             "exonSplit",
             "genomicLength",
+            "svType",
             "coverage",
             "subjson"
           ],

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -954,6 +954,7 @@ export type DataTransform =
     | DisplaceTransform
     | ExonSplitTransform
     | GenomicLengthTransform
+    | SvTypeTransform
     | CoverageTransform
     | JSONParseTransform;
 
@@ -1065,6 +1066,22 @@ export interface GenomicLengthTransform {
     type: 'genomicLength';
     startField: string;
     endField: string;
+    newField: string;
+}
+
+/**
+ * Based on the BEDPE, infer SV types.
+ * SV types are specified as one of the following strings: DUP, TRA, DEL, t2tINV, h2hINV.
+ */
+type BpFields = {
+    chrField: string;
+    posField: string;
+    strandField: string;
+};
+export interface SvTypeTransform {
+    type: 'svType';
+    firstBp: BpFields;
+    secondBp: BpFields;
     newField: string;
 }
 

--- a/src/core/utils/data-transform.test.ts
+++ b/src/core/utils/data-transform.test.ts
@@ -1,4 +1,4 @@
-import { filterData, calculateData, aggregateData, splitExon } from './data-transform';
+import { filterData, calculateData, aggregateData, splitExon, inferSvType } from './data-transform';
 
 describe('Data Transformation', () => {
     it('Filter', () => {
@@ -11,6 +11,60 @@ describe('Data Transformation', () => {
         expect(filtered).toHaveLength(2);
         expect(filtered.filter(d => d['c'] === 'b')).toHaveLength(0);
         expect(filtered.filter(d => d['q'] === 4)).toHaveLength(0);
+    });
+    it('SV', () => {
+        const svTypes = inferSvType(
+            {
+                type: 'svType',
+                firstBp: { chrField: 'chr1', posField: 'start1', strandField: 'strand1' },
+                secondBp: { chrField: 'chr2', posField: 'start2', strandField: 'strand2' },
+                newField: 'svclass'
+            },
+            [
+                {
+                    chr1: 7,
+                    start1: 51456884,
+                    chr2: 7,
+                    start2: 51457472,
+                    strand1: '+',
+                    strand2: '-'
+                },
+                {
+                    chr1: 10,
+                    start1: 72295397,
+                    chr2: 10,
+                    start2: 1000,
+                    strand1: '-',
+                    strand2: '-'
+                },
+                {
+                    chr1: 10,
+                    start1: 133252888,
+                    chr2: 10,
+                    start2: 1000,
+                    strand1: '+',
+                    strand2: '-'
+                },
+                {
+                    chr1: 10,
+                    start1: 134996297,
+                    chr2: 10,
+                    start2: 134996635,
+                    strand1: '+',
+                    strand2: '+'
+                },
+                {
+                    chr1: 1,
+                    start1: 169963,
+                    chr2: 2,
+                    start2: 170300,
+                    strand1: '+',
+                    strand2: '-'
+                }
+            ]
+        );
+        expect(svTypes).toHaveLength(5);
+        expect(svTypes.map(d => d['svclass'])).toEqual(['DEL', 't2tINV', 'DUP', 'h2hINV', 'TRA']);
     });
     it('Log', () => {
         {

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -10,6 +10,7 @@ import {
     StrConcatTransform,
     StrReplaceTransform,
     GenomicLengthTransform,
+    SvTypeTransform,
     CoverageTransform,
     DisplaceTransform,
     JSONParseTransform
@@ -118,6 +119,58 @@ export function calculateGenomicLength(_: GenomicLengthTransform, data: Datum[])
             return;
         }
         d[newField] = Math.abs(+e - +s);
+    });
+    return output;
+}
+
+/*
+ * Infer SV types (i.e., one of DUP, TRA, DEL, t2tINV, h2hINV).
+ */
+export function inferSvType(_: SvTypeTransform, data: Datum[]): Datum[] {
+    const { firstBp, secondBp, newField } = _;
+    const output = Array.from(data);
+    const [DUP, TRA, DEL, t2tINV, h2hINV] = ['DUP', 'TRA', 'DEL', 't2tINV', 'h2hINV'];
+
+    output.forEach(d => {
+        const chr1 = d[firstBp.chrField];
+        const chr2 = d[secondBp.chrField];
+
+        if (chr1 !== chr2) {
+            d[newField] = TRA;
+            return;
+        }
+
+        let pos1 = d[firstBp.posField];
+        let pos2 = d[secondBp.posField];
+        let strand1 = d[firstBp.strandField];
+        let strand2 = d[secondBp.strandField];
+
+        if (pos1 > pos2) {
+            // need to sort first
+            const _pos = pos1;
+            const _strand = strand1;
+            pos1 = pos2;
+            strand1 = strand2;
+            pos2 = _pos;
+            strand2 = _strand;
+        }
+
+        switch (`${strand1}${strand2}`) {
+            case '+-':
+                d[newField] = DEL;
+                break;
+            case '--':
+                d[newField] = t2tINV;
+                break;
+            case '++':
+                d[newField] = h2hINV;
+                break;
+            case '-+':
+                d[newField] = DUP;
+                break;
+            default:
+                d[newField] = 'unknown';
+        }
     });
     return output;
 }

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -21,7 +21,8 @@ import {
     calculateGenomicLength,
     parseSubJSON,
     replaceString,
-    splitExon
+    splitExon,
+    inferSvType
 } from '../core/utils/data-transform';
 import { getTabularData } from './data-abstraction';
 import { BAMDataFetcher } from '../data-fetcher/bam';
@@ -874,6 +875,9 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                                 break;
                             case 'genomicLength':
                                 tile.gos.tabularDataFiltered = calculateGenomicLength(t, tile.gos.tabularDataFiltered);
+                                break;
+                            case 'svType':
+                                tile.gos.tabularDataFiltered = inferSvType(t, tile.gos.tabularDataFiltered);
                                 break;
                             case 'coverage':
                                 tile.gos.tabularDataFiltered = aggregateCoverage(


### PR DESCRIPTION
```js
{
  "type": "svType",
  "firstBp": {
    "chrField": "chr1",
    "posField": "start1",
    "strandField": "strand1"
  },
  "secondBp": {
    "chrField": "chr2",
    "posField": "start2",
    "strandField": "strand2"
  },
   "newField": "svclass2"
}
```