### PR TITLE
chore: use github warning markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 <img width="1549" alt="teaser" src="https://user-images.githubusercontent.com/9922882/109852545-e05f3400-7c22-11eb-90f3-7371e4ddeb42.png">
 
-> ⚠️ Please be aware that the grammar of Gosling.js may change to some extent before the first official release.
+> **Warning**
+> Please be aware that the grammar of Gosling.js may change to some extent before the first official release.
 
 ## Why Gosling?
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <img width="1549" alt="teaser" src="https://user-images.githubusercontent.com/9922882/109852545-e05f3400-7c22-11eb-90f3-7371e4ddeb42.png">
 
 > **Warning**
-> Please be aware that the grammar of Gosling.js may change to some extent before the first official release.
+> Please be aware that the grammar of Gosling.js is subject to change before the v1.0.0 release.
 
 ## Why Gosling?
 


### PR DESCRIPTION
GitHub introduced support for `**Note**` and `**Warning**` in markdown. I've applied the change here, which you can see in the markdown preview.

As a general question, should we change the wording in the warning? It seems to me that Gosling has officially been "released" but the grammar is subject to changes?
