### PR TITLE
chore: set `importsNotUsedAsValues` compiler flag

### DIFF
--- a/editor/example/doc-examples/triangle.ts
+++ b/editor/example/doc-examples/triangle.ts
@@ -1,5 +1,4 @@
-import { SingleTrack } from '@gosling.schema';
-import type { GoslingSpec } from 'gosling.js';
+import type { GoslingSpec, SingleTrack } from '@gosling.schema';
 
 import { HiGlass } from '../json-spec/gene-annotation';
 

--- a/editor/example/json-spec/basic-semantic-zoom.ts
+++ b/editor/example/json-spec/basic-semantic-zoom.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec } from 'gosling.js';
+import type { GoslingSpec } from 'gosling.js';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 export const EX_SPEC_BASIC_SEMANTIC_ZOOM: GoslingSpec = {

--- a/editor/example/json-spec/mark-displacement.ts
+++ b/editor/example/json-spec/mark-displacement.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec } from 'gosling.js';
+import type { GoslingSpec } from 'gosling.js';
 import { EX_SPEC_GENE_TRANSCRIPT } from './gene-transcript';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 

--- a/editor/example/json-spec/matrix.ts
+++ b/editor/example/json-spec/matrix.ts
@@ -1,4 +1,4 @@
-import { PREDEFINED_COLORS, SingleTrack } from '@gosling.schema';
+import type { PredefinedColors, SingleTrack } from '@gosling.schema';
 import type { GoslingSpec } from 'gosling.js';
 import { random } from 'lodash';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
