### PR TITLE
fix: remove legend layer in `remove()`; do not render twice on Editor when example ID is specified in URL

### DIFF
--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -201,9 +201,9 @@ function Editor(props: any) {
     const urlGist = urlParams?.gist ?? null;
     const urlExampleId = (urlParams?.example ?? '') as string;
 
-    const defaultCode = urlGist ? emptySpec() : stringify(urlSpec ?? (INIT_DEMO.spec as gosling.GoslingSpec));
-
-    const defaultJsCode = INIT_DEMO.specJs ?? json2js(defaultCode);
+    const defaultCode =
+        urlGist || urlExampleId ? emptySpec() : stringify(urlSpec ?? (INIT_DEMO.spec as gosling.GoslingSpec));
+    const defaultJsCode = urlGist || urlExampleId || !INIT_DEMO.specJs ? json2js(defaultCode) : INIT_DEMO.specJs;
 
     const previewData = useRef<PreviewData[]>([]);
     const [refreshData, setRefreshData] = useState<boolean>(false);

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -313,7 +313,8 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             super.remove();
 
             if (this.gLegend) {
-                this.gLegend.selectAll('.brush').remove();
+                this.gLegend.remove();
+                this.gLegend = null;
             }
         }
         /*


### PR DESCRIPTION
Fix #685