### PR TITLE
feat: support indels in VCF

### DIFF
--- a/src/data-fetcher/vcf/vcf-worker.js
+++ b/src/data-fetcher/vcf/vcf-worker.js
@@ -204,7 +204,7 @@ const tile = async (uid, z, x) => {
                 const DISTPREVLOGE = !prevPos ? null : Math.log(vcfRecord.POS - prevPos);
                 const MUTTYPE = getMutationType(vcfRecord.REF, vcfRecord.ALT);
                 const SUBTYPE = getSubstitutionType(vcfRecord.REF, vcfRecord.ALT);
-                const POSEND = POS + Math.max(vcfRecord.REF.length, vcfRecord.ALT.length);
+                const POSEND = POS + vcfRecord.REF.length;
 
                 // Create key values
                 const data = {


### PR DESCRIPTION
Updates
- Calculates the end position of REF
- Additionally infer the mutation type, i.e., 'insertion', 'deletion', 'substitution'

(Make changes to #689, i.e., field name `TYPE` is now `SUBTYPE`)

<a href="http://localhost:3000/?full=false&spec=(~'layout!4linear'%2C~'arrangement!4vertical'%2C~'centerRadiusJ0.8%2C~'xDomainJ(4chromosome!41'%20)%2C~'viewsJ%5B~*(~**%3C~***(2'id!4vcf'G'dataJ(2*'url!4hKj'G*'type!4vcf'G*'indexUrl!4hKj.tbi'G*'sampleLengthJ50002)G'dataTransformJ%5B2*(4type!4concat'%26fieldsJ%5B'REF'%26ALT'%5D%26separator!4%20%E2%86%924%26newF%2BLAB')2%5DG'alignment!4overlay'G%3C2*(2*%3DZ2*)G*(2**'mark!4text'G**'textJ(4f%2BLABH*'%23%3DZG**'color%24!4white'%20)G**%3B1%20)G**'visibilityJ%5B(2***'target!*'mark'G***'operation!*'LT'G***'measure!4width'G***'transitionPaddingJ30G***'threshold!4%7Cxe-x%7C'2**)%5D2*)2%5DG'mark!4rect'G'x%22ZG'stroke!C%26l72'strokeWidth%24J1)G'color!C%26l72'row!C%26l72'tooltipJ%5B2*XPOS%25)G*XPOSEND%25)G*C)G*XALTH4%23XREFH4%23XQUALH4quantitative')2%5DG%3B0.9%20)G'widthJ600G'heightJ100~***)~**%5D~*)~%5D%0A)*%20%202~****4%20'7egendJtrue%26domainJ%5B'insertion'%26deletion'%5D)%2CCXMUTTYPEH4nominal'G%2C2H'%26type!J!%20Kttps%3A%2F%2Fs3.amazonaws.com%2Fgosling-lang.org%2Fdata%2FSV%2FX%20(4f%2BZ%25%26axis!4top')jINDEL_test_tumor_normal_with_panel.vcf.gz~%0A*%22J('f%2BPOS%23nominal')G*%24J(4value%25H4genomic'%26%2C4%2Bield!4%3B'opacity%24J%3C'tracksJ%5B%3D*'xe%22END%01%3D%3C%3B%2B%26%25%24%23%22~jZXKJHGC742*_">Code</a>