@@ -126,7 +126,7 @@ export const EX_SPEC_MATRIX: GoslingSpec = {
 
 const getMatrix: (
     t: string,
-    c: PREDEFINED_COLORS,
+    c: PredefinedColors,
     e: 'full' | 'upper-right' | 'lower-left',
     w: number,
     h: number

--- a/editor/example/json-spec/mouse-event.ts
+++ b/editor/example/json-spec/mouse-event.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec, SingleTrack } from '@gosling.schema';
+import type { GoslingSpec, SingleTrack } from '@gosling.schema';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 import { CytoBands } from './ideograms';
 

--- a/editor/example/json-spec/responsive-alignment.ts
+++ b/editor/example/json-spec/responsive-alignment.ts
@@ -1,4 +1,4 @@
-import { OverlaidTracks, SingleTrack, SingleView } from '@gosling.schema';
+import type { OverlaidTracks, SingleTrack, SingleView } from '@gosling.schema';
 import type { GoslingSpec } from 'gosling.js';
 import { CHANNEL_DEFAULTS } from '../../../src/core/channel';
 

--- a/editor/example/json-spec/responsive-track-wise-comparison.ts
+++ b/editor/example/json-spec/responsive-track-wise-comparison.ts
@@ -1,4 +1,4 @@
-import { DomainChrInterval, GoslingSpec, OverlaidTracks, SingleTrack, TemplateTrack } from '@gosling.schema';
+import type { DomainChrInterval, GoslingSpec, OverlaidTracks, SingleTrack, TemplateTrack } from '@gosling.schema';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 const trackColor = {

--- a/editor/example/json-spec/responsive.ts
+++ b/editor/example/json-spec/responsive.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec } from '@gosling.schema';
+import type { GoslingSpec } from '@gosling.schema';
 
 export const EX_SPEC_RESPONSIVE_SEGREGATED_AREA_CHART: GoslingSpec = {
     // title: 'Responsive Visualization',

--- a/editor/example/json-spec/sashimi.ts
+++ b/editor/example/json-spec/sashimi.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec } from 'gosling.js';
+import type { GoslingSpec } from '@gosling.schema';
 
 export const EX_SPEC_SASHIMI: GoslingSpec = {
     title: 'Sashimi Plot',

--- a/editor/example/json-spec/theme.ts
+++ b/editor/example/json-spec/theme.ts
@@ -1,4 +1,4 @@
-import type { GoslingSpec } from 'gosling.js';
+import type { GoslingSpec } from '@gosling.schema';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 export const EX_SPEC_CUSTOM_THEME: GoslingSpec = {

--- a/editor/example/json-spec/visual-linking.ts
+++ b/editor/example/json-spec/visual-linking.ts
@@ -1,4 +1,4 @@
-import type { GoslingSpec } from 'gosling.js';
+import type { GoslingSpec } from '@gosling.schema';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 export const EX_SPEC_LINKING: GoslingSpec = {

--- a/editor/example/spec/basic-semantic-zoom.ts
+++ b/editor/example/spec/basic-semantic-zoom.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec, VisibilityCondition, MultivecData } from '@gosling.schema';
+import type { GoslingSpec, VisibilityCondition, MultivecData } from '@gosling.schema';
 
 const data: MultivecData = {
     type: 'multivec',

--- a/editor/example/spec/corces.ts
+++ b/editor/example/spec/corces.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec, PartialTrack, View, BIGWIGData, BEDDBData } from '@gosling.schema';
+import type { GoslingSpec, PartialTrack, View, BIGWIGData, BEDDBData } from '@gosling.schema';
 
 const width = 400;
 

--- a/editor/example/spec/rule.ts
+++ b/editor/example/spec/rule.ts
@@ -1,4 +1,4 @@
-import { PartialTrack, GoslingSpec, JSONData } from '@gosling.schema';
+import type { PartialTrack, GoslingSpec, JSONData } from '@gosling.schema';
 
 const barTrack: PartialTrack = {
     data: {

--- a/editor/example/spec/sashimi.ts
+++ b/editor/example/spec/sashimi.ts
@@ -1,4 +1,4 @@
-import { BAMData, GoslingSpec } from '@gosling.schema';
+import type { BAMData, GoslingSpec } from '@gosling.schema';
 
 const bamData: BAMData = {
     type: 'bam',

--- a/editor/example/spec/vertical-band.ts
+++ b/editor/example/spec/vertical-band.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec, CSVData, Track } from '@gosling.schema';
+import type { GoslingSpec, CSVData, Track } from '@gosling.schema';
 const data: CSVData = {
     type: 'csv',
     url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',

--- a/editor/example/spec/visual-encoding-circular.ts
+++ b/editor/example/spec/visual-encoding-circular.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec, View, MultivecData, Tooltip } from '@gosling.schema';
+import type { GoslingSpec, View, MultivecData, Tooltip } from '@gosling.schema';
 
 const size = { width: 350, height: 130 };
 const data: MultivecData = {

--- a/editor/example/spec/visual-encoding.ts
+++ b/editor/example/spec/visual-encoding.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec, MultivecData, View, Tooltip } from '@gosling.schema';
+import type { GoslingSpec, MultivecData, View, Tooltip } from '@gosling.schema';
 
 const size = { width: 600, height: 130 };
 

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -5009,20 +5009,6 @@
       ],
       "type": "object"
     },
-    "PREDEFINED_COLORS": {
-      "enum": [
-        "viridis",
-        "grey",
-        "spectral",
-        "warm",
-        "cividis",
-        "bupu",
-        "rdbu",
-        "hot",
-        "pink"
-      ],
-      "type": "string"
-    },
     "PartialTrack": {
       "additionalProperties": false,
       "properties": {
@@ -5748,13 +5734,27 @@
       },
       "type": "object"
     },
+    "PredefinedColors": {
+      "enum": [
+        "viridis",
+        "grey",
+        "spectral",
+        "warm",
+        "cividis",
+        "bupu",
+        "rdbu",
+        "hot",
+        "pink"
+      ],
+      "type": "string"
+    },
     "Range": {
       "anyOf": [
         {
           "$ref": "#/definitions/ValueExtent"
         },
         {
-          "$ref": "#/definitions/PREDEFINED_COLORS"
+          "$ref": "#/definitions/PredefinedColors"
         }
       ]
     },

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,9 +1,9 @@
 import * as PIXI from 'pixi.js';
-import { Datum } from './gosling.schema';
-import { HiGlassApi } from './higlass-component-wrapper';
-import { HiGlassSpec } from './higlass.schema';
+import type { Datum } from './gosling.schema';
+import type { HiGlassApi } from './higlass-component-wrapper';
+import type { HiGlassSpec } from './higlass.schema';
 import { GET_CHROM_SIZES } from './utils/assembly';
-import { CompleteThemeDeep } from './utils/theme';
+import type { CompleteThemeDeep } from './utils/theme';
 import { traverseViewsInViewConfig } from './utils/view-config';
 
 export type CommonEventData = {

--- a/src/core/compile.test.ts
+++ b/src/core/compile.test.ts
@@ -1,7 +1,7 @@
 import { EX_SPEC_VISUAL_ENCODING } from '../../editor/example/json-spec/visual-encoding';
 import { compile } from './compile';
 import { getTheme } from './utils/theme';
-import { GoslingSpec } from '../index';
+import type { GoslingSpec } from '../index';
 
 describe('compile', () => {
     it('compile should not touch the original spec of users', () => {

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -1,9 +1,9 @@
-import { GoslingSpec, TemplateTrackDef } from './gosling.schema';
-import { HiGlassSpec } from './higlass.schema';
+import type { GoslingSpec, TemplateTrackDef } from './gosling.schema';
+import type { HiGlassSpec } from './higlass.schema';
 import { traverseToFixSpecDownstream, overrideDataTemplates } from './utils/spec-preprocess';
 import { replaceTrackTemplates } from './utils/template';
 import { getRelativeTrackInfo, Size } from './utils/bounding-box';
-import { CompleteThemeDeep } from './utils/theme';
+import type { CompleteThemeDeep } from './utils/theme';
 import { renderHiGlass as createHiGlassModels } from './create-higlass-models';
 import { manageResponsiveSpecs } from './responsive';
 

--- a/src/core/create-higlass-models.ts
+++ b/src/core/create-higlass-models.ts
@@ -1,10 +1,10 @@
 import { getBoundingBox, Size, TrackInfo } from './utils/bounding-box';
 import { goslingToHiGlass } from './gosling-to-higlass';
 import { HiGlassModel } from './higlass-model';
-import { HiGlassSpec } from './higlass.schema';
 import { getLinkingInfo } from './utils/linking';
-import { GoslingSpec } from './gosling.schema';
-import { CompleteThemeDeep } from './utils/theme';
+import type { HiGlassSpec } from './higlass.schema';
+import type { GoslingSpec } from './gosling.schema';
+import type { CompleteThemeDeep } from './utils/theme';
 
 export function renderHiGlass(
     spec: GoslingSpec,

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -5,11 +5,12 @@ import { ResizeSensor } from 'css-element-queries';
 import * as gosling from '..';
 import { getTheme, Theme } from './utils/theme';
 import { createApi, GoslingApi } from './api';
-import { TemplateTrackDef } from './gosling.schema';
 import { GoslingTemplates } from '..';
 import { omitDeep } from './utils/omit-deep';
 import { isEqual } from 'lodash';
 import * as uuid from 'uuid';
+
+import type { TemplateTrackDef } from './gosling.schema';
 
 // Before rerendering, wait for a few time so that HiGlass container is resized already.
 // If HiGlass is rendered and then the container resizes, the viewport position changes, unmatching `xDomain` specified by users.

--- a/src/core/gosling-embed.ts
+++ b/src/core/gosling-embed.ts
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { GoslingSpec } from './gosling.schema';
-import { HiGlassSpec } from './higlass.schema';
+import type { GoslingSpec } from './gosling.schema';
+import type { HiGlassSpec } from './higlass.schema';
 
 import { validateGoslingSpec } from './utils/validate';
 import { compile } from './compile';

--- a/src/core/gosling-to-higlass.test.ts
+++ b/src/core/gosling-to-higlass.test.ts
@@ -1,9 +1,10 @@
 import { goslingToHiGlass } from './gosling-to-higlass';
-import { SingleTrack } from './gosling.schema';
 import { HiGlassModel } from './higlass-model';
 import { EX_TRACK_SEMANTIC_ZOOM } from '../../editor/example/json-spec/semantic-zoom';
 import { convertToFlatTracks } from './utils/spec-preprocess';
 import { getTheme } from './utils/theme';
+
+import type { SingleTrack } from './gosling.schema';
 
 describe('Should convert gosling spec to higlass view config.', () => {
     it('Should return a generated higlass view config correctly', () => {

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -1,9 +1,9 @@
 import * as uuid from 'uuid';
-import { Track as HiGlassTrack } from './higlass.schema';
+import type { Track as HiGlassTrack } from './higlass.schema';
 import { HiGlassModel, HIGLASS_AXIS_SIZE } from './higlass-model';
 import { parseServerAndTilesetUidFromUrl } from './utils';
-import { Track, Domain } from './gosling.schema';
-import { BoundingBox, RelativePosition } from './utils/bounding-box';
+import type { Track, Domain } from './gosling.schema';
+import type { BoundingBox, RelativePosition } from './utils/bounding-box';
 import { resolveSuperposedTracks } from './utils/overlay';
 import { getGenomicChannelKeyFromTrack, getGenomicChannelFromTrack } from './utils/validate';
 import {
@@ -16,7 +16,7 @@ import {
     getHiGlassColorRange
 } from './gosling.schema.guards';
 import { DEWFAULT_TITLE_PADDING_ON_TOP_AND_BOTTOM } from './defaults';
-import { CompleteThemeDeep } from './utils/theme';
+import type { CompleteThemeDeep } from './utils/theme';
 import { DEFAULT_TEXT_STYLE } from './utils/text-style';
 
 /**

--- a/src/core/gosling-track-model.test.ts
+++ b/src/core/gosling-track-model.test.ts
@@ -1,5 +1,5 @@
 import { GoslingTrackModel } from './gosling-track-model';
-import { Track } from './gosling.schema';
+import type { Track } from './gosling.schema';
 import { isEqual } from 'lodash-es';
 import { IsChannelDeep, IsChannelValue } from './gosling.schema.guards';
 import { getTheme } from './utils/theme';

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -1,7 +1,7 @@
 import * as uuid from 'uuid';
-import {
+import type {
     ChannelDeep,
-    PREDEFINED_COLORS,
+    PredefinedColors,
     ChannelTypes,
     ChannelValue,
     SingleTrack,
@@ -24,7 +24,7 @@ import { interpolateViridis } from 'd3-scale-chromatic';
 import { min as d3min, max as d3max, sum as d3sum, group } from 'd3-array';
 import { HIGLASS_AXIS_SIZE } from './higlass-model';
 import { SUPPORTED_CHANNELS } from './mark';
-import { PIXIVisualProperty } from './visual-property.schema';
+import type { PIXIVisualProperty } from './visual-property.schema';
 import { rectProperty } from './mark/rect';
 import { pointProperty } from './mark/point';
 import { barProperty } from './mark/bar';
@@ -670,7 +670,7 @@ export class GoslingTrackModel {
                                 break;
                             case 'color':
                             case 'stroke':
-                                range = CHANNEL_DEFAULTS.QUANTITATIVE_COLOR as PREDEFINED_COLORS;
+                                range = CHANNEL_DEFAULTS.QUANTITATIVE_COLOR as PredefinedColors;
                                 break;
                             case 'size':
                                 range = this.theme.markCommon.quantitativeSizeRange;
@@ -686,7 +686,7 @@ export class GoslingTrackModel {
                                 break;
                         }
                         if (range) {
-                            channel.range = range as PREDEFINED_COLORS | number[];
+                            channel.range = range as PredefinedColors | number[];
                         }
                     }
                 } else if (IsChannelDeep(channel) && channel.type === 'nominal') {

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     ChannelDeep,
     ChannelValue,
     DataDeep,

--- a/src/core/gosling.schema.test.ts
+++ b/src/core/gosling.schema.test.ts
@@ -1,4 +1,4 @@
-import { Channel, SingleTrack } from './gosling.schema';
+import type { Channel, SingleTrack } from './gosling.schema';
 import {
     IsChannelDeep,
     IsChannelValue,

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -1,4 +1,4 @@
-import { Chromosome } from './utils/chrom-size';
+import type { Chromosome } from './utils/chrom-size';
 
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec =
@@ -651,8 +651,8 @@ export type FieldType = 'genomic' | 'nominal' | 'quantitative';
 export type ValueExtent = string[] | number[];
 export type GenomicDomain = DomainInterval | DomainChrInterval | DomainChr | DomainGene;
 export type Domain = ValueExtent | GenomicDomain;
-export type Range = ValueExtent | PREDEFINED_COLORS;
-export type PREDEFINED_COLORS = 'viridis' | 'grey' | 'spectral' | 'warm' | 'cividis' | 'bupu' | 'rdbu' | 'hot' | 'pink';
+export type Range = ValueExtent | PredefinedColors;
+export type PredefinedColors = 'viridis' | 'grey' | 'spectral' | 'warm' | 'cividis' | 'bupu' | 'rdbu' | 'hot' | 'pink';
 
 export interface DomainChr {
     // For showing a certain chromosome

--- a/src/core/higlass-component-wrapper.tsx
+++ b/src/core/higlass-component-wrapper.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable react/prop-types */
-import * as PIXI from 'pixi.js';
+import type * as PIXI from 'pixi.js';
 import React, { useEffect, useState, forwardRef, useMemo } from 'react';
 import * as uuid from 'uuid';
 
 import * as gosling from '..';
 // @ts-ignore
 import { HiGlassComponent } from 'higlass';
-import { HiGlassSpec } from './higlass.schema';
+import type { HiGlassSpec } from './higlass.schema';
 
 /**
  * Register plugin tracks and data fetchers to HiGlass. This is necessary for the first time before using Gosling.

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -1,12 +1,12 @@
 import * as uuid from 'uuid';
-import { HiGlassSpec, Track } from './higlass.schema';
+import type { HiGlassSpec, Track } from './higlass.schema';
 import HiGlassSchema from '../../schema/higlass.schema.json';
-import { Assembly, AxisPosition, Domain, Orientation, ZoomLimits } from './gosling.schema';
+import type { Assembly, AxisPosition, Domain, Orientation, ZoomLimits } from './gosling.schema';
 import { getNumericDomain } from './utils/scales';
-import { RelativePosition } from './utils/bounding-box';
+import type { RelativePosition } from './utils/bounding-box';
 import { validateSpec } from './utils/validate';
 import { GET_CHROM_SIZES } from './utils/assembly';
-import { CompleteThemeDeep } from './utils/theme';
+import type { CompleteThemeDeep } from './utils/theme';
 import exampleHg from './example/hg-view-config-1';
 import { insertItemToArray } from './utils/array';
 

--- a/src/core/higlass.schema.ts
+++ b/src/core/higlass.schema.ts
@@ -1,7 +1,7 @@
 // HiGlass Specification Should be consistent to the following scheme:
 // https://github.com/higlass/higlass/blob/develop/app/schema.json (2ced037)
 
-import { Assembly, FilterTransform } from './gosling.schema';
+import type { Assembly, FilterTransform } from './gosling.schema';
 
 // The json schema is converted to TypeScript codes using:
 // https://github.com/quicktype/quicktype

--- a/src/core/mark/area.ts
+++ b/src/core/mark/area.ts
@@ -1,5 +1,5 @@
-import { GoslingTrackModel } from '../gosling-track-model';
-import { Channel, Datum } from '../gosling.schema';
+import type { GoslingTrackModel } from '../gosling-track-model';
+import type { Channel, Datum } from '../gosling.schema';
 import { min as d3min, max as d3max, group } from 'd3-array';
 import { IsStackedMark, getValueUsingChannel } from '../gosling.schema.guards';
 import { cartesianToPolar } from '../utils/polar';

--- a/src/core/mark/axis.test.ts
+++ b/src/core/mark/axis.test.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
-import { SingleTrack } from '../gosling.schema';
+import type { SingleTrack } from '../gosling.schema';
 import { getTheme } from '../utils/theme';
 import { drawLinearYAxis } from './axis';
 

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -1,7 +1,7 @@
-import { GoslingTrackModel } from '../gosling-track-model';
+import type { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
-import { CompleteThemeDeep } from '../utils/theme';
+import type { CompleteThemeDeep } from '../utils/theme';
 import { scaleLinear } from 'd3-scale';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import { getTextStyle } from '../utils/text-style';

--- a/src/core/mark/background.ts
+++ b/src/core/mark/background.ts
@@ -1,8 +1,8 @@
 import { isUndefined } from 'lodash-es';
-import { GoslingTrackModel } from '../gosling-track-model';
+import type { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
-import { CompleteThemeDeep } from '../utils/theme';
+import type { CompleteThemeDeep } from '../utils/theme';
 
 export function drawBackground(
     HGC: any,

--- a/src/core/mark/bar.ts
+++ b/src/core/mark/bar.ts
@@ -1,7 +1,7 @@
-import { GoslingTrackModel } from '../gosling-track-model';
-import { Channel } from '../gosling.schema';
+import type { GoslingTrackModel } from '../gosling-track-model';
+import type { Channel } from '../gosling.schema';
 import { group } from 'd3-array';
-import { PIXIVisualProperty } from '../visual-property.schema';
+import type { PIXIVisualProperty } from '../visual-property.schema';
 import { IsChannelDeep, IsStackedMark, getValueUsingChannel } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';

--- a/src/core/mark/betweenLink.ts
+++ b/src/core/mark/betweenLink.ts
@@ -1,6 +1,6 @@
-import * as PIXI from 'pixi.js';
-import { GoslingTrackModel } from '../gosling-track-model';
-import { Channel } from '../gosling.schema';
+import type * as PIXI from 'pixi.js';
+import type { GoslingTrackModel } from '../gosling-track-model';
+import type { Channel } from '../gosling.schema';
 import { getValueUsingChannel, Is2DTrack } from '../gosling.schema.guards';
 import { cartesianToPolar, positionToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';

--- a/src/core/mark/grid.test.ts
+++ b/src/core/mark/grid.test.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
-import { SingleTrack } from '../gosling.schema';
+import type { SingleTrack } from '../gosling.schema';
 import { getTheme } from '../utils/theme';
 import { drawGrid } from './grid';
 

--- a/src/core/mark/grid.ts
+++ b/src/core/mark/grid.ts
@@ -1,9 +1,9 @@
-import { ScaleLinear } from 'd3-scale';
-import { GoslingTrackModel } from '../gosling-track-model';
+import type { ScaleLinear } from 'd3-scale';
+import type { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
-import { CompleteThemeDeep } from '../utils/theme';
+import type { CompleteThemeDeep } from '../utils/theme';
 
 export function drawGrid(trackInfo: any, tm: GoslingTrackModel, theme: Required<CompleteThemeDeep>) {
     drawYGridQuantitative(trackInfo, tm, theme);

--- a/src/core/mark/index.test.ts
+++ b/src/core/mark/index.test.ts
@@ -1,6 +1,6 @@
 import { drawMark } from '.';
 import { GoslingTrackModel } from '../gosling-track-model';
-import { SingleTrack } from '../gosling.schema';
+import type { SingleTrack } from '../gosling.schema';
 import { getTheme } from '../utils/theme';
 
 describe('Should draw marks correctly', () => {

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -1,10 +1,10 @@
-import { GoslingTrackModel } from '../gosling-track-model';
+import type { GoslingTrackModel } from '../gosling-track-model';
 import { drawPoint } from './point';
 import { drawLine } from './line';
 import { drawBar } from './bar';
 import { drawArea } from './area';
 import { drawRect } from './rect';
-import { ChannelTypes } from '../gosling.schema';
+import type { ChannelTypes } from '../gosling.schema';
 import { drawTriangle } from './triangle';
 import { drawText } from './text';
 import { drawRule } from './rule';
@@ -16,7 +16,7 @@ import { drawColorLegend, drawRowLegend } from './legend';
 import { drawCircularYAxis, drawLinearYAxis } from './axis';
 import { drawCircularOutlines } from './outline-circular';
 import { drawBackground } from './background';
-import { CompleteThemeDeep } from '../utils/theme';
+import type { CompleteThemeDeep } from '../utils/theme';
 import { Is2DTrack, IsVerticalRule } from '../gosling.schema.guards';
 import { drawBetweenLink } from './betweenLink';
 

--- a/src/core/mark/legend.test.ts
+++ b/src/core/mark/legend.test.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
-import { SingleTrack } from '../gosling.schema';
+import type { SingleTrack } from '../gosling.schema';
 import { getTheme } from '../utils/theme';
 import { drawColorLegend } from './legend';
 

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -1,8 +1,8 @@
-import { GoslingTrackModel } from '../gosling-track-model';
+import type { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
-import { CompleteThemeDeep } from '../utils/theme';
-import { Dimension } from '../utils/position';
+import type { CompleteThemeDeep } from '../utils/theme';
+import type { Dimension } from '../utils/position';
 import { scaleLinear, ScaleLinear } from 'd3-scale';
 import { getTextStyle } from '../utils/text-style';
 

--- a/src/core/mark/line.test.ts
+++ b/src/core/mark/line.test.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
-import { SingleTrack } from '../gosling.schema';
+import type { SingleTrack } from '../gosling.schema';
 import { getTheme } from '../utils/theme';
 import { drawLine } from './line';
 

--- a/src/core/mark/line.ts
+++ b/src/core/mark/line.ts
@@ -1,6 +1,6 @@
-import * as PIXI from 'pixi.js';
-import { GoslingTrackModel } from '../gosling-track-model';
-import { Channel } from '../gosling.schema';
+import type * as PIXI from 'pixi.js';
+import type { GoslingTrackModel } from '../gosling-track-model';
+import type { Channel } from '../gosling.schema';
 import { getValueUsingChannel } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
 import { cartesianToPolar } from '../utils/polar';

--- a/src/core/mark/outline-circular.ts
+++ b/src/core/mark/outline-circular.ts
@@ -1,8 +1,8 @@
-import { GoslingTrackModel } from '../gosling-track-model';
+import type { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
-import { CompleteThemeDeep } from '../utils/theme';
+import type { CompleteThemeDeep } from '../utils/theme';
 
 export function drawCircularOutlines(
     HGC: any,

--- a/src/core/mark/outline.ts
+++ b/src/core/mark/outline.ts
@@ -1,7 +1,7 @@
-import { GoslingTrackModel } from '../gosling-track-model';
+import type { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
-import { CompleteThemeDeep } from '../utils/theme';
+import type { CompleteThemeDeep } from '../utils/theme';
 
 export const TITLE_STYLE = {
     fontSize: '12px',

--- a/src/core/mark/point.test.ts
+++ b/src/core/mark/point.test.ts
@@ -1,9 +1,9 @@
 import * as PIXI from 'pixi.js';
 import { CHANNEL_DEFAULTS } from '../channel';
 import { GoslingTrackModel } from '../gosling-track-model';
-import { Track } from '../gosling.schema';
+import type { Track } from '../gosling.schema';
 import { HIGLASS_AXIS_SIZE } from '../higlass-model';
-import { SingleTrack } from '../gosling.schema';
+import type { SingleTrack } from '../gosling.schema';
 import { drawPoint } from './point';
 import { getTheme } from '../utils/theme';
 

--- a/src/core/mark/point.ts
+++ b/src/core/mark/point.ts
@@ -1,10 +1,10 @@
-import * as PIXI from 'pixi.js';
-import { GoslingTrackModel } from '../gosling-track-model';
-import { Channel } from '../gosling.schema';
+import type * as PIXI from 'pixi.js';
+import type { GoslingTrackModel } from '../gosling-track-model';
+import type { Channel } from '../gosling.schema';
 import { getValueUsingChannel } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
 import { cartesianToPolar } from '../utils/polar';
-import { PIXIVisualProperty } from '../visual-property.schema';
+import type { PIXIVisualProperty } from '../visual-property.schema';
 
 export function drawPoint(trackInfo: any, g: PIXI.Graphics, model: GoslingTrackModel) {
     /* track spec */
@@ -102,10 +102,11 @@ export function pointProperty(
     switch (propertyKey) {
         case 'x-center':
             return xe ? (xe + x) / 2.0 : x;
-        case 'y-center':
+        case 'y-center': {
             const ye = model.visualPropertyByChannel('ye', datum);
             const y = model.visualPropertyByChannel('y', datum);
             return ye ? (ye + y) / 2.0 : y;
+        }
         case 'p-size':
             return xe && model.spec().stretch ? (xe - x) / 2.0 : size;
         default:

--- a/src/core/mark/rect.ts
+++ b/src/core/mark/rect.ts
@@ -1,6 +1,6 @@
-import { GoslingTrackModel } from '../gosling-track-model';
+import type { GoslingTrackModel } from '../gosling-track-model';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
-import { PIXIVisualProperty } from '../visual-property.schema';
+import type { PIXIVisualProperty } from '../visual-property.schema';
 import colorToHex from '../utils/color-to-hex';
 import { IsChannelDeep } from '../gosling.schema.guards';
 

--- a/src/core/mark/rule.ts
+++ b/src/core/mark/rule.ts
@@ -1,5 +1,5 @@
-import { GoslingTrackModel } from '../gosling-track-model';
-import { Channel } from '../gosling.schema';
+import type { GoslingTrackModel } from '../gosling-track-model';
+import type { Channel } from '../gosling.schema';
 import { getValueUsingChannel } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';

--- a/src/core/mark/text.ts
+++ b/src/core/mark/text.ts
@@ -1,5 +1,5 @@
-import { GoslingTrackModel } from '../gosling-track-model';
-import { Channel } from '../gosling.schema';
+import type { GoslingTrackModel } from '../gosling-track-model';
+import type { Channel } from '../gosling.schema';
 import { group } from 'd3-array';
 import { getValueUsingChannel, IsStackedMark } from '../gosling.schema.guards';
 import { cartesianToPolar } from '../utils/polar';

--- a/src/core/mark/title.ts
+++ b/src/core/mark/title.ts
@@ -1,7 +1,7 @@
-import { GoslingTrackModel } from '../gosling-track-model';
+import type { GoslingTrackModel } from '../gosling-track-model';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
-import { CompleteThemeDeep } from '../utils/theme';
+import type { CompleteThemeDeep } from '../utils/theme';
 import { getTextStyle } from '../utils/text-style';
 
 export function drawCircularTitle(

--- a/src/core/mark/triangle.test.ts
+++ b/src/core/mark/triangle.test.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
-import { SingleTrack } from '../gosling.schema';
+import type { SingleTrack } from '../gosling.schema';
 import { getTheme } from '../utils/theme';
 import { drawTriangle } from './triangle';
 

--- a/src/core/mark/triangle.ts
+++ b/src/core/mark/triangle.ts
@@ -1,6 +1,6 @@
-import * as PIXI from 'pixi.js';
-import { GoslingTrackModel } from '../gosling-track-model';
-import { Channel, Mark } from '../gosling.schema';
+import type * as PIXI from 'pixi.js';
+import type { GoslingTrackModel } from '../gosling-track-model';
+import type { Channel, Mark } from '../gosling.schema';
 import { getValueUsingChannel } from '../gosling.schema.guards';
 import colorToHex from '../utils/color-to-hex';
 import { cartesianToPolar } from '../utils/polar';

--- a/src/core/mark/withinLink.test.ts
+++ b/src/core/mark/withinLink.test.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { GoslingTrackModel } from '../gosling-track-model';
-import { SingleTrack } from '../gosling.schema';
+import type { SingleTrack } from '../gosling.schema';
 import { getTheme } from '../utils/theme';
 import { drawWithinLink } from './withinLink';
 

--- a/src/core/mark/withinLink.ts
+++ b/src/core/mark/withinLink.ts
@@ -1,6 +1,6 @@
-import * as PIXI from 'pixi.js';
-import { GoslingTrackModel } from '../gosling-track-model';
-import { Channel } from '../gosling.schema';
+import type * as PIXI from 'pixi.js';
+import type { GoslingTrackModel } from '../gosling-track-model';
+import type { Channel } from '../gosling.schema';
 import { IsChannelDeep, getValueUsingChannel, Is2DTrack } from '../gosling.schema.guards';
 import { cartesianToPolar, positionToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';

--- a/src/core/responsive.test.ts
+++ b/src/core/responsive.test.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec } from '@gosling.schema';
+import type { GoslingSpec } from '@gosling.schema';
 import { manageResponsiveSpecs } from './responsive';
 
 describe('ResponsiveSpec', () => {

--- a/src/core/responsive.ts
+++ b/src/core/responsive.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec, SelectivityCondition, SingleView } from '@gosling.schema';
+import type { GoslingSpec, SelectivityCondition, SingleView } from '@gosling.schema';
 import { logicalComparison } from './utils/semantic-zoom';
 
 export function manageResponsiveSpecs(

--- a/src/core/utils/bounding-box.test.ts
+++ b/src/core/utils/bounding-box.test.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec, Track } from '../gosling.schema';
+import type { GoslingSpec, Track } from '../gosling.schema';
 import { DEFAULT_CIRCULAR_VIEW_PADDING, DEFAULT_VIEW_SPACING } from '../defaults';
 import { getBoundingBox, getRelativeTrackInfo } from './bounding-box';
 import { traverseToFixSpecDownstream } from './spec-preprocess';

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -1,4 +1,4 @@
-import { MultipleViews, CommonViewDef, GoslingSpec, Track, SingleView } from '../gosling.schema';
+import type { MultipleViews, CommonViewDef, GoslingSpec, Track, SingleView } from '../gosling.schema';
 import { Is2DTrack, IsOverlaidTrack, IsXAxis, IsYAxis } from '../gosling.schema.guards';
 import { HIGLASS_AXIS_SIZE } from '../higlass-model';
 import {
@@ -9,7 +9,7 @@ import {
 } from '../defaults';
 import { resolveSuperposedTracks } from './overlay';
 import { traverseTracksAndViews, traverseViewArrangements } from './spec-preprocess';
-import { CompleteThemeDeep } from './theme';
+import type { CompleteThemeDeep } from './theme';
 
 export interface Size {
     width: number;

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -1,6 +1,5 @@
-import { ScaleLinear } from 'd3-scale';
-import { assign } from 'lodash-es';
-import {
+import type { ScaleLinear } from 'd3-scale';
+import type {
     SingleTrack,
     Datum,
     FilterTransform,
@@ -391,7 +390,7 @@ export function splitExon(split: ExonSplitTransform, data: Datum[], assembly: As
                     }
                     if (!newRows[i]) {
                         // No row exist, so create one.
-                        newRows[i] = assign(JSON.parse(JSON.stringify(d)), {
+                        newRows[i] = Object.assign(JSON.parse(JSON.stringify(d)), {
                             [newField]: newValue,
                             [flag.field]: flag.value
                         });
@@ -420,7 +419,7 @@ export function parseSubJSON(_: JSONParseTransform, data: Datum[]): Datum[] {
                     row[`${genomicField}_end`] = +row[genomicField] + +d[baseGenomicField] + +row[genomicLengthField];
                 }
 
-                return assign(JSON.parse(JSON.stringify(d)), {
+                return Object.assign(JSON.parse(JSON.stringify(d)), {
                     ...row,
                     [`${genomicField}_start`]: row[`${genomicField}_start`],
                     [`${genomicField}_end`]: row[`${genomicField}_end`],

--- a/src/core/utils/linking.ts
+++ b/src/core/utils/linking.ts
@@ -1,5 +1,5 @@
 import { IsChannelDeep } from '../gosling.schema.guards';
-import { HiGlassModel } from '../higlass-model';
+import type { HiGlassModel } from '../higlass-model';
 import { SUPPORTED_CHANNELS } from '../mark';
 import { resolveSuperposedTracks } from './overlay';
 

--- a/src/core/utils/omit-deep.ts
+++ b/src/core/utils/omit-deep.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec } from '@gosling.schema';
+import type { GoslingSpec } from '@gosling.schema';
 import { cloneDeepWith, CloneDeepWithCustomizer } from 'lodash';
 
 export function omitDeep(spec: GoslingSpec, omitKeys: string[]) {

--- a/src/core/utils/overlay.test.ts
+++ b/src/core/utils/overlay.test.ts
@@ -1,4 +1,4 @@
-import { OverlaidTrack } from '../gosling.schema';
+import type { OverlaidTrack } from '../gosling.schema';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import { resolveSuperposedTracks, spreadTracksByData } from './overlay';
 

--- a/src/core/utils/overlay.ts
+++ b/src/core/utils/overlay.ts
@@ -1,5 +1,4 @@
-import { AxisPosition, SingleTrack, OverlaidTrack, Track, ChannelDeep, DataDeep } from '../gosling.schema';
-import { assign } from 'lodash-es';
+import type { AxisPosition, SingleTrack, OverlaidTrack, Track, ChannelDeep, DataDeep } from '../gosling.schema';
 import { IsChannelDeep, IsDataTrack, IsOverlaidTrack, IsSingleTrack } from '../gosling.schema.guards';
 
 /**
@@ -27,7 +26,7 @@ export function resolveSuperposedTracks(track: Track): SingleTrack[] {
 
     const resolved: SingleTrack[] = [];
     track.overlay.forEach((subSpec, i) => {
-        const spec = assign(JSON.parse(JSON.stringify(base)), subSpec) as SingleTrack;
+        const spec = Object.assign(JSON.parse(JSON.stringify(base)), subSpec) as SingleTrack;
         if (spec.title && i !== 0) {
             delete spec.title;
         }
@@ -97,7 +96,7 @@ export function spreadTracksByData(tracks: Track[]): Track[] {
                     return;
                 }
 
-                const spec = assign(JSON.parse(JSON.stringify(base)), subSpec) as SingleTrack;
+                const spec = Object.assign(JSON.parse(JSON.stringify(base)), subSpec) as SingleTrack;
                 spread.push(spec);
             });
 

--- a/src/core/utils/scales.ts
+++ b/src/core/utils/scales.ts
@@ -1,5 +1,5 @@
-import { GoslingTrackModel } from '../gosling-track-model';
-import { Assembly, Domain } from '../gosling.schema';
+import type { GoslingTrackModel } from '../gosling-track-model';
+import type { Assembly, Domain } from '../gosling.schema';
 import { SUPPORTED_CHANNELS } from '../mark';
 import {
     IsDomainChr,
@@ -9,7 +9,7 @@ import {
     IsChannelDeep
 } from '../gosling.schema.guards';
 import { GET_CHROM_SIZES } from './assembly';
-import { Chromosome } from './chrom-size';
+import type { Chromosome } from './chrom-size';
 
 /**
  * Get a numeric domain based on a domain specification.

--- a/src/core/utils/semantic-zoom.ts
+++ b/src/core/utils/semantic-zoom.ts
@@ -1,4 +1,4 @@
-import { LogicalOperation } from '../gosling.schema';
+import type { LogicalOperation } from '../gosling.schema';
 
 export function getMaxZoomLevel() {
     // TODO: How to correctly calculate maxZoomLevel?

--- a/src/core/utils/spec-preprocess.test.ts
+++ b/src/core/utils/spec-preprocess.test.ts
@@ -1,4 +1,4 @@
-import { GoslingSpec, SingleView, Track } from '../gosling.schema';
+import type { GoslingSpec, SingleView, Track } from '../gosling.schema';
 import { getBoundingBox, getRelativeTrackInfo } from './bounding-box';
 import { traverseToFixSpecDownstream, overrideDataTemplates, convertToFlatTracks } from './spec-preprocess';
 import { getTheme } from './theme';

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -1,6 +1,6 @@
 import { assign } from 'lodash-es';
 import * as uuid from 'uuid';
-import {
+import type {
     SingleTrack,
     GoslingSpec,
     View,

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -1,4 +1,3 @@
-import { assign } from 'lodash-es';
 import * as uuid from 'uuid';
 import type {
     SingleTrack,
@@ -99,7 +98,7 @@ export function convertToFlatTracks(spec: SingleView): Track[] {
         delete (base as any).tracks;
         return spec.tracks
             .filter(track => !track._invalidTrack)
-            .map(track => assign(JSON.parse(JSON.stringify(base)), track) as SingleTrack);
+            .map(track => Object.assign(JSON.parse(JSON.stringify(base)), track) as SingleTrack);
     }
 
     const newTracks: Track[] = [];
@@ -119,7 +118,7 @@ export function convertToFlatTracks(spec: SingleView): Track[] {
                     // Override track definitions from views
                     const base = JSON.parse(JSON.stringify(spec));
                     delete (base as any).tracks;
-                    const newSpec = assign(JSON.parse(JSON.stringify(base)), track) as SingleTrack;
+                    const newSpec = Object.assign(JSON.parse(JSON.stringify(base)), track) as SingleTrack;
                     newTracks.push(newSpec);
                 }
             });
@@ -141,7 +140,7 @@ export function convertToFlatTracks(spec: SingleView): Track[] {
  * @param callback
  */
 export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, parentDef?: CommonViewDef | MultipleViews) {
-    // TODO: Instead of overriding props individually, use lodash.assign()
+    // TODO: Instead of overriding props individually, use Object.assign()
     if (parentDef) {
         // For assembly and layout, we use the ones defiend by the parents if missing
         if (spec.assembly === undefined) spec.assembly = parentDef.assembly;
@@ -525,10 +524,13 @@ export function overrideDataTemplates(spec: GoslingSpec) {
         switch (t.data.type) {
             case 'vector':
             case 'bigwig':
-                ts[i] = assign(getVectorTemplate(t.data.column, t.data.value), t);
+                ts[i] = Object.assign(getVectorTemplate(t.data.column, t.data.value), t);
                 break;
             case 'multivec':
-                ts[i] = assign(getMultivecTemplate(t.data.row, t.data.column, t.data.value, t.data.categories), t);
+                ts[i] = Object.assign(
+                    getMultivecTemplate(t.data.row, t.data.column, t.data.value, t.data.categories),
+                    t
+                );
                 break;
         }
     });

--- a/src/core/utils/style.ts
+++ b/src/core/utils/style.ts
@@ -1,5 +1,5 @@
 import { assign } from 'lodash-es';
-import { Style } from '../gosling.schema';
+import type { Style } from '../gosling.schema';
 
 export function getStyleOverridden(parent: Style | undefined, child: Style | undefined) {
     // Deep overriding instead of replacing.

--- a/src/core/utils/style.ts
+++ b/src/core/utils/style.ts
@@ -1,8 +1,7 @@
-import { assign } from 'lodash-es';
 import type { Style } from '../gosling.schema';
 
 export function getStyleOverridden(parent: Style | undefined, child: Style | undefined) {
     // Deep overriding instead of replacing.
     const base = parent ? JSON.parse(JSON.stringify(parent)) : {};
-    return child ? assign(base, child) : base;
+    return child ? Object.assign(base, child) : base;
 }

--- a/src/core/utils/template.ts
+++ b/src/core/utils/template.ts
@@ -1,4 +1,3 @@
-import { assign } from 'lodash-es';
 import type {
     CustomChannelDef,
     DataTransform,
@@ -366,7 +365,7 @@ export function replaceTrackTemplates(spec: GoslingSpec, templates: TemplateTrac
                                 // This means we need to override a user's spec for this channel
                                 const base = JSON.parse(JSON.stringify(encodingSpec[baseChannelName]));
                                 delete channelMap.base;
-                                const newChannelSpec = assign(channelMap, JSON.parse(JSON.stringify(base)));
+                                const newChannelSpec = Object.assign(channelMap, JSON.parse(JSON.stringify(base)));
                                 convertedTrack[channelKey as keyof TemplateTrackMappingDef] = newChannelSpec;
                             } else {
                                 // This means a user did not specify a optional custom channel, so just remove a `base` property.

--- a/src/core/utils/template.ts
+++ b/src/core/utils/template.ts
@@ -1,5 +1,5 @@
 import { assign } from 'lodash-es';
-import {
+import type {
     CustomChannelDef,
     DataTransform,
     DataTransformWithBase,

--- a/src/core/utils/theme.ts
+++ b/src/core/utils/theme.ts
@@ -1,6 +1,5 @@
 // @ts-ignore
 import * as gt from 'gosling-theme';
-import { assign } from 'lodash-es';
 import { CHANNEL_DEFAULTS } from '../channel';
 
 /* ----------------------------- THEME ----------------------------- */
@@ -153,7 +152,7 @@ export function getTheme(theme: Theme = 'light'): Required<CompleteThemeDeep> {
         // Override defaults from `base`
         Object.keys(baseSpec).forEach(k => {
             if ((theme as any)[k] && k !== 'base') {
-                baseSpec[k] = assign(
+                baseSpec[k] = Object.assign(
                     JSON.parse(JSON.stringify(baseSpec[k])),
                     JSON.parse(JSON.stringify((theme as any)[k]))
                 );

--- a/src/core/utils/validate.ts
+++ b/src/core/utils/validate.ts
@@ -1,5 +1,5 @@
 import Ajv from 'ajv';
-import { SingleTrack, ChannelDeep, ChannelTypes, OverlaidTrack, Track } from '../gosling.schema';
+import type { SingleTrack, ChannelDeep, ChannelTypes, OverlaidTrack, Track } from '../gosling.schema';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import { resolveSuperposedTracks } from './overlay';
 import GoslingSchema from '../../../schema/gosling.schema.json';

--- a/src/core/utils/view-config.ts
+++ b/src/core/utils/view-config.ts
@@ -1,4 +1,4 @@
-import { HiGlassSpec, View } from '../higlass.schema';
+import type { HiGlassSpec, View } from '../higlass.schema';
 
 /**
  * Traverse all views in a HiGlass viewConfig.

--- a/src/data-fetcher/bam/bam-datafetcher.ts
+++ b/src/data-fetcher/bam/bam-datafetcher.ts
@@ -2,7 +2,7 @@
  * This code is based on the following repo:
  * https://github.com/higlass/higlass-pileup
  */
-import { Assembly } from '../../core/gosling.schema';
+import type { Assembly } from '../../core/gosling.schema';
 
 const DEBOUNCE_TIME = 200;
 

--- a/src/data-fetcher/csv/higlass-csv-datafetcher.ts
+++ b/src/data-fetcher/csv/higlass-csv-datafetcher.ts
@@ -1,7 +1,7 @@
 import { dsvFormat as d3dsvFormat } from 'd3-dsv';
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 import { sampleSize } from 'lodash-es';
-import { Assembly, FilterTransform } from '../../core/gosling.schema';
+import type { Assembly, FilterTransform } from '../../core/gosling.schema';
 import { filterData } from '../../core/utils/data-transform';
 
 /**

--- a/src/data-fetcher/vcf/gosling-vcf-data.ts
+++ b/src/data-fetcher/vcf/gosling-vcf-data.ts
@@ -3,7 +3,7 @@
  * https://github.com/dbmi-bgm/higlass-sv/blob/main/src/sv-fetcher.js
  */
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
-import { Assembly, VCFData } from '../../core/gosling.schema';
+import type { Assembly, VCFData } from '../../core/gosling.schema';
 
 const DEBOUNCE_TIME = 200;
 

--- a/src/gosling-mouse-event/mouse-event-model.ts
+++ b/src/gosling-mouse-event/mouse-event-model.ts
@@ -1,4 +1,4 @@
-import { Datum } from '../core/gosling.schema';
+import type { Datum } from '../core/gosling.schema';
 import { isPointInPolygon, isPointNearLine, isPointNearPoint } from './polygon';
 import * as uuid from 'uuid';
 

--- a/src/gosling-track/data-abstraction.ts
+++ b/src/gosling-track/data-abstraction.ts
@@ -1,4 +1,4 @@
-import { Datum, SingleTrack } from '../core/gosling.schema';
+import type { Datum, SingleTrack } from '../core/gosling.schema';
 import { IsDataDeepTileset } from '../core/gosling.schema.guards';
 
 export const GOSLING_DATA_ROW_UID_FIELD = 'gosling-data-row-uid';

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -1,4 +1,4 @@
-import * as PIXI from 'pixi.js';
+import type * as PIXI from 'pixi.js';
 import PubSub from 'pubsub-js';
 import * as uuid from 'uuid';
 import { isEqual, sampleSize, uniqBy } from 'lodash-es';
@@ -9,7 +9,7 @@ import { GoslingTrackModel } from '../core/gosling-track-model';
 import { validateTrack } from '../core/utils/validate';
 import { shareScaleAcrossTracks } from '../core/utils/scales';
 import { resolveSuperposedTracks } from '../core/utils/overlay';
-import { SingleTrack, OverlaidTrack, Datum } from '../core/gosling.schema';
+import type { SingleTrack, OverlaidTrack, Datum } from '../core/gosling.schema';
 import colorToHex from '../core/utils/color-to-hex';
 import {
     aggregateCoverage,
@@ -28,9 +28,9 @@ import { getRelativeGenomicPosition } from '../core/utils/assembly';
 import { getTextStyle } from '../core/utils/text-style';
 import { Is2DTrack, IsChannelDeep, IsXAxis } from '../core/gosling.schema.guards';
 import { spawn } from 'threads';
-import { InteractionEvent } from 'pixi.js';
+import type { InteractionEvent } from 'pixi.js';
 import { HIGLASS_AXIS_SIZE } from '../core/higlass-model';
-import { MouseEventData } from '../gosling-mouse-event/mouse-event-model';
+import type { MouseEventData } from '../gosling-mouse-event/mouse-event-model';
 import { flatArrayToPairArray } from '../core/utils/array';
 import { BAMDataFetcher } from '../data-fetcher/bam';
 import { GoslingVcfData } from '../data-fetcher/vcf';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "strict": true,
     "strictNullChecks": true,
     "resolveJsonModule": true,
+    "importsNotUsedAsValues": "error",
     "jsx": "react",
     "paths": {
       "gosling.js": ["./src/index.ts"],


### PR DESCRIPTION
Adds the `importsNotUsedAsValues: "error"` TS compiler option to enforce [type-only imports](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports) for types in the codebase.

Imports which are included but not used as values (e.g., only as a type) will raise an error. This is now enforced by the compiler for consistency across the codebase.

```diff
- import { GoslingSpec } from '@gosling.schema';
+ import type { GoslingSpec } from '@gosling.schema';

function example(spec: GoslingSpec) { 
  /* ... */
}
```

Additional changes:

- uses of `assign` from `lodash-es` are replaced with `Object.assign`
- the type `PREDEFINED_COLORS` is renamed to `PredefinedColors` since it refers to a type, not a constant value.
