### PR TITLE
feat(editor): visualize JS spec using Gist URL

### DIFF
--- a/editor/editor-panel.tsx
+++ b/editor/editor-panel.tsx
@@ -8,6 +8,8 @@ import goslingSpec from '../src/core/gosling.schema?raw';
 export * from './monaco_worker';
 import * as Monaco from 'monaco-editor';
 
+export type EditorLangauge = 'json' | 'javascript';
+
 function EditorPanel(props: {
     code: string;
     readOnly?: boolean;
@@ -17,7 +19,7 @@ function EditorPanel(props: {
     onChange?: (code: string, language: string) => void;
     hide?: boolean;
     isDarkTheme?: boolean;
-    language: string;
+    language: EditorLangauge;
 }) {
     const { code: templateCode, readOnly, openFindBox, fontZoomIn, fontZoomOut, isDarkTheme, language } = props;
     const editor = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);

--- a/editor/editor-panel.tsx
+++ b/editor/editor-panel.tsx
@@ -16,7 +16,7 @@ function EditorPanel(props: {
     openFindBox?: boolean;
     fontZoomIn?: boolean;
     fontZoomOut?: boolean;
-    onChange?: (code: string, language: string) => void;
+    onChange?: (code: string, language: EditorLangauge) => void;
     hide?: boolean;
     isDarkTheme?: boolean;
     language: EditorLangauge;

--- a/editor/editor-panel.tsx
+++ b/editor/editor-panel.tsx
@@ -8,7 +8,7 @@ import goslingSpec from '../src/core/gosling.schema?raw';
 export * from './monaco_worker';
 import * as Monaco from 'monaco-editor';
 
-export type EditorLangauge = 'json' | 'javascript';
+export type EditorLangauge = 'json' | 'javascript' | 'typescript';
 
 function EditorPanel(props: {
     code: string;

--- a/editor/editor-panel.tsx
+++ b/editor/editor-panel.tsx
@@ -8,7 +8,7 @@ import goslingSpec from '../src/core/gosling.schema?raw';
 export * from './monaco_worker';
 import * as Monaco from 'monaco-editor';
 
-export type EditorLangauge = 'json' | 'javascript' | 'typescript';
+export type EditorLangauge = 'json' | 'typescript';
 
 function EditorPanel(props: {
     code: string;

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -351,7 +351,7 @@ function Editor(props: RouteComponentProps) {
             setCode(urlSpec);
             setJsCode(json2js(urlSpec));
         } else if (urlGist) {
-            setCode(emptySpec());
+            setCode(emptySpec('loading....'));
         } else {
             const jsonCode = stringifySpec(demo.spec as gosling.GoslingSpec);
             setCode(jsonCode);
@@ -1181,8 +1181,9 @@ function Editor(props: RouteComponentProps) {
                                                                 key={JSON.stringify(d)}
                                                                 onClick={() => setSelectedPreviewData(i)}
                                                             >
-                                                                {`${(JSON.parse(d.dataConfig).data
-                                                                    .type as string).toLocaleLowerCase()} `}
+                                                                {`${(
+                                                                    JSON.parse(d.dataConfig).data.type as string
+                                                                ).toLocaleLowerCase()} `}
                                                                 <small>{i}</small>
                                                             </button>
                                                         ))}

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -197,7 +197,7 @@ const fetchSpecFromGist = async (gist: string) => {
         } else {
             jsCode = code;
             jsonCode = emptySpec('compiling...'); // set json code later in dynamic import
-            language = 'javascript';
+            language = 'typescript';
         }
         return {
             code: jsonCode,
@@ -518,7 +518,7 @@ function Editor(props: RouteComponentProps) {
                 if (!editedGos || valid?.state !== 'success' || (!autoRun && !run)) return;
 
                 setGoslingSpec(editedGos);
-            } else if (language === 'javascript') {
+            } else if (language === 'typescript') {
                 // vite-ignore to enable dynamic import from data uri
                 import(/* @vite-ignore */ esm`${codeParser(jsCode)}`)
                     .then(ns => {
@@ -1011,9 +1011,9 @@ function Editor(props: RouteComponentProps) {
                                             </span>
                                         </button>
                                         <button
-                                            className={`tablinks ${language == 'javascript' && 'active'}`}
+                                            className={`tablinks ${language == 'typescript' && 'active'}`}
                                             onClick={() => {
-                                                changeLanguage('javascript');
+                                                changeLanguage('typescript');
                                                 setLog({ message: '', state: 'success' });
                                             }}
                                         >
@@ -1041,7 +1041,7 @@ function Editor(props: RouteComponentProps) {
                                             language="json"
                                         />
                                     </div>
-                                    <div className={`tabContent ${language == 'javascript' ? 'show' : 'hide'}`}>
+                                    <div className={`tabContent ${language == 'typescript' ? 'show' : 'hide'}`}>
                                         <EditorPanel
                                             code={jsCode}
                                             readOnly={readOnly}
@@ -1050,7 +1050,6 @@ function Editor(props: RouteComponentProps) {
                                             fontZoomOut={isFontZoomOut}
                                             onChange={debounceCodeEdit.current}
                                             isDarkTheme={theme === 'dark'}
-                                            // language="javascript"
                                             language="typescript"
                                         />
                                     </div>

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -4,7 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import gfm from 'remark-gfm';
 import PubSub from 'pubsub-js';
 import fetchJsonp from 'fetch-jsonp';
-import EditorPanel from './editor-panel';
+import EditorPanel, { EditorLangauge } from './editor-panel';
 import { drag as d3Drag } from 'd3-drag';
 import { event as d3Event } from 'd3-selection';
 import { select as d3Select } from 'd3-selection';
@@ -185,7 +185,7 @@ const fetchSpecFromGist = async (gist: string) => {
     );
 
     return Promise.all([whenCode, whenText]).then(([code, description]) => {
-        let jsonCode: string, jsCode: string, language: string;
+        let jsonCode: string, jsCode: string, language: EditorLangauge;
         if (!code) {
             language = 'json';
             jsCode = emptySpec('no content from the gist');
@@ -234,7 +234,7 @@ function Editor(props: RouteComponentProps) {
 
     const previewData = useRef<PreviewData[]>([]);
     const [refreshData, setRefreshData] = useState<boolean>(false);
-    const [language, changeLanguage] = useState<string>('json');
+    const [language, changeLanguage] = useState<EditorLangauge>('json');
 
     const [demo, setDemo] = useState(
         examples[urlExampleId] ? { id: urlExampleId, ...examples[urlExampleId] } : INIT_DEMO
@@ -302,7 +302,7 @@ function Editor(props: RouteComponentProps) {
     const gosRef = useRef<gosling.GoslingRef>(null);
 
     const debounceCodeEdit = useRef(
-        debounce((code: string, language: string) => {
+        debounce((code: string, language: EditorLangauge) => {
             if (language == 'json') {
                 setCode(code);
             } else {

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -32,6 +32,15 @@ function json2js(jsonCode: string | null) {
     return `var spec = ${jsonCode} \nexport { spec }; \n`;
 }
 
+function isJSON(str: string | null) {
+    if (!str) return false;
+    try {
+        return JSON.parse(str);
+    } catch (e) {
+        return false;
+    }
+}
+
 // a hack to solve the reference erro in typescript
 // some posts fixed it thorugh changing ts compiler options, but did not work for me
 // https://stackoverflow.com/questions/34895737/uncaught-referenceerror-exports-is-not-defined-and-require
@@ -179,7 +188,7 @@ const fetchSpecFromGist = async (gist: string) => {
 
     return Promise.all([whenCode, whenText]).then(([code, description]) => {
         let jsonCode: string | null, jsCode: string, language: string;
-        if (code?.startsWith('{')) {
+        if (isJSON(code)) {
             language = 'json';
             jsonCode = resolveRelativeCsvUrls(code, specUrl);
             jsCode = json2js(jsonCode);

--- a/editor/example/json-spec/mark-displacement.ts
+++ b/editor/example/json-spec/mark-displacement.ts
@@ -4,7 +4,7 @@ import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
     title: 'Mark Displacement',
-    subtitle: 'Reposition marks to address visual overlaps using `displacement` options',
+    subtitle: 'Reposition marks to address visual overlaps using displacement options',
     // static: true,
     spacing: 1,
     centerRadius: 0.8,

--- a/editor/example/spec/basic-semantic-zoom.ts
+++ b/editor/example/spec/basic-semantic-zoom.ts
@@ -17,7 +17,7 @@ const getVisibilityCondition = (thresholds: [number | undefined, number | undefi
             conditions.push({
                 operation: i == 0 ? 'GT' : 'LT',
                 target: 'mark',
-                threshold: 100000000,
+                threshold,
                 measure: 'zoomLevel'
             });
         }


### PR DESCRIPTION
enable users to open gist examples that are written in js/ts

e.g., http://localhost:3000/?gist=wangqianwen0418/d92364a49e434ee22acdf2b16de11d76