### PR TITLE
feat: genomic range selection in linear tracks

### DIFF
--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -26,7 +26,6 @@ import type { HiGlassSpec } from '@higlass.schema';
 import type { Datum } from '@gosling.schema';
 
 import './editor.css';
-import { RangeMouseEventData } from 'src/core/api';
 
 function json2js(jsonCode: string) {
     return `var spec = ${jsonCode} \nexport { spec }; \n`;
@@ -288,21 +287,21 @@ function Editor(props: RouteComponentProps) {
     // publish event listeners to Gosling.js
     useEffect(() => {
         if (gosRef.current) {
-            // gosRef.current.api.subscribe('rawdata', (type: string, data: RawDataEventData) => {
+            // gosRef.current.api.subscribe('rawdata', (type, data) => {
             // console.log('rawdata', data);
             // gosRef.current.api.zoomTo('bam-1', `chr${data.data.chr1}:${data.data.start1}-${data.data.end1}`, 2000);
             // gosRef.current.api.zoomTo('bam-2', `chr${data.data.chr2}:${data.data.start2}-${data.data.end2}`, 2000);
             // console.log('click', data.data);
             // TODO: show messages on the right-bottom of the editor
-            // gosRef.current.api.subscribe('mouseover', (type: string, eventData: CommonEventData) => {
+            // gosRef.current.api.subscribe('mouseover', (type, eventData) => {
             //     setMouseEventInfo({ type: 'mouseover', data: eventData.data, position: eventData.genomicPosition });
             // });
-            // gosRef.current.api.subscribe('click', (type: string, eventData: CommonEventData) => {
+            // gosRef.current.api.subscribe('click', (type, eventData) => {
             //     setMouseEventInfo({ type: 'click', data: eventData.data, position: eventData.genomicPosition });
             // });
 
             // Range Select API
-            gosRef.current.api.subscribe('rangeselect', (type: string, eventData: RangeMouseEventData) => {
+            gosRef.current.api.subscribe('rangeselect', (type, eventData) => {
                 console.warn(type, eventData.id, eventData.genomicRange, eventData.data);
             });
         }

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -326,16 +326,15 @@ function Editor(props: RouteComponentProps) {
             // gosRef.current.api.subscribe('click', (type, eventData) => {
             //     setMouseEventInfo({ type: 'click', data: eventData.data, position: eventData.genomicPosition });
             // });
-
             // Range Select API
-            gosRef.current.api.subscribe('rangeselect', (type, eventData) => {
-                console.warn(type, eventData.id, eventData.genomicRange, eventData.data);
-            });
+            // gosRef.current.api.subscribe('rangeselect', (type, eventData) => {
+            //     console.warn(type, eventData.id, eventData.genomicRange, eventData.data);
+            // });
         }
         return () => {
             // gosRef.current.api.unsubscribe('mouseover');
             // gosRef.current.api.unsubscribe('click');
-            gosRef.current?.api.unsubscribe('rangeselect');
+            // gosRef.current?.api.unsubscribe('rangeselect');
         };
     }, [gosRef.current]);
 

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -26,7 +26,7 @@ import type { HiGlassSpec } from '@higlass.schema';
 import type { Datum } from '@gosling.schema';
 
 import './editor.css';
-import { RangeSelectEventData } from 'src/core/api';
+import { RangeMouseEventData } from 'src/core/api';
 
 function json2js(jsonCode: string) {
     return `var spec = ${jsonCode} \nexport { spec }; \n`;
@@ -302,14 +302,14 @@ function Editor(props: RouteComponentProps) {
             // });
 
             // Range Select API
-            gosRef.current.api.subscribe('rangeselect', (type: string, eventData: RangeSelectEventData) => {
-                console.warn(type, eventData.genomicRange, eventData.data);
+            gosRef.current.api.subscribe('rangeselect', (type: string, eventData: RangeMouseEventData) => {
+                console.warn(type, eventData.id, eventData.genomicRange, eventData.data);
             });
         }
         return () => {
             // gosRef.current.api.unsubscribe('mouseover');
             // gosRef.current.api.unsubscribe('click');
-            // gosRef.current.api.unsubscribe('rangeselect');
+            gosRef.current?.api.unsubscribe('rangeselect');
         };
     }, [gosRef.current]);
 

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -26,6 +26,7 @@ import type { HiGlassSpec } from '@higlass.schema';
 import type { Datum } from '@gosling.schema';
 
 import './editor.css';
+import { RangeSelectEventData } from 'src/core/api';
 
 function json2js(jsonCode: string) {
     return `var spec = ${jsonCode} \nexport { spec }; \n`;
@@ -299,10 +300,16 @@ function Editor(props: RouteComponentProps) {
             // gosRef.current.api.subscribe('click', (type: string, eventData: CommonEventData) => {
             //     setMouseEventInfo({ type: 'click', data: eventData.data, position: eventData.genomicPosition });
             // });
+
+            // Range Select API
+            gosRef.current.api.subscribe('rangeselect', (type: string, eventData: RangeSelectEventData) => {
+                console.warn(type, eventData.genomicRange, eventData.data);
+            });
         }
         return () => {
             // gosRef.current.api.unsubscribe('mouseover');
             // gosRef.current.api.unsubscribe('click');
+            // gosRef.current.api.unsubscribe('rangeselect');
         };
     }, [gosRef.current]);
 

--- a/editor/example/index.ts
+++ b/editor/example/index.ts
@@ -322,7 +322,7 @@ export const examples: {
     },
     MOUSE_EVENT: {
         group: 'Visual Encoding',
-        name: 'Mouse Hovering Effects',
+        name: 'Custom Mouse Events',
         spec: EX_SPEC_MOUSE_EVENT,
         underDevelopment: true,
         image: THUMBNAILS.MOUSE_EVENT

--- a/editor/example/json-spec/mouse-event.ts
+++ b/editor/example/json-spec/mouse-event.ts
@@ -59,9 +59,8 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                     title: 'Group Hovering By Sample',
                     ...BAR,
                     experimental: {
+                        groupMarksByField: 'sample',
                         hovering: {
-                            enableGroupHovering: true,
-                            searchGroupByField: 'sample',
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
@@ -76,9 +75,8 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                     title: 'Group Hovering By Genomic Position',
                     ...BAR,
                     experimental: {
+                        groupMarksByField: 'position',
                         hovering: {
-                            enableGroupHovering: true,
-                            searchGroupByField: 'position',
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
@@ -128,8 +126,8 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                     width: BAR.width,
                     height: BAR.height,
                     experimental: {
+                        groupMarksByField: 'name',
                         hovering: {
-                            enableGroupHovering: true,
                             showHoveringOnTheBack: true,
                             color: '#E0E0E0',
                             stroke: '#E0E0E0',
@@ -149,9 +147,8 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                     height: 60,
                     tooltip: [{ field: 'Chr.', type: 'nominal' }],
                     experimental: {
+                        groupMarksByField: 'Chr.',
                         hovering: {
-                            enableGroupHovering: true,
-                            searchGroupByField: 'Chr.',
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0

--- a/editor/example/json-spec/mouse-event.ts
+++ b/editor/example/json-spec/mouse-event.ts
@@ -34,20 +34,28 @@ export const BAR: SingleTrack = {
 };
 
 export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
-    title: 'Mouse Hover Effects',
-    subtitle: 'Customize mouse hovering events reflecting on your use cases!',
+    title: 'Custom Mouse Events',
+    subtitle: 'Customize mouse hovering and range selection events',
     xDomain: { chromosome: '1' },
     views: [
         {
             tracks: [
                 {
-                    title: 'Hover Individual Marks',
+                    title: 'Individual Marks',
                     ...BAR,
                     experimental: {
                         hovering: {
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
+                        },
+                        selection: {
+                            color: 'red',
+                            opacity: 0.5
+                        },
+                        brush: {
+                            color: 'purple',
+                            stroke: 'purple'
                         }
                     }
                 }
@@ -56,7 +64,7 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
         {
             tracks: [
                 {
-                    title: 'Group Hovering By Sample',
+                    title: 'Group Marks By Sample',
                     ...BAR,
                     experimental: {
                         groupMarksByField: 'sample',
@@ -64,6 +72,14 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
+                        },
+                        selection: {
+                            color: 'red',
+                            opacity: 0.5
+                        },
+                        brush: {
+                            color: 'green',
+                            stroke: 'green'
                         }
                     }
                 }
@@ -72,7 +88,7 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
         {
             tracks: [
                 {
-                    title: 'Group Hovering By Genomic Position',
+                    title: 'Group Marks By Genomic Position',
                     ...BAR,
                     experimental: {
                         groupMarksByField: 'position',
@@ -80,6 +96,14 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
+                        },
+                        selection: {
+                            color: 'red',
+                            opacity: 0.5
+                        },
+                        brush: {
+                            color: 'yellow',
+                            stroke: 'yellow'
                         }
                     }
                 }
@@ -89,7 +113,7 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
             xDomain: { chromosome: '3', interval: [52168000, 52890000] },
             tracks: [
                 {
-                    title: 'Group Hovering By Gene',
+                    title: 'Group Marks By Gene',
                     template: 'gene',
                     data: {
                         url: GOSLING_PUBLIC_DATA.geneAnnotation,
@@ -132,6 +156,12 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                             color: '#E0E0E0',
                             stroke: '#E0E0E0',
                             strokeWidth: 4
+                        },
+                        selection: {
+                            showOnTheBack: true,
+                            color: '#B9D4FA',
+                            stroke: '#B9D4FA',
+                            strokeWidth: 4
                         }
                     }
                 }
@@ -141,7 +171,7 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
             xDomain: { interval: [1, 1000000000] },
             tracks: [
                 {
-                    title: 'Group Hovering By Chromosome',
+                    title: 'Group Marks By Chromosome',
                     ...CytoBands,
                     size: { value: 20 },
                     height: 60,
@@ -150,6 +180,11 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                         groupMarksByField: 'Chr.',
                         hovering: {
                             color: 'blue',
+                            opacity: 0.5,
+                            strokeWidth: 0
+                        },
+                        selection: {
+                            color: 'red',
                             opacity: 0.5,
                             strokeWidth: 0
                         }

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1092,6 +1092,27 @@
             "experimental": {
               "additionalProperties": false,
               "properties": {
+                "brush": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
                 "hovering": {
                   "additionalProperties": false,
                   "properties": {
@@ -1112,6 +1133,27 @@
                     },
                     "showHoveringOnTheBack": {
                       "type": "boolean"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "selection": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
                     },
                     "stroke": {
                       "type": "string"
@@ -1261,6 +1303,27 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
+                          "brush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
@@ -1281,6 +1344,27 @@
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selection": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
                               },
                               "stroke": {
                                 "type": "string"
@@ -1896,6 +1980,27 @@
             "experimental": {
               "additionalProperties": false,
               "properties": {
+                "brush": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
                 "hovering": {
                   "additionalProperties": false,
                   "properties": {
@@ -1916,6 +2021,27 @@
                     },
                     "showHoveringOnTheBack": {
                       "type": "boolean"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "selection": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
                     },
                     "stroke": {
                       "type": "string"
@@ -2065,6 +2191,27 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
+                          "brush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
@@ -2085,6 +2232,27 @@
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selection": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
                               },
                               "stroke": {
                                 "type": "string"
@@ -2751,6 +2919,27 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
+                          "brush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
@@ -2771,6 +2960,27 @@
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selection": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
                               },
                               "stroke": {
                                 "type": "string"
@@ -3964,6 +4174,27 @@
         "experimental": {
           "additionalProperties": false,
           "properties": {
+            "brush": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
             "hovering": {
               "additionalProperties": false,
               "properties": {
@@ -3984,6 +4215,27 @@
                 },
                 "showHoveringOnTheBack": {
                   "type": "boolean"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "selection": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
                 },
                 "stroke": {
                   "type": "string"
@@ -4102,6 +4354,27 @@
               "experimental": {
                 "additionalProperties": false,
                 "properties": {
+                  "brush": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "color": {
+                        "type": "string"
+                      },
+                      "opacity": {
+                        "type": "number"
+                      },
+                      "stroke": {
+                        "type": "string"
+                      },
+                      "strokeOpacity": {
+                        "type": "number"
+                      },
+                      "strokeWidth": {
+                        "type": "number"
+                      }
+                    },
+                    "type": "object"
+                  },
                   "hovering": {
                     "additionalProperties": false,
                     "properties": {
@@ -4122,6 +4395,27 @@
                       },
                       "showHoveringOnTheBack": {
                         "type": "boolean"
+                      },
+                      "stroke": {
+                        "type": "string"
+                      },
+                      "strokeOpacity": {
+                        "type": "number"
+                      },
+                      "strokeWidth": {
+                        "type": "number"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "selection": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "color": {
+                        "type": "string"
+                      },
+                      "opacity": {
+                        "type": "number"
                       },
                       "stroke": {
                         "type": "string"
@@ -4689,6 +4983,27 @@
         "experimental": {
           "additionalProperties": false,
           "properties": {
+            "brush": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
             "hovering": {
               "additionalProperties": false,
               "properties": {
@@ -4709,6 +5024,27 @@
                 },
                 "showHoveringOnTheBack": {
                   "type": "boolean"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "selection": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
                 },
                 "stroke": {
                   "type": "string"
@@ -5087,6 +5423,27 @@
         "experimental": {
           "additionalProperties": false,
           "properties": {
+            "brush": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
             "hovering": {
               "additionalProperties": false,
               "properties": {
@@ -5107,6 +5464,27 @@
                 },
                 "showHoveringOnTheBack": {
                   "type": "boolean"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "selection": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
                 },
                 "stroke": {
                   "type": "string"
@@ -5225,6 +5603,27 @@
               "experimental": {
                 "additionalProperties": false,
                 "properties": {
+                  "brush": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "color": {
+                        "type": "string"
+                      },
+                      "opacity": {
+                        "type": "number"
+                      },
+                      "stroke": {
+                        "type": "string"
+                      },
+                      "strokeOpacity": {
+                        "type": "number"
+                      },
+                      "strokeWidth": {
+                        "type": "number"
+                      }
+                    },
+                    "type": "object"
+                  },
                   "hovering": {
                     "additionalProperties": false,
                     "properties": {
@@ -5245,6 +5644,27 @@
                       },
                       "showHoveringOnTheBack": {
                         "type": "boolean"
+                      },
+                      "stroke": {
+                        "type": "string"
+                      },
+                      "strokeOpacity": {
+                        "type": "number"
+                      },
+                      "strokeWidth": {
+                        "type": "number"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "selection": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "color": {
+                        "type": "string"
+                      },
+                      "opacity": {
+                        "type": "number"
                       },
                       "stroke": {
                         "type": "string"
@@ -5937,6 +6357,27 @@
         "experimental": {
           "additionalProperties": false,
           "properties": {
+            "brush": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
             "hovering": {
               "additionalProperties": false,
               "properties": {
@@ -5957,6 +6398,27 @@
                 },
                 "showHoveringOnTheBack": {
                   "type": "boolean"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "selection": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
                 },
                 "stroke": {
                   "type": "string"
@@ -6315,6 +6777,27 @@
             "experimental": {
               "additionalProperties": false,
               "properties": {
+                "brush": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
                 "hovering": {
                   "additionalProperties": false,
                   "properties": {
@@ -6335,6 +6818,27 @@
                     },
                     "showHoveringOnTheBack": {
                       "type": "boolean"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "selection": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
                     },
                     "stroke": {
                       "type": "string"
@@ -6480,6 +6984,27 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
+                          "brush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
@@ -6500,6 +7025,27 @@
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selection": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
                               },
                               "stroke": {
                                 "type": "string"
@@ -7112,6 +7658,27 @@
             "experimental": {
               "additionalProperties": false,
               "properties": {
+                "brush": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
                 "hovering": {
                   "additionalProperties": false,
                   "properties": {
@@ -7132,6 +7699,27 @@
                     },
                     "showHoveringOnTheBack": {
                       "type": "boolean"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "selection": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
                     },
                     "stroke": {
                       "type": "string"
@@ -7277,6 +7865,27 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
+                          "brush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
@@ -7297,6 +7906,27 @@
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selection": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
                               },
                               "stroke": {
                                 "type": "string"
@@ -7956,6 +8586,27 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
+                          "brush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
@@ -7976,6 +8627,27 @@
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selection": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
                               },
                               "stroke": {
                                 "type": "string"

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1113,23 +1113,20 @@
                   },
                   "type": "object"
                 },
+                "groupMarksByField": {
+                  "type": "string"
+                },
                 "hovering": {
                   "additionalProperties": false,
                   "properties": {
                     "color": {
                       "type": "string"
                     },
-                    "enableGroupHovering": {
-                      "type": "boolean"
-                    },
                     "enableMultiHovering": {
                       "type": "boolean"
                     },
                     "opacity": {
                       "type": "number"
-                    },
-                    "searchGroupByField": {
-                      "type": "string"
                     },
                     "showHoveringOnTheBack": {
                       "type": "boolean"
@@ -1324,23 +1321,20 @@
                             },
                             "type": "object"
                           },
+                          "groupMarksByField": {
+                            "type": "string"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {
                                 "type": "string"
                               },
-                              "enableGroupHovering": {
-                                "type": "boolean"
-                              },
                               "enableMultiHovering": {
                                 "type": "boolean"
                               },
                               "opacity": {
                                 "type": "number"
-                              },
-                              "searchGroupByField": {
-                                "type": "string"
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"
@@ -2001,23 +1995,20 @@
                   },
                   "type": "object"
                 },
+                "groupMarksByField": {
+                  "type": "string"
+                },
                 "hovering": {
                   "additionalProperties": false,
                   "properties": {
                     "color": {
                       "type": "string"
                     },
-                    "enableGroupHovering": {
-                      "type": "boolean"
-                    },
                     "enableMultiHovering": {
                       "type": "boolean"
                     },
                     "opacity": {
                       "type": "number"
-                    },
-                    "searchGroupByField": {
-                      "type": "string"
                     },
                     "showHoveringOnTheBack": {
                       "type": "boolean"
@@ -2212,23 +2203,20 @@
                             },
                             "type": "object"
                           },
+                          "groupMarksByField": {
+                            "type": "string"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {
                                 "type": "string"
                               },
-                              "enableGroupHovering": {
-                                "type": "boolean"
-                              },
                               "enableMultiHovering": {
                                 "type": "boolean"
                               },
                               "opacity": {
                                 "type": "number"
-                              },
-                              "searchGroupByField": {
-                                "type": "string"
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"
@@ -2940,23 +2928,20 @@
                             },
                             "type": "object"
                           },
+                          "groupMarksByField": {
+                            "type": "string"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {
                                 "type": "string"
                               },
-                              "enableGroupHovering": {
-                                "type": "boolean"
-                              },
                               "enableMultiHovering": {
                                 "type": "boolean"
                               },
                               "opacity": {
                                 "type": "number"
-                              },
-                              "searchGroupByField": {
-                                "type": "string"
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"
@@ -4195,23 +4180,20 @@
               },
               "type": "object"
             },
+            "groupMarksByField": {
+              "type": "string"
+            },
             "hovering": {
               "additionalProperties": false,
               "properties": {
                 "color": {
                   "type": "string"
                 },
-                "enableGroupHovering": {
-                  "type": "boolean"
-                },
                 "enableMultiHovering": {
                   "type": "boolean"
                 },
                 "opacity": {
                   "type": "number"
-                },
-                "searchGroupByField": {
-                  "type": "string"
                 },
                 "showHoveringOnTheBack": {
                   "type": "boolean"
@@ -4375,23 +4357,20 @@
                     },
                     "type": "object"
                   },
+                  "groupMarksByField": {
+                    "type": "string"
+                  },
                   "hovering": {
                     "additionalProperties": false,
                     "properties": {
                       "color": {
                         "type": "string"
                       },
-                      "enableGroupHovering": {
-                        "type": "boolean"
-                      },
                       "enableMultiHovering": {
                         "type": "boolean"
                       },
                       "opacity": {
                         "type": "number"
-                      },
-                      "searchGroupByField": {
-                        "type": "string"
                       },
                       "showHoveringOnTheBack": {
                         "type": "boolean"
@@ -5004,23 +4983,20 @@
               },
               "type": "object"
             },
+            "groupMarksByField": {
+              "type": "string"
+            },
             "hovering": {
               "additionalProperties": false,
               "properties": {
                 "color": {
                   "type": "string"
                 },
-                "enableGroupHovering": {
-                  "type": "boolean"
-                },
                 "enableMultiHovering": {
                   "type": "boolean"
                 },
                 "opacity": {
                   "type": "number"
-                },
-                "searchGroupByField": {
-                  "type": "string"
                 },
                 "showHoveringOnTheBack": {
                   "type": "boolean"
@@ -5444,23 +5420,20 @@
               },
               "type": "object"
             },
+            "groupMarksByField": {
+              "type": "string"
+            },
             "hovering": {
               "additionalProperties": false,
               "properties": {
                 "color": {
                   "type": "string"
                 },
-                "enableGroupHovering": {
-                  "type": "boolean"
-                },
                 "enableMultiHovering": {
                   "type": "boolean"
                 },
                 "opacity": {
                   "type": "number"
-                },
-                "searchGroupByField": {
-                  "type": "string"
                 },
                 "showHoveringOnTheBack": {
                   "type": "boolean"
@@ -5624,23 +5597,20 @@
                     },
                     "type": "object"
                   },
+                  "groupMarksByField": {
+                    "type": "string"
+                  },
                   "hovering": {
                     "additionalProperties": false,
                     "properties": {
                       "color": {
                         "type": "string"
                       },
-                      "enableGroupHovering": {
-                        "type": "boolean"
-                      },
                       "enableMultiHovering": {
                         "type": "boolean"
                       },
                       "opacity": {
                         "type": "number"
-                      },
-                      "searchGroupByField": {
-                        "type": "string"
                       },
                       "showHoveringOnTheBack": {
                         "type": "boolean"
@@ -6378,23 +6348,20 @@
               },
               "type": "object"
             },
+            "groupMarksByField": {
+              "type": "string"
+            },
             "hovering": {
               "additionalProperties": false,
               "properties": {
                 "color": {
                   "type": "string"
                 },
-                "enableGroupHovering": {
-                  "type": "boolean"
-                },
                 "enableMultiHovering": {
                   "type": "boolean"
                 },
                 "opacity": {
                   "type": "number"
-                },
-                "searchGroupByField": {
-                  "type": "string"
                 },
                 "showHoveringOnTheBack": {
                   "type": "boolean"
@@ -6798,23 +6765,20 @@
                   },
                   "type": "object"
                 },
+                "groupMarksByField": {
+                  "type": "string"
+                },
                 "hovering": {
                   "additionalProperties": false,
                   "properties": {
                     "color": {
                       "type": "string"
                     },
-                    "enableGroupHovering": {
-                      "type": "boolean"
-                    },
                     "enableMultiHovering": {
                       "type": "boolean"
                     },
                     "opacity": {
                       "type": "number"
-                    },
-                    "searchGroupByField": {
-                      "type": "string"
                     },
                     "showHoveringOnTheBack": {
                       "type": "boolean"
@@ -7005,23 +6969,20 @@
                             },
                             "type": "object"
                           },
+                          "groupMarksByField": {
+                            "type": "string"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {
                                 "type": "string"
                               },
-                              "enableGroupHovering": {
-                                "type": "boolean"
-                              },
                               "enableMultiHovering": {
                                 "type": "boolean"
                               },
                               "opacity": {
                                 "type": "number"
-                              },
-                              "searchGroupByField": {
-                                "type": "string"
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"
@@ -7679,23 +7640,20 @@
                   },
                   "type": "object"
                 },
+                "groupMarksByField": {
+                  "type": "string"
+                },
                 "hovering": {
                   "additionalProperties": false,
                   "properties": {
                     "color": {
                       "type": "string"
                     },
-                    "enableGroupHovering": {
-                      "type": "boolean"
-                    },
                     "enableMultiHovering": {
                       "type": "boolean"
                     },
                     "opacity": {
                       "type": "number"
-                    },
-                    "searchGroupByField": {
-                      "type": "string"
                     },
                     "showHoveringOnTheBack": {
                       "type": "boolean"
@@ -7886,23 +7844,20 @@
                             },
                             "type": "object"
                           },
+                          "groupMarksByField": {
+                            "type": "string"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {
                                 "type": "string"
                               },
-                              "enableGroupHovering": {
-                                "type": "boolean"
-                              },
                               "enableMultiHovering": {
                                 "type": "boolean"
                               },
                               "opacity": {
                                 "type": "number"
-                              },
-                              "searchGroupByField": {
-                                "type": "string"
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"
@@ -8607,23 +8562,20 @@
                             },
                             "type": "object"
                           },
+                          "groupMarksByField": {
+                            "type": "string"
+                          },
                           "hovering": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {
                                 "type": "string"
                               },
-                              "enableGroupHovering": {
-                                "type": "boolean"
-                              },
                               "enableMultiHovering": {
                                 "type": "boolean"
                               },
                               "opacity": {
                                 "type": "number"
-                              },
-                              "searchGroupByField": {
-                                "type": "string"
                               },
                               "showHoveringOnTheBack": {
                                 "type": "boolean"

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1152,6 +1152,9 @@
                     "opacity": {
                       "type": "number"
                     },
+                    "showOnTheBack": {
+                      "type": "boolean"
+                    },
                     "stroke": {
                       "type": "string"
                     },
@@ -1359,6 +1362,9 @@
                               },
                               "opacity": {
                                 "type": "number"
+                              },
+                              "showOnTheBack": {
+                                "type": "boolean"
                               },
                               "stroke": {
                                 "type": "string"
@@ -2034,6 +2040,9 @@
                     "opacity": {
                       "type": "number"
                     },
+                    "showOnTheBack": {
+                      "type": "boolean"
+                    },
                     "stroke": {
                       "type": "string"
                     },
@@ -2241,6 +2250,9 @@
                               },
                               "opacity": {
                                 "type": "number"
+                              },
+                              "showOnTheBack": {
+                                "type": "boolean"
                               },
                               "stroke": {
                                 "type": "string"
@@ -2966,6 +2978,9 @@
                               },
                               "opacity": {
                                 "type": "number"
+                              },
+                              "showOnTheBack": {
+                                "type": "boolean"
                               },
                               "stroke": {
                                 "type": "string"
@@ -4219,6 +4234,9 @@
                 "opacity": {
                   "type": "number"
                 },
+                "showOnTheBack": {
+                  "type": "boolean"
+                },
                 "stroke": {
                   "type": "string"
                 },
@@ -4395,6 +4413,9 @@
                       },
                       "opacity": {
                         "type": "number"
+                      },
+                      "showOnTheBack": {
+                        "type": "boolean"
                       },
                       "stroke": {
                         "type": "string"
@@ -5022,6 +5043,9 @@
                 "opacity": {
                   "type": "number"
                 },
+                "showOnTheBack": {
+                  "type": "boolean"
+                },
                 "stroke": {
                   "type": "string"
                 },
@@ -5459,6 +5483,9 @@
                 "opacity": {
                   "type": "number"
                 },
+                "showOnTheBack": {
+                  "type": "boolean"
+                },
                 "stroke": {
                   "type": "string"
                 },
@@ -5635,6 +5662,9 @@
                       },
                       "opacity": {
                         "type": "number"
+                      },
+                      "showOnTheBack": {
+                        "type": "boolean"
                       },
                       "stroke": {
                         "type": "string"
@@ -6387,6 +6417,9 @@
                 "opacity": {
                   "type": "number"
                 },
+                "showOnTheBack": {
+                  "type": "boolean"
+                },
                 "stroke": {
                   "type": "string"
                 },
@@ -6804,6 +6837,9 @@
                     "opacity": {
                       "type": "number"
                     },
+                    "showOnTheBack": {
+                      "type": "boolean"
+                    },
                     "stroke": {
                       "type": "string"
                     },
@@ -7007,6 +7043,9 @@
                               },
                               "opacity": {
                                 "type": "number"
+                              },
+                              "showOnTheBack": {
+                                "type": "boolean"
                               },
                               "stroke": {
                                 "type": "string"
@@ -7679,6 +7718,9 @@
                     "opacity": {
                       "type": "number"
                     },
+                    "showOnTheBack": {
+                      "type": "boolean"
+                    },
                     "stroke": {
                       "type": "string"
                     },
@@ -7882,6 +7924,9 @@
                               },
                               "opacity": {
                                 "type": "number"
+                              },
+                              "showOnTheBack": {
+                                "type": "boolean"
                               },
                               "stroke": {
                                 "type": "string"
@@ -8600,6 +8645,9 @@
                               },
                               "opacity": {
                                 "type": "number"
+                              },
+                              "showOnTheBack": {
+                                "type": "boolean"
                               },
                               "stroke": {
                                 "type": "string"

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -11,6 +11,11 @@ export type CommonEventData = {
     data: Datum[];
 };
 
+export type RangeSelectEventData = {
+    genomicRange: [string, string] | null; // null if range deselected
+    data: Datum[];
+};
+
 export type RawDataEventData = {
     id: string;
     data: Datum[];
@@ -28,8 +33,9 @@ type PubSubEvent<EventName extends string, Payload> = {
 };
 
 // New `PubSubEvent`s should be added to the `EventMap`...
-type EventMap = PubSubEvent<'mouseover' | 'click', CommonEventData> & PubSubEvent<'rawdata', RawDataEventData>;
-// & PubSubEvent<'my-event', { hello: 'world' }> & PubSubEvent<'foo', "bar">;
+type EventMap = PubSubEvent<'mouseover' | 'click', CommonEventData> &
+    PubSubEvent<'rangeselect', RangeSelectEventData> &
+    PubSubEvent<'rawdata', RawDataEventData>;
 
 /**
  * Information of suggested genes.
@@ -107,10 +113,9 @@ export function createApi(
         subscribe: (type, callback) => {
             switch (type) {
                 case 'mouseover':
-                    return PubSub.subscribe(type, callback);
                 case 'click':
-                    return PubSub.subscribe(type, callback);
                 case 'rawdata':
+                case 'rangeselect':
                     return PubSub.subscribe(type, callback);
                 default: {
                     console.error(`Event type not recognized, got ${JSON.stringify(type)}.`);

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -6,20 +6,22 @@ import { GET_CHROM_SIZES } from './utils/assembly';
 import { CompleteThemeDeep } from './utils/theme';
 import { traverseViewsInViewConfig } from './utils/view-config';
 
-export type CommonEventData = {
-    genomicPosition: string;
-    data: Datum[];
-};
-
-export type RangeSelectEventData = {
-    genomicRange: [string, string] | null; // null if range deselected
-    data: Datum[];
-};
-
-export type RawDataEventData = {
+export interface CommonEventData {
+    /** Source visualization ID, i.e., `track.id` */
     id: string;
+    /** Values in a JSON array that represent data after data transformation */
     data: Datum[];
-};
+}
+
+export interface PointMouseEventData extends CommonEventData {
+    /* A genomic coordinate, e.g., `chr1:100,000`. */
+    genomicPosition: string;
+}
+
+export interface RangeMouseEventData extends CommonEventData {
+    /* Start and end genomic coordinates, e.g., `chr1:100,000`. NULL if a range is deselected. */
+    genomicRange: [string, string] | null;
+}
 
 // Utility type for building strongly typed PubSub API.
 //
@@ -33,9 +35,9 @@ type PubSubEvent<EventName extends string, Payload> = {
 };
 
 // New `PubSubEvent`s should be added to the `EventMap`...
-type EventMap = PubSubEvent<'mouseover' | 'click', CommonEventData> &
-    PubSubEvent<'rangeselect', RangeSelectEventData> &
-    PubSubEvent<'rawdata', RawDataEventData>;
+type EventMap = PubSubEvent<'mouseover' | 'click', PointMouseEventData> &
+    PubSubEvent<'rangeselect', RangeMouseEventData> &
+    PubSubEvent<'rawdata', CommonEventData>;
 
 /**
  * Information of suggested genes.

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -257,6 +257,7 @@ interface SingleTrackBase extends CommonTrackDef {
             opacity?: number;
         };
         selection?: {
+            showOnTheBack?: boolean;
             color?: string;
             stroke?: string;
             strokeWidth?: number;

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -232,6 +232,14 @@ export type Mark =
 /* ----------------------------- TRACK ----------------------------- */
 export type SingleTrack = SingleTrackBase & Encoding;
 
+export interface BrushAndMarkHighlightingStyle {
+    color: string;
+    stroke: string;
+    strokeWidth: number;
+    strokeOpacity: number;
+    opacity: number;
+}
+
 interface SingleTrackBase extends CommonTrackDef {
     // Data
     data: DataDeep;
@@ -250,27 +258,9 @@ interface SingleTrackBase extends CommonTrackDef {
         hovering?: {
             enableMultiHovering?: boolean;
             showHoveringOnTheBack?: boolean;
-            color?: string;
-            stroke?: string;
-            strokeWidth?: number;
-            strokeOpacity?: number;
-            opacity?: number;
-        };
-        selection?: {
-            showOnTheBack?: boolean;
-            color?: string;
-            stroke?: string;
-            strokeWidth?: number;
-            strokeOpacity?: number;
-            opacity?: number;
-        };
-        brush?: {
-            color?: string;
-            stroke?: string;
-            strokeWidth?: number;
-            strokeOpacity?: number;
-            opacity?: number;
-        };
+        } & Partial<BrushAndMarkHighlightingStyle>;
+        selection?: { showOnTheBack?: boolean } & Partial<BrushAndMarkHighlightingStyle>;
+        brush?: Partial<BrushAndMarkHighlightingStyle>;
     };
 
     // Mark

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -255,6 +255,20 @@ interface SingleTrackBase extends CommonTrackDef {
             strokeOpacity?: number;
             opacity?: number;
         };
+        selection?: {
+            color?: string;
+            stroke?: string;
+            strokeWidth?: number;
+            strokeOpacity?: number;
+            opacity?: number;
+        };
+        brush?: {
+            color?: string;
+            stroke?: string;
+            strokeWidth?: number;
+            strokeOpacity?: number;
+            opacity?: number;
+        };
     };
 
     // Mark

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -244,10 +244,11 @@ interface SingleTrackBase extends CommonTrackDef {
 
     // Mouse events
     experimental?: {
+        /* Group marks using keys in a field. This affects how a set of marks are highlighted/selected by interaction. */
+        groupMarksByField?: string;
+
         hovering?: {
             enableMultiHovering?: boolean;
-            enableGroupHovering?: boolean;
-            searchGroupByField?: string;
             showHoveringOnTheBack?: boolean;
             color?: string;
             stroke?: string;

--- a/src/core/mark/bar.ts
+++ b/src/core/mark/bar.ts
@@ -140,7 +140,7 @@ export function drawBar(trackInfo: any, tile: any, model: GoslingTrackModel) {
 
                 if (typeof ye !== 'undefined') {
                     // make sure `ye` is a larger range value
-                    [y, ye] = [y, ye].sort();
+                    [y, ye] = [y, ye].sort((a, b) => a - b);
                 }
 
                 const barWidth = model.encodedPIXIProperty('width', d, { tileUnitWidth });

--- a/src/core/mark/bar.ts
+++ b/src/core/mark/bar.ts
@@ -138,9 +138,9 @@ export function drawBar(trackInfo: any, tile: any, model: GoslingTrackModel) {
                 let y = model.encodedPIXIProperty('y', d);
                 let ye = model.encodedPIXIProperty('ye', d);
 
-                if (typeof ye !== 'undefined') {
-                    // make sure `ye` is a larger range value
-                    [y, ye] = [y, ye].sort((a, b) => a - b);
+                if (typeof ye !== 'undefined' && y > ye) {
+                    // ensure `ye` is larger
+                    [y, ye] = [ye, y];
                 }
 
                 const barWidth = model.encodedPIXIProperty('width', d, { tileUnitWidth });

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -1,6 +1,6 @@
 import type * as D3Selection from 'd3-selection';
 import type * as D3Drag from 'd3-drag';
-import { BrushAndMarkHighlightingStyle } from '@gosling.schema';
+import type { BrushAndMarkHighlightingStyle } from '@gosling.schema';
 
 const HIDDEN_BRUSH_EDGE_SIZE = 3;
 

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -79,7 +79,7 @@ export class LinearBrushModel {
 
     constructor(
         selection: D3Selection.Selection<SVGGElement, unknown, HTMLElement, unknown>,
-        HGC: any,
+        hgLibraries: any,
         track: any,
         style: Partial<BrushStyle> = {}
     ) {
@@ -91,8 +91,8 @@ export class LinearBrushModel {
         this.size = 0;
 
         this.externals = {
-            d3Selection: HGC.d3Selection,
-            d3Drag: HGC.d3Drag
+            d3Selection: hgLibraries.d3Selection,
+            d3Drag: hgLibraries.d3Drag
         };
 
         this.style = Object.assign(BRUSH_STYLE_DEFAULT, style);

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -54,14 +54,11 @@ export class OneDimBrushModel {
         d3Drag: typeof d3Drag;
     };
 
-    /* Callback function */
-    private onBrush: OnBrushCallbackFn;
+    // TODO: A way to pass only the required function (e.g., onRangeBrush)?
+    /* gosling track */
+    private track: any;
 
-    constructor(
-        selection: d3Selection.Selection<SVGGElement, unknown, HTMLElement, unknown>,
-        HGC: any,
-        onBrush: OnBrushCallbackFn
-    ) {
+    constructor(selection: d3Selection.Selection<SVGGElement, unknown, HTMLElement, unknown>, HGC: any, track: any) {
         this.range = [0, 1];
         this.prevExtent = [0, 1];
         this.data = this.rangeToData(...this.range);
@@ -82,7 +79,7 @@ export class OneDimBrushModel {
             .attr('class', 'genomic-range-brush')
             .call(this.onDrag());
 
-        this.onBrush = onBrush;
+        this.track = track;
     }
 
     public getRange() {
@@ -111,7 +108,7 @@ export class OneDimBrushModel {
         return this;
     }
 
-    public drawBrush(skipCb = false) {
+    public drawBrush(skipCallback = false) {
         const [x, y] = this.offset;
         const height = this.size;
         const getWidth = (d: OneDimBrushDataUnion) => Math.abs(d.end - d.start); // the start and end can be minus values
@@ -128,8 +125,8 @@ export class OneDimBrushModel {
             .attr('stroke-opacity', d => (d.type === 'body' ? 1 : 0))
             .attr('cursor', d => d.cursor);
 
-        if (!skipCb) {
-            this.onBrush(...this.range);
+        if (!skipCallback) {
+            this.track.onRangeBrush(...this.getRange());
         }
         return this;
     }

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -46,12 +46,12 @@ export class OneDimBrushModel {
     private readonly style: BrushStyle;
 
     /* data */
-    private range: [number, number];
+    private range?: [number, number];
     private data: oneDimBrushData;
 
     /* drag */
     private startEvent: typeof d3Selection.event;
-    private prevExtent: [number, number];
+    private prevExtent?: [number, number];
 
     /* visual parameters */
     private offset: [number, number];
@@ -106,7 +106,7 @@ export class OneDimBrushModel {
     }
 
     public getRange() {
-        return this.range;
+        return this.range ?? [0, 0];
     }
 
     public setSize(size: number) {
@@ -133,9 +133,9 @@ export class OneDimBrushModel {
 
     /**
      * Update the brush using the internal range value. By default,
-     * This function calls a callback function from gosling-track.
+     * This function calls a render function from gosling-track.
      */
-    public drawBrush(skipCallback = false) {
+    public drawBrush(skipApiTrigger = false) {
         const [x, y] = this.offset;
         const height = this.size;
         const getWidth = (d: OneDimBrushDataUnion) => Math.abs(d.end - d.start); // the start and end can be minus values
@@ -152,9 +152,8 @@ export class OneDimBrushModel {
             .attr('stroke-opacity', d => (d.type === 'body' ? this.style.strokeOpacity : 0))
             .attr('cursor', d => d.cursor);
 
-        if (!skipCallback) {
-            this.track.onRangeBrush(...this.getRange());
-        }
+        this.track.onRangeBrush(...this.getRange(), skipApiTrigger);
+
         return this;
     }
 
@@ -216,7 +215,7 @@ export class OneDimBrushModel {
             const delta = this.externals.d3Selection.event.sourceEvent.layerX - this.startEvent.layerX;
 
             // previous extent of brush
-            let [s, e]: [number, number] = this.prevExtent;
+            let [s, e]: [number, number] = this.prevExtent ?? [0, 0];
 
             if (d.type === 'body') {
                 s += delta;

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -1,5 +1,6 @@
 import type * as D3Selection from 'd3-selection';
 import type * as D3Drag from 'd3-drag';
+import { BrushAndMarkHighlightingStyle } from '@gosling.schema';
 
 const HIDDEN_BRUSH_EDGE_SIZE = 3;
 
@@ -29,14 +30,6 @@ export interface LinearBrushEndEdgeData extends LinearBrushDataCommon {
 
 export type OnBrushCallbackFn = (start: number, end: number) => void;
 
-interface BrushStyle {
-    color: string;
-    stroke: string;
-    strokeWidth: number;
-    strokeOpacity: number;
-    opacity: number;
-}
-
 // default styles for brush
 const BRUSH_STYLE_DEFAULT = {
     color: '#777',
@@ -52,7 +45,7 @@ const BRUSH_STYLE_DEFAULT = {
 export class LinearBrushModel {
     /* graphical elements */
     private brushSelection: D3Selection.Selection<SVGRectElement, LinearBrushDataUnion, SVGGElement, any>;
-    private readonly style: BrushStyle;
+    private readonly style: BrushAndMarkHighlightingStyle;
 
     /* data */
     private range: [number, number] | null;
@@ -79,7 +72,7 @@ export class LinearBrushModel {
         selection: D3Selection.Selection<SVGGElement, unknown, HTMLElement, unknown>,
         hgLibraries: any,
         onBrush: (range: [number, number] | null, skipApiTrigger: boolean) => void,
-        style: Partial<BrushStyle> = {}
+        style: Partial<BrushAndMarkHighlightingStyle> = {}
     ) {
         this.range = null;
         this.prevExtent = [0, 0];

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -63,8 +63,8 @@ export class OneDimBrushModel {
         d3Drag: typeof d3Drag;
     };
 
-    // TODO: A way to pass only the required function (e.g., onRangeBrush)?
-    // note that inside `onRangeBrush()` uses `this` which points to the GoslingTrack
+    // TODO (May-19-2022): A way to pass only the required function (e.g., onRangeBrush) and allow
+    // to use `this` (i.e., instance of GoslingTrack) in the function?
     /* gosling track */
     private track: any;
 

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -72,15 +72,13 @@ export class LinearBrushModel {
         d3Drag: typeof D3Drag;
     };
 
-    // TODO (May-19-2022): A way to pass only the required function (e.g., onRangeBrush) and allow
-    // to use `this` (i.e., instance of GoslingTrack) in the function?
-    /* gosling track */
-    private track: any;
+    /* A function that is called every time when the brush has been updated */
+    private onBrush: (range: [number, number] | null, skipApiTrigger: boolean) => void;
 
     constructor(
         selection: D3Selection.Selection<SVGGElement, unknown, HTMLElement, unknown>,
         hgLibraries: any,
-        track: any,
+        onBrush: (range: [number, number] | null, skipApiTrigger: boolean) => void,
         style: Partial<BrushStyle> = {}
     ) {
         this.range = null;
@@ -105,7 +103,7 @@ export class LinearBrushModel {
             .attr('class', 'genomic-range-brush')
             .call(this.onDrag());
 
-        this.track = track;
+        this.onBrush = onBrush;
     }
 
     public getRange() {
@@ -159,7 +157,7 @@ export class LinearBrushModel {
             .attr('stroke-opacity', d => (d.type === 'body' ? this.style.strokeOpacity : 0))
             .attr('cursor', d => d.cursor);
 
-        this.track.onRangeBrush(this.getRange(), skipApiTrigger);
+        this.onBrush(this.getRange(), skipApiTrigger);
 
         return this;
     }

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -6,8 +6,6 @@ const HIDDEN_BRUSH_EDGE_SIZE = 3;
 
 export type LinearBrushData = [LinearBrushBodyData, LinearBrushStartEdgeData, LinearBrushEndEdgeData];
 
-export type LinearBrushDataUnion = LinearBrushBodyData | LinearBrushStartEdgeData | LinearBrushEndEdgeData;
-
 export interface LinearBrushDataCommon {
     start: number;
     end: number;
@@ -44,7 +42,7 @@ const BRUSH_STYLE_DEFAULT = {
  */
 export class LinearBrushModel {
     /* graphical elements */
-    private brushSelection: D3Selection.Selection<SVGRectElement, LinearBrushDataUnion, SVGGElement, any>;
+    private brushSelection: D3Selection.Selection<SVGRectElement, LinearBrushData[number], SVGGElement, any>;
     private readonly style: BrushAndMarkHighlightingStyle;
 
     /* data */
@@ -136,7 +134,7 @@ export class LinearBrushModel {
     public drawBrush(skipApiTrigger = false) {
         const [x, y] = this.offset;
         const height = this.size;
-        const getWidth = (d: LinearBrushDataUnion) => Math.abs(d.end - d.start); // the start and end can be minus values
+        const getWidth = (d: LinearBrushData[number]) => Math.abs(d.end - d.start); // the start and end can be minus values
         this.brushSelection
             .data(this.data)
             .attr('visibility', 'visible')
@@ -209,7 +207,7 @@ export class LinearBrushModel {
             this.prevExtent = this.range;
         };
 
-        const dragged = (d: LinearBrushDataUnion) => {
+        const dragged = (d: LinearBrushData[number]) => {
             const delta = this.externals.d3Selection.event.sourceEvent.layerX - this.startEvent.layerX;
 
             // previous extent of brush
@@ -228,7 +226,7 @@ export class LinearBrushModel {
         };
 
         return this.externals.d3Drag
-            .drag<SVGRectElement, LinearBrushDataUnion>()
+            .drag<SVGRectElement, LinearBrushData[number]>()
             .on('start', started)
             .on('drag', dragged);
     }

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -1,0 +1,184 @@
+import * as d3Selection from 'd3-selection';
+import { drag as d3Drag } from 'd3-drag';
+
+const HIDDEN_BRUSH_EDGE_SIZE = 3;
+
+export type oneDimBrushData = [OneDimBrushBodyData, OneDimBrushStartEdgeData, OneDimBrushEndEdgeData];
+
+export type OneDimBrushDataUnion = OneDimBrushBodyData | OneDimBrushStartEdgeData | OneDimBrushEndEdgeData;
+
+export interface OneDimBrushDataCommon {
+    start: number;
+    end: number;
+}
+
+export interface OneDimBrushBodyData extends OneDimBrushDataCommon {
+    type: 'body';
+    cursor: 'grab';
+}
+
+export interface OneDimBrushStartEdgeData extends OneDimBrushDataCommon {
+    type: 'start';
+    cursor: 'move';
+}
+
+export interface OneDimBrushEndEdgeData extends OneDimBrushDataCommon {
+    type: 'end';
+    cursor: 'move';
+}
+
+/**
+ * A model to manage 1D brush graphics and its data.
+ */
+export class OneDimBrushModel {
+    /* graphical elements */
+    private brushSelection: d3Selection.Selection<SVGRectElement, OneDimBrushDataUnion, SVGGElement, any>;
+
+    /* data */
+    private range: [number, number];
+    private data: oneDimBrushData;
+
+    /* drag */
+    private startEvent: typeof d3Selection.event;
+    private prevExtent: [number, number];
+
+    /* visual parameters */
+    private offset: [number, number];
+    private size: number; // fixed size of one-dimension of a brush (e.g., height)
+
+    /* External libraries that we re-use from HiGlass */
+    private externals: {
+        d3Selection: typeof d3Selection;
+        d3Drag: typeof d3Drag;
+    };
+
+    constructor(selection: d3Selection.Selection<SVGGElement, unknown, HTMLElement, unknown>, HGC: any) {
+        this.range = [0, 1];
+        this.prevExtent = [0, 1];
+        this.data = this.rangeToData(...this.range);
+
+        this.offset = [0, 0];
+        this.size = 0;
+
+        this.externals = {
+            d3Selection: HGC.d3Selection,
+            d3Drag: HGC.d3Drag.drag
+        };
+
+        this.brushSelection = selection
+            .selectAll('.genomic-range-brush')
+            .data(this.data)
+            .enter()
+            .append('rect')
+            .attr('class', 'genomic-range-brush')
+            .call(this.onDrag());
+    }
+
+    /* --------------------------------------------- GET/SET --------------------------------------------- */
+    public getRange() {
+        return this.range;
+    }
+
+    public setSize(size: number) {
+        this.size = size;
+        return this;
+    }
+
+    /**
+     * Based on the extent values, generate a JSON object for the brush.
+     */
+    private rangeToData(start: number, end: number): oneDimBrushData {
+        return [
+            {
+                type: 'body',
+                cursor: 'grab',
+                start,
+                end
+            },
+            {
+                type: 'start',
+                cursor: 'move',
+                start: start - HIDDEN_BRUSH_EDGE_SIZE,
+                end: start
+            },
+            {
+                type: 'end',
+                cursor: 'move',
+                start: end,
+                end: end + HIDDEN_BRUSH_EDGE_SIZE
+            }
+        ];
+    }
+
+    /**
+     * Update the left and top offsets for drawing the brush.
+     */
+    public setOffset(offsetX: number, offsetY: number) {
+        this.offset = [offsetX, offsetY];
+        return this;
+    }
+
+    /**
+     * Update brush data based on the positions of two edges.
+     */
+    public updateRange(value1: number, value2: number) {
+        this.range = [value1, value2].sort((a, b) => a - b) as [number, number];
+        this.data = this.rangeToData(...this.range);
+        return this;
+    }
+
+    public drawBrush() {
+        const [x, y] = this.offset;
+        const height = this.size;
+        const getWidth = (d: OneDimBrushDataUnion) => Math.abs(d.end - d.start); // the start and end can be minus values
+        this.brushSelection
+            .data(this.data)
+            .attr('transform', d => `translate(${x + d.start}, ${y + 1})`)
+            .attr('width', d => `${getWidth(d)}px`)
+            .attr('height', `${height - 2}px`)
+            .attr('fill', 'red')
+            .attr('stroke', 'red')
+            .attr('stroke-width', '1px')
+            .attr('fill-opacity', d => (d.type === 'body' ? 0.3 : 0))
+            .attr('stroke-opacity', d => (d.type === 'body' ? 1 : 0))
+            .attr('cursor', d => d.cursor);
+        return this;
+    }
+
+    public enable() {
+        this.brushSelection.attr('pointer-events', 'all');
+        return this;
+    }
+
+    public disable() {
+        this.brushSelection.attr('pointer-events', 'none');
+        return this;
+    }
+
+    onDrag() {
+        const started = () => {
+            this.startEvent = this.externals.d3Selection.event.sourceEvent;
+            this.prevExtent = this.range;
+        };
+
+        const dragged = (d: OneDimBrushDataUnion) => {
+            const delta = this.externals.d3Selection.event.sourceEvent.layerX - this.startEvent.layerX;
+
+            // previous extent of brush
+            let [s, e]: [number, number] = this.prevExtent;
+
+            if (d.type === 'body') {
+                s += delta;
+                e += delta;
+            } else if (d.type === 'start') {
+                s += delta;
+            } else if (d.type === 'end') {
+                e += delta;
+            }
+
+            this.updateRange(s, e).drawBrush();
+        };
+
+        return this.externals.d3Drag<SVGRectElement, OneDimBrushDataUnion>().on('start', started).on('drag', dragged);
+    }
+}

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -130,7 +130,8 @@ export class LinearBrushModel {
      */
     public updateRange(range: [number, number] | null) {
         if (range) {
-            this.data = this.rangeToData(Math.min(...range), Math.max(...range));
+            this.range = [Math.min(...range), Math.max(...range)];
+            this.data = this.rangeToData(...this.range);
         } else {
             this.range = null;
         }

--- a/src/gosling-mouse-event/mouse-event-model.ts
+++ b/src/gosling-mouse-event/mouse-event-model.ts
@@ -146,12 +146,4 @@ export class MouseEventModel {
                 return isAnyPointsWithinRange([x1, x2], data.polygon);
         }
     }
-
-    /**
-     * Find all event data using UIDs.
-     */
-    public findAllBasedOnUids(uids: string[]) {
-        const _ = Array.from(this.data);
-        return _.filter(d => uids.indexOf(d.uid) !== -1);
-    }
 }

--- a/src/gosling-mouse-event/mouse-event-model.ts
+++ b/src/gosling-mouse-event/mouse-event-model.ts
@@ -1,5 +1,11 @@
 import { Datum } from '../core/gosling.schema';
-import { isPointInPolygon, isPointNearLine, isPointNearPoint } from './polygon';
+import {
+    isPointsWithinRange,
+    isPointInPolygon,
+    isPointNearLine,
+    isPointNearPoint,
+    isPointWithinRange
+} from './polygon';
 import * as uuid from 'uuid';
 
 export type MouseEventData = PointEventData | LineEventData | PolygonEventData;
@@ -122,5 +128,36 @@ export class MouseEventModel {
             default:
                 return isPointInPolygon([x, y], data.polygon);
         }
+    }
+
+    /**
+     * Find all event data that is within the range along the x-axis.
+     */
+    public findAllWithinRange(x1: number, x2: number, reverse = false) {
+        const _ = Array.from(this.data);
+        if (reverse) _.reverse();
+        return _.filter(d => this.isWithinRange(d, x1, x2));
+    }
+
+    /**
+     * Test if a given object is within an 1D range.
+     */
+    public isWithinRange(data: MouseEventData, x1: number, x2: number) {
+        switch (data.type) {
+            case 'point':
+                return isPointWithinRange([x1, x2], data.polygon);
+            case 'line':
+            case 'polygon':
+            default:
+                return isPointsWithinRange([x1, x2], data.polygon);
+        }
+    }
+
+    /**
+     * Find all event data using UIDs.
+     */
+    public findAllBasedOnUids(uids: string[]) {
+        const _ = Array.from(this.data);
+        return _.filter(d => uids.indexOf(d.uid) !== -1);
     }
 }

--- a/src/gosling-mouse-event/mouse-event-model.ts
+++ b/src/gosling-mouse-event/mouse-event-model.ts
@@ -99,10 +99,11 @@ export class MouseEventModel {
      */
     public getSiblings(source: MouseEventData[], idField: string) {
         const siblings: MouseEventData[] = [];
-        source.forEach(d => {
-            const id = d.value[idField];
+        const sourceUids = Array.from(new Set(source.map(d => d.uid)));
+        source.forEach(s => {
+            const id = s.value[idField];
             if (id) {
-                siblings.push(...this.data.filter(_ => _.value[idField] === id && d.uid !== _.uid));
+                siblings.push(...this.data.filter(_ => _.value[idField] === id && sourceUids.indexOf(_.uid) === -1));
             }
         });
         return siblings;

--- a/src/gosling-mouse-event/mouse-event-model.ts
+++ b/src/gosling-mouse-event/mouse-event-model.ts
@@ -1,4 +1,4 @@
-import { Datum } from '../core/gosling.schema';
+import type { Datum } from '@gosling.schema';
 import {
     isAllPointsWithinRange,
     isPointInPolygon,

--- a/src/gosling-mouse-event/mouse-event-model.ts
+++ b/src/gosling-mouse-event/mouse-event-model.ts
@@ -1,10 +1,10 @@
 import { Datum } from '../core/gosling.schema';
 import {
-    isPointsWithinRange,
+    isAnyPointsWithinRange,
     isPointInPolygon,
     isPointNearLine,
     isPointNearPoint,
-    isPointWithinRange
+    isCircleOverlapRange
 } from './polygon';
 import * as uuid from 'uuid';
 
@@ -145,11 +145,11 @@ export class MouseEventModel {
     public isWithinRange(data: MouseEventData, x1: number, x2: number) {
         switch (data.type) {
             case 'point':
-                return isPointWithinRange([x1, x2], data.polygon);
+                return isCircleOverlapRange([x1, x2], data.polygon[0], data.polygon[2]);
             case 'line':
             case 'polygon':
             default:
-                return isPointsWithinRange([x1, x2], data.polygon);
+                return isAnyPointsWithinRange([x1, x2], data.polygon);
         }
     }
 

--- a/src/gosling-mouse-event/mouse-event-model.ts
+++ b/src/gosling-mouse-event/mouse-event-model.ts
@@ -4,7 +4,7 @@ import {
     isPointInPolygon,
     isPointNearLine,
     isPointNearPoint,
-    isCircleOverlapRange
+    isCircleWithinRange
 } from './polygon';
 import * as uuid from 'uuid';
 
@@ -46,13 +46,6 @@ export class MouseEventModel {
      */
     public size() {
         return this.data.length;
-    }
-
-    /**
-     * Add a new mouse event at the end.
-     */
-    public add(eventData: MouseEventData) {
-        this.data.push(eventData);
     }
 
     /**
@@ -145,7 +138,7 @@ export class MouseEventModel {
     public isWithinRange(data: MouseEventData, x1: number, x2: number) {
         switch (data.type) {
             case 'point':
-                return isCircleOverlapRange([x1, x2], data.polygon[0], data.polygon[2]);
+                return isCircleWithinRange([x1, x2], data.polygon[0], data.polygon[2]);
             case 'line':
             case 'polygon':
             default:

--- a/src/gosling-mouse-event/mouse-event-model.ts
+++ b/src/gosling-mouse-event/mouse-event-model.ts
@@ -1,6 +1,6 @@
 import { Datum } from '../core/gosling.schema';
 import {
-    isAnyPointsWithinRange,
+    isAllPointsWithinRange,
     isPointInPolygon,
     isPointNearLine,
     isPointNearPoint,
@@ -143,7 +143,7 @@ export class MouseEventModel {
             case 'line':
             case 'polygon':
             default:
-                return isAnyPointsWithinRange([x1, x2], data.polygon);
+                return isAllPointsWithinRange([x1, x2], data.polygon);
         }
     }
 }

--- a/src/gosling-mouse-event/polygon.ts
+++ b/src/gosling-mouse-event/polygon.ts
@@ -14,16 +14,25 @@ export const isPointNearPoint: (point: [number, number], point2: number[], radiu
 
 /**
  * @param {Array} range Tuple of the form `[x1,x2]` to be tested.
- * @param {Array} point Tuple of the form `[x,y]` to be tested.
- * @param {number} radius A radius of the second point.
+ * @param {Array} point A value x to be tested.
  * @returns {boolean} If `true` point lies within the point.
  */
-export const isPointWithinRange: (range: [number, number], point: number[], radius?: number) => boolean = (
-    [x1, x2],
-    [px],
+export const isPointInsideRange: (range: [number, number], x: number) => boolean = ([x1, x2], x) => {
+    return x1 <= x && x <= x2;
+};
+
+/**
+ * @param {Array} range Tuple of the form `[x1,x2]` to be tested.
+ * @param {Array} x A value x to be tested.
+ * @param {number} radius A radius of the point.
+ * @returns {boolean} If `true` point lies within the point.
+ */
+export const isCircleOverlapRange: (range: [number, number], x: number, radius?: number) => boolean = (
+    range,
+    x,
     radius = 5
 ) => {
-    return x1 <= px - radius && px + radius <= x2;
+    return isPointInsideRange(range, x - radius) || isPointInsideRange(range, x + radius);
 };
 
 /**
@@ -31,14 +40,12 @@ export const isPointWithinRange: (range: [number, number], point: number[], radi
  * @param {Array} path 1D list of vertices defining the line segments.
  * @return {boolean} If `true` point lies within the polygon.
  */
-export const isPointsWithinRange: (range: [number, number], path: number[]) => boolean = ([x1, x2], path) => {
+export const isAnyPointsWithinRange: (range: [number, number], path: number[]) => boolean = ([x1, x2], path) => {
     let lx;
-    let ly;
-    let isWithin = true;
+    let isWithin = false;
     for (let i = 0; i < path.length; i += 2) {
         lx = path[i];
-        ly = path[i + 1];
-        isWithin = isWithin && isPointWithinRange([x1, x2], [lx, ly], 0);
+        isWithin = isWithin || isPointInsideRange([x1, x2], lx);
     }
     return isWithin;
 };

--- a/src/gosling-mouse-event/polygon.ts
+++ b/src/gosling-mouse-event/polygon.ts
@@ -40,14 +40,8 @@ export const isCircleWithinRange: (range: [number, number], x: number, radius?: 
  * @param {Array} path 1D list of vertices defining the line segments.
  * @return {boolean} If `true` point lies within the polygon.
  */
-export const isAnyPointsWithinRange: (range: [number, number], path: number[]) => boolean = ([x1, x2], path) => {
-    let lx;
-    let isWithin = true;
-    for (let i = 0; i < path.length; i += 2) {
-        lx = path[i];
-        isWithin = isWithin && isPointInsideRange([x1, x2], lx);
-    }
-    return isWithin;
+export const isAllPointsWithinRange: (range: [number, number], path: number[]) => boolean = (range, path) => {
+    return path.filter((_, i) => i % 2 === 0).every(x => isPointInsideRange(range, x));
 };
 
 /**

--- a/src/gosling-mouse-event/polygon.ts
+++ b/src/gosling-mouse-event/polygon.ts
@@ -27,12 +27,12 @@ export const isPointInsideRange: (range: [number, number], x: number) => boolean
  * @param {number} radius A radius of the point.
  * @returns {boolean} If `true` point lies within the point.
  */
-export const isCircleOverlapRange: (range: [number, number], x: number, radius?: number) => boolean = (
+export const isCircleWithinRange: (range: [number, number], x: number, radius?: number) => boolean = (
     range,
     x,
     radius = 5
 ) => {
-    return isPointInsideRange(range, x - radius) || isPointInsideRange(range, x + radius);
+    return isPointInsideRange(range, x - radius) && isPointInsideRange(range, x + radius);
 };
 
 /**
@@ -42,10 +42,10 @@ export const isCircleOverlapRange: (range: [number, number], x: number, radius?:
  */
 export const isAnyPointsWithinRange: (range: [number, number], path: number[]) => boolean = ([x1, x2], path) => {
     let lx;
-    let isWithin = false;
+    let isWithin = true;
     for (let i = 0; i < path.length; i += 2) {
         lx = path[i];
-        isWithin = isWithin || isPointInsideRange([x1, x2], lx);
+        isWithin = isWithin && isPointInsideRange([x1, x2], lx);
     }
     return isWithin;
 };

--- a/src/gosling-mouse-event/polygon.ts
+++ b/src/gosling-mouse-event/polygon.ts
@@ -13,6 +13,37 @@ export const isPointNearPoint: (point: [number, number], point2: number[], radiu
 };
 
 /**
+ * @param {Array} range Tuple of the form `[x1,x2]` to be tested.
+ * @param {Array} point Tuple of the form `[x,y]` to be tested.
+ * @param {number} radius A radius of the second point.
+ * @returns {boolean} If `true` point lies within the point.
+ */
+export const isPointWithinRange: (range: [number, number], point: number[], radius?: number) => boolean = (
+    [x1, x2],
+    [px],
+    radius = 5
+) => {
+    return x1 <= px - radius && px + radius <= x2;
+};
+
+/**
+ * @param {Array} point Tuple of the form `[x1,x2]` to be tested.
+ * @param {Array} path 1D list of vertices defining the line segments.
+ * @return {boolean} If `true` point lies within the polygon.
+ */
+export const isPointsWithinRange: (range: [number, number], path: number[]) => boolean = ([x1, x2], path) => {
+    let lx;
+    let ly;
+    let isWithin = true;
+    for (let i = 0; i < path.length; i += 2) {
+        lx = path[i];
+        ly = path[i + 1];
+        isWithin = isWithin && isPointWithinRange([x1, x2], [lx, ly], 0);
+    }
+    return isWithin;
+};
+
+/**
  * From: https://www.geeksforgeeks.org/minimum-distance-from-a-point-to-the-line-segment-using-vectors/
  * @param {Array} point Tuple of the form `[x,y]` to be tested.
  * @param {Array} path 1D list of vertices defining the line segments.

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -158,7 +158,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             this.mRangeBrush = new LinearBrushModel(
                 this.gBrush,
                 HGC.libraries,
-                this,
+                this.onRangeBrush.bind(this),
                 this.options.spec.experimental?.brush
             );
             this.pMask.mousedown = (e: InteractionEvent) =>

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -320,7 +320,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
         }
 
         /**
-         * Rerender tiles using the manually changed options.
+         * Render this track again using a new option when a user changed the option.
          * (Refer to https://github.com/higlass/higlass/blob/54f5aae61d3474f9e868621228270f0c90ef9343/app/scripts/HorizontalLine1DPixiTrack.js#L75)
          */
         rerender(newOptions: GoslingTrackOption) {

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -316,14 +316,17 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
          * Rerender tiles using the manually changed options.
          * (Refer to https://github.com/higlass/higlass/blob/54f5aae61d3474f9e868621228270f0c90ef9343/app/scripts/HorizontalLine1DPixiTrack.js#L75)
          */
-        rerender(newOptions: any) {
+        rerender(newOptions: GoslingTrackOption) {
             if (PRINT_RENDERING_CYCLE) console.warn('rerender(options)');
             // !! We only call draw for the simplicity
             // super.rerender(newOptions); // This calls `renderTile()` on every tiles
 
             this.options = newOptions;
 
-            // this.mouseEventModel.clear();
+            if (this.options.spec.layout === 'circular') {
+                this.mRangeBrush.remove();
+            }
+
             this.clearMouseEventData();
             this.svgData = [];
             this.textsBeingUsed = 0;

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -1094,7 +1094,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 .flat();
 
             // Collect all mouse event data from tiles and overlaid tracks
-            const capturedElements: MouseEventData[] = models
+            let capturedElements: MouseEventData[] = models
                 .map(model => model.getMouseEventModel().findAllWithinRange(startX, endX, true))
                 .flat();
 
@@ -1111,13 +1111,15 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 this.pMain.removeChild(g);
                 this.pMain.addChild(g);
 
-                // Iterate again to select sibling marks (e.g., entire glyphs)
+                // Deselect marks if their siblings are not selected.
+                // i.e., if only one exon is selected in a gene, we do not select it.
                 const idField = this.options.spec.experimental?.groupMarksByField;
                 if (capturedElements.length !== 0 && idField) {
-                    const source = Array.from(capturedElements);
                     models.forEach(model => {
-                        const siblings = model.getMouseEventModel().getSiblings(source, idField);
-                        capturedElements.push(...siblings);
+                        const siblings = model.getMouseEventModel().getSiblings(capturedElements, idField);
+                        const siblingIds = Array.from(new Set(siblings.map(d => d.value[idField])));
+                        capturedElements = capturedElements.filter(d => siblingIds.indexOf(d.value[idField]) === -1);
+                        // console.log(siblings, siblingIds, capturedElements);
                     });
                 }
 

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -1132,6 +1132,14 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 this.highlightMarks(g, capturedElements, stroke, strokeWidth, strokeOpacity, color, fillOpacity);
             }
 
+            /* API call */
+            const genomicRange = [
+                getRelativeGenomicPosition(Math.floor(this._xScale.invert(startX))),
+                getRelativeGenomicPosition(Math.floor(this._xScale.invert(endX)))
+            ];
+
+            PubSub.publish('rangeselect', { genomicRange, data: capturedElements.map(d => d.value) });
+
             this.forceDraw();
         }
 
@@ -1160,6 +1168,8 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             if (!this.isBrushActivated && !isDrag) {
                 this.mRangeBrush.clear();
                 this.pMouseSelection.clear();
+
+                PubSub.publish('rangeselect', { genomicRange: null, data: [] });
             }
 
             this.isBrushActivated = false;


### PR DESCRIPTION
# Updates

- Support genomic range selection using mouse + alt key
   - Individual marks (or grouped marks) that are entirely inside the given genomic range are selected and highlighted
   - Clicking on the outside of the brush removes the brush
   - Each track can have only one brush
   - Users can resize the brush by dragging the edge of the brush
   - Users can reposition the brush by dragging the body of the brush
   - Brush positions, as well as highlighted elements, are maintained upon zooming and panning
- Support `rangeselect` API to subscribe range brush change
```ts
api.subscribe('rangeselect', (type: string, eventData: RangeSelectEventData) => {
   console.log(
      type, // 'rangeselect'
      eventData.id. // 'track-3'
      eventData.genomicRange, // ['chr1:124,000', 'chr1:450,000'] or null if brush removed
      eventData.data // [{ chr: '1', pos: 124000, value: 12 }, ...]
   );
});
```
- Support customizing the selection and hovering effects, as well as the brush.
```ts
// ... track-level properties
// Mouse events
experimental?: {
    /* Group marks using keys in a field. This affects how a set of marks are highlighted/selected by interaction. */
    groupMarksByField?: string;

    hovering?: {
        enableMultiHovering?: boolean;
        showHoveringOnTheBack?: boolean;
        color?: string;
        stroke?: string;
        strokeWidth?: number;
        strokeOpacity?: number;
        opacity?: number;
    };
    selection?: {
        showOnTheBack?: boolean;
        color?: string;
        stroke?: string;
        strokeWidth?: number;
        strokeOpacity?: number;
        opacity?: number;
    };
    brush?: {
        color?: string;
        stroke?: string;
        strokeWidth?: number;
        strokeOpacity?: number;
        opacity?: number;
    };
};
```

## To-Do

- [x] Support APIs to access selected elements (e.g., `{ genomicRange, values }`)
- [x] Expose customization properties
- [x] Fix an issue that `rangeselect` API is called redundantly.
- [x] Support selecting a group of marks (e.g., a gene annotation)
- [x] Select marks that are entirely inside a range
- [x] Selection effects seem to be redundantly displayed when selecting grouped marks.
- [x] Better handle when selection is null
- [x] Remove brush when changed to circular layout

# Screenshots

![Screen Shot 2022-05-18 at 15 56 57](https://user-images.githubusercontent.com/9922882/169145164-f5f000b2-09ff-432a-bc36-70e6a3c267dc.png)

https://user-images.githubusercontent.com/9922882/169143907-e1e814c9-eb93-4865-9bca-c2b05ac726fb.mov

![Screen Shot 2022-05-24 at 12 13 00](https://user-images.githubusercontent.com/9922882/170083131-e18223f2-9b76-4718-bf75-9b42357fb8c3.png)


![Screen Shot 2022-05-24 at 12 21 25](https://user-images.githubusercontent.com/9922882/170084777-af5b686b-b2df-42a1-a931-9e444137a531.png)


# Open Issues
- Selection across separate tracks that are overlaid because they use different data (e.g., mark displaced lollipop plot example)
- Allow API callers to know the "type" of selection events (e.g., dragging, adjusting edge, creating, removing, zooming)
- Alternative triggering methods? (e.g., a selection-mode button like in Peax?)
- Selection along a single `row`?
- Proper visual cues when selection is triggered?
- Let the API subscriber know when the selected data changed although the range did not change (e.g., new tilesets by zooming in)
- Unify with the current `brush` mark.
- Merging sets of selections (e.g., union or intersection)
- Limit the size of the JSON array (i.e., `data`) that is sent to API subscribers?
- Should we add an option for users to only get the genomic range (w/o selected data)?