### PR TITLE
feat: turn off mouse events by default; rename API keys; rename and restructure mouse event properties

### DIFF
--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -230,7 +230,7 @@ function Editor(props: RouteComponentProps) {
     const [goslingSpec, setGoslingSpec] = useState<gosling.GoslingSpec>();
     const [log, setLog] = useState<ReturnType<typeof gosling.validateGoslingSpec>>({ message: '', state: 'success' });
     // const [mouseEventInfo, setMouseEventInfo] =
-    //     useState<{ type: 'mouseover' | 'click'; data: Datum[]; position: string }>();
+    //     useState<{ type: 'mouseOver' | 'click'; data: Datum[]; position: string }>();
     const [showExamples, setShowExamples] = useState(false);
     const [autoRun, setAutoRun] = useState(true);
     const [selectedPreviewData, setSelectedPreviewData] = useState<number>(0);
@@ -303,21 +303,21 @@ function Editor(props: RouteComponentProps) {
             // gosRef.current.api.zoomTo('bam-2', `chr${data.data.chr2}:${data.data.start2}-${data.data.end2}`, 2000);
             // console.log('click', data.data);
             // TODO: show messages on the right-bottom of the editor
-            // gosRef.current.api.subscribe('mouseover', (type, eventData) => {
-            //     setMouseEventInfo({ type: 'mouseover', data: eventData.data, position: eventData.genomicPosition });
+            // gosRef.current.api.subscribe('mouseOver', (type, eventData) => {
+            //     setMouseEventInfo({ type: 'mouseOver', data: eventData.data, position: eventData.genomicPosition });
             // });
             // gosRef.current.api.subscribe('click', (type, eventData) => {
             //     setMouseEventInfo({ type: 'click', data: eventData.data, position: eventData.genomicPosition });
             // });
             // Range Select API
-            // gosRef.current.api.subscribe('rangeselect', (type, eventData) => {
+            // gosRef.current.api.subscribe('rangeSelect', (type, eventData) => {
             //     console.warn(type, eventData.id, eventData.genomicRange, eventData.data);
             // });
         }
         return () => {
-            // gosRef.current.api.unsubscribe('mouseover');
+            // gosRef.current.api.unsubscribe('mouseOver');
             // gosRef.current.api.unsubscribe('click');
-            // gosRef.current?.api.unsubscribe('rangeselect');
+            // gosRef.current?.api.unsubscribe('rangeSelect');
         };
     }, [gosRef.current]);
 

--- a/editor/example/json-spec/mouse-event.ts
+++ b/editor/example/json-spec/mouse-event.ts
@@ -44,16 +44,20 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                     title: 'Individual Marks',
                     ...BAR,
                     experimental: {
-                        hovering: {
+                        mouseEvents: {
+                            mouseOver: true,
+                            rangeSelect: true
+                        },
+                        mouseOveredMarks: {
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
                         },
-                        selection: {
+                        selectedMarks: {
                             color: 'red',
                             opacity: 0.5
                         },
-                        brush: {
+                        rangeSelectBrush: {
                             color: 'purple',
                             stroke: 'purple'
                         }
@@ -67,17 +71,21 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                     title: 'Group Marks By Sample',
                     ...BAR,
                     experimental: {
-                        groupMarksByField: 'sample',
-                        hovering: {
+                        mouseEvents: {
+                            mouseOver: true,
+                            rangeSelect: true,
+                            groupMarksByField: 'smaple'
+                        },
+                        mouseOveredMarks: {
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
                         },
-                        selection: {
+                        selectedMarks: {
                             color: 'red',
                             opacity: 0.5
                         },
-                        brush: {
+                        rangeSelectBrush: {
                             color: 'green',
                             stroke: 'green'
                         }
@@ -91,17 +99,21 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                     title: 'Group Marks By Genomic Position',
                     ...BAR,
                     experimental: {
-                        groupMarksByField: 'position',
-                        hovering: {
+                        mouseEvents: {
+                            mouseOver: true,
+                            rangeSelect: true,
+                            groupMarksByField: 'position'
+                        },
+                        mouseOveredMarks: {
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
                         },
-                        selection: {
+                        selectedMarks: {
                             color: 'red',
                             opacity: 0.5
                         },
-                        brush: {
+                        rangeSelectBrush: {
                             color: 'yellow',
                             stroke: 'yellow'
                         }
@@ -150,14 +162,18 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                     width: BAR.width,
                     height: BAR.height,
                     experimental: {
-                        groupMarksByField: 'name',
-                        hovering: {
+                        mouseEvents: {
+                            mouseOver: true,
+                            rangeSelect: true,
+                            groupMarksByField: 'name'
+                        },
+                        mouseOveredMarks: {
                             showHoveringOnTheBack: true,
                             color: '#E0E0E0',
                             stroke: '#E0E0E0',
                             strokeWidth: 4
                         },
-                        selection: {
+                        selectedMarks: {
                             showOnTheBack: true,
                             color: '#B9D4FA',
                             stroke: '#B9D4FA',
@@ -177,13 +193,18 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                     height: 60,
                     tooltip: [{ field: 'Chr.', type: 'nominal' }],
                     experimental: {
-                        groupMarksByField: 'Chr.',
-                        hovering: {
+                        mouseEvents: {
+                            click: true,
+                            mouseOver: true,
+                            rangeSelect: true,
+                            groupMarksByField: 'Chr.'
+                        },
+                        mouseOveredMarks: {
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
                         },
-                        selection: {
+                        selectedMarks: {
                             color: 'red',
                             opacity: 0.5,
                             strokeWidth: 0

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1092,38 +1092,21 @@
             "experimental": {
               "additionalProperties": false,
               "properties": {
-                "brush": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "groupMarksByField": {
-                  "type": "string"
-                },
-                "hovering": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "enableMultiHovering": {
+                "mouseEvents": {
+                  "anyOf": [
+                    {
                       "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/MouseEventsDeep"
+                    }
+                  ]
+                },
+                "mouseOveredMarks": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
                     },
                     "opacity": {
                       "type": "number"
@@ -1143,7 +1126,28 @@
                   },
                   "type": "object"
                 },
-                "selection": {
+                "rangeSelectBrush": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "selectedMarks": {
                   "additionalProperties": false,
                   "properties": {
                     "color": {
@@ -1303,38 +1307,21 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
-                          "brush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "groupMarksByField": {
-                            "type": "string"
-                          },
-                          "hovering": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "enableMultiHovering": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
                                 "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "mouseOveredMarks": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
                               },
                               "opacity": {
                                 "type": "number"
@@ -1354,7 +1341,28 @@
                             },
                             "type": "object"
                           },
-                          "selection": {
+                          "rangeSelectBrush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selectedMarks": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {
@@ -1980,38 +1988,21 @@
             "experimental": {
               "additionalProperties": false,
               "properties": {
-                "brush": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "groupMarksByField": {
-                  "type": "string"
-                },
-                "hovering": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "enableMultiHovering": {
+                "mouseEvents": {
+                  "anyOf": [
+                    {
                       "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/MouseEventsDeep"
+                    }
+                  ]
+                },
+                "mouseOveredMarks": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
                     },
                     "opacity": {
                       "type": "number"
@@ -2031,7 +2022,28 @@
                   },
                   "type": "object"
                 },
-                "selection": {
+                "rangeSelectBrush": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "selectedMarks": {
                   "additionalProperties": false,
                   "properties": {
                     "color": {
@@ -2191,38 +2203,21 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
-                          "brush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "groupMarksByField": {
-                            "type": "string"
-                          },
-                          "hovering": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "enableMultiHovering": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
                                 "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "mouseOveredMarks": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
                               },
                               "opacity": {
                                 "type": "number"
@@ -2242,7 +2237,28 @@
                             },
                             "type": "object"
                           },
-                          "selection": {
+                          "rangeSelectBrush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selectedMarks": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {
@@ -2919,38 +2935,21 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
-                          "brush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "groupMarksByField": {
-                            "type": "string"
-                          },
-                          "hovering": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "enableMultiHovering": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
                                 "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "mouseOveredMarks": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
                               },
                               "opacity": {
                                 "type": "number"
@@ -2970,7 +2969,28 @@
                             },
                             "type": "object"
                           },
-                          "selection": {
+                          "rangeSelectBrush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selectedMarks": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {
@@ -3870,6 +3890,27 @@
       ],
       "type": "object"
     },
+    "MouseEventsDeep": {
+      "additionalProperties": false,
+      "properties": {
+        "click": {
+          "type": "boolean"
+        },
+        "enableMouseOverOnMultipleMarks": {
+          "type": "boolean"
+        },
+        "groupMarksByField": {
+          "type": "string"
+        },
+        "mouseOver": {
+          "type": "boolean"
+        },
+        "rangeSelect": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "MultipleViews": {
       "additionalProperties": false,
       "properties": {
@@ -4174,38 +4215,21 @@
         "experimental": {
           "additionalProperties": false,
           "properties": {
-            "brush": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "groupMarksByField": {
-              "type": "string"
-            },
-            "hovering": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "enableMultiHovering": {
+            "mouseEvents": {
+              "anyOf": [
+                {
                   "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            },
+            "mouseOveredMarks": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
                 },
                 "opacity": {
                   "type": "number"
@@ -4225,7 +4249,28 @@
               },
               "type": "object"
             },
-            "selection": {
+            "rangeSelectBrush": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "selectedMarks": {
               "additionalProperties": false,
               "properties": {
                 "color": {
@@ -4354,38 +4399,21 @@
               "experimental": {
                 "additionalProperties": false,
                 "properties": {
-                  "brush": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "color": {
-                        "type": "string"
-                      },
-                      "opacity": {
-                        "type": "number"
-                      },
-                      "stroke": {
-                        "type": "string"
-                      },
-                      "strokeOpacity": {
-                        "type": "number"
-                      },
-                      "strokeWidth": {
-                        "type": "number"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "groupMarksByField": {
-                    "type": "string"
-                  },
-                  "hovering": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "color": {
-                        "type": "string"
-                      },
-                      "enableMultiHovering": {
+                  "mouseEvents": {
+                    "anyOf": [
+                      {
                         "type": "boolean"
+                      },
+                      {
+                        "$ref": "#/definitions/MouseEventsDeep"
+                      }
+                    ]
+                  },
+                  "mouseOveredMarks": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "color": {
+                        "type": "string"
                       },
                       "opacity": {
                         "type": "number"
@@ -4405,7 +4433,28 @@
                     },
                     "type": "object"
                   },
-                  "selection": {
+                  "rangeSelectBrush": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "color": {
+                        "type": "string"
+                      },
+                      "opacity": {
+                        "type": "number"
+                      },
+                      "stroke": {
+                        "type": "string"
+                      },
+                      "strokeOpacity": {
+                        "type": "number"
+                      },
+                      "strokeWidth": {
+                        "type": "number"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "selectedMarks": {
                     "additionalProperties": false,
                     "properties": {
                       "color": {
@@ -4983,38 +5032,21 @@
         "experimental": {
           "additionalProperties": false,
           "properties": {
-            "brush": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "groupMarksByField": {
-              "type": "string"
-            },
-            "hovering": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "enableMultiHovering": {
+            "mouseEvents": {
+              "anyOf": [
+                {
                   "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            },
+            "mouseOveredMarks": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
                 },
                 "opacity": {
                   "type": "number"
@@ -5034,7 +5066,28 @@
               },
               "type": "object"
             },
-            "selection": {
+            "rangeSelectBrush": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "selectedMarks": {
               "additionalProperties": false,
               "properties": {
                 "color": {
@@ -5409,38 +5462,21 @@
         "experimental": {
           "additionalProperties": false,
           "properties": {
-            "brush": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "groupMarksByField": {
-              "type": "string"
-            },
-            "hovering": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "enableMultiHovering": {
+            "mouseEvents": {
+              "anyOf": [
+                {
                   "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            },
+            "mouseOveredMarks": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
                 },
                 "opacity": {
                   "type": "number"
@@ -5460,7 +5496,28 @@
               },
               "type": "object"
             },
-            "selection": {
+            "rangeSelectBrush": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "selectedMarks": {
               "additionalProperties": false,
               "properties": {
                 "color": {
@@ -5589,38 +5646,21 @@
               "experimental": {
                 "additionalProperties": false,
                 "properties": {
-                  "brush": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "color": {
-                        "type": "string"
-                      },
-                      "opacity": {
-                        "type": "number"
-                      },
-                      "stroke": {
-                        "type": "string"
-                      },
-                      "strokeOpacity": {
-                        "type": "number"
-                      },
-                      "strokeWidth": {
-                        "type": "number"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "groupMarksByField": {
-                    "type": "string"
-                  },
-                  "hovering": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "color": {
-                        "type": "string"
-                      },
-                      "enableMultiHovering": {
+                  "mouseEvents": {
+                    "anyOf": [
+                      {
                         "type": "boolean"
+                      },
+                      {
+                        "$ref": "#/definitions/MouseEventsDeep"
+                      }
+                    ]
+                  },
+                  "mouseOveredMarks": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "color": {
+                        "type": "string"
                       },
                       "opacity": {
                         "type": "number"
@@ -5640,7 +5680,28 @@
                     },
                     "type": "object"
                   },
-                  "selection": {
+                  "rangeSelectBrush": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "color": {
+                        "type": "string"
+                      },
+                      "opacity": {
+                        "type": "number"
+                      },
+                      "stroke": {
+                        "type": "string"
+                      },
+                      "strokeOpacity": {
+                        "type": "number"
+                      },
+                      "strokeWidth": {
+                        "type": "number"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "selectedMarks": {
                     "additionalProperties": false,
                     "properties": {
                       "color": {
@@ -6357,38 +6418,21 @@
         "experimental": {
           "additionalProperties": false,
           "properties": {
-            "brush": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "groupMarksByField": {
-              "type": "string"
-            },
-            "hovering": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "enableMultiHovering": {
+            "mouseEvents": {
+              "anyOf": [
+                {
                   "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            },
+            "mouseOveredMarks": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
                 },
                 "opacity": {
                   "type": "number"
@@ -6408,7 +6452,28 @@
               },
               "type": "object"
             },
-            "selection": {
+            "rangeSelectBrush": {
+              "additionalProperties": false,
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "opacity": {
+                  "type": "number"
+                },
+                "stroke": {
+                  "type": "string"
+                },
+                "strokeOpacity": {
+                  "type": "number"
+                },
+                "strokeWidth": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "selectedMarks": {
               "additionalProperties": false,
               "properties": {
                 "color": {
@@ -6777,38 +6842,21 @@
             "experimental": {
               "additionalProperties": false,
               "properties": {
-                "brush": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "groupMarksByField": {
-                  "type": "string"
-                },
-                "hovering": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "enableMultiHovering": {
+                "mouseEvents": {
+                  "anyOf": [
+                    {
                       "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/MouseEventsDeep"
+                    }
+                  ]
+                },
+                "mouseOveredMarks": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
                     },
                     "opacity": {
                       "type": "number"
@@ -6828,7 +6876,28 @@
                   },
                   "type": "object"
                 },
-                "selection": {
+                "rangeSelectBrush": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "selectedMarks": {
                   "additionalProperties": false,
                   "properties": {
                     "color": {
@@ -6984,38 +7053,21 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
-                          "brush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "groupMarksByField": {
-                            "type": "string"
-                          },
-                          "hovering": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "enableMultiHovering": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
                                 "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "mouseOveredMarks": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
                               },
                               "opacity": {
                                 "type": "number"
@@ -7035,7 +7087,28 @@
                             },
                             "type": "object"
                           },
-                          "selection": {
+                          "rangeSelectBrush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selectedMarks": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {
@@ -7658,38 +7731,21 @@
             "experimental": {
               "additionalProperties": false,
               "properties": {
-                "brush": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "groupMarksByField": {
-                  "type": "string"
-                },
-                "hovering": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "enableMultiHovering": {
+                "mouseEvents": {
+                  "anyOf": [
+                    {
                       "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/MouseEventsDeep"
+                    }
+                  ]
+                },
+                "mouseOveredMarks": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
                     },
                     "opacity": {
                       "type": "number"
@@ -7709,7 +7765,28 @@
                   },
                   "type": "object"
                 },
-                "selection": {
+                "rangeSelectBrush": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "color": {
+                      "type": "string"
+                    },
+                    "opacity": {
+                      "type": "number"
+                    },
+                    "stroke": {
+                      "type": "string"
+                    },
+                    "strokeOpacity": {
+                      "type": "number"
+                    },
+                    "strokeWidth": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "selectedMarks": {
                   "additionalProperties": false,
                   "properties": {
                     "color": {
@@ -7865,38 +7942,21 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
-                          "brush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "groupMarksByField": {
-                            "type": "string"
-                          },
-                          "hovering": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "enableMultiHovering": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
                                 "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "mouseOveredMarks": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
                               },
                               "opacity": {
                                 "type": "number"
@@ -7916,7 +7976,28 @@
                             },
                             "type": "object"
                           },
-                          "selection": {
+                          "rangeSelectBrush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selectedMarks": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {
@@ -8586,38 +8667,21 @@
                       "experimental": {
                         "additionalProperties": false,
                         "properties": {
-                          "brush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "groupMarksByField": {
-                            "type": "string"
-                          },
-                          "hovering": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "enableMultiHovering": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
                                 "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "mouseOveredMarks": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
                               },
                               "opacity": {
                                 "type": "number"
@@ -8637,7 +8701,28 @@
                             },
                             "type": "object"
                           },
-                          "selection": {
+                          "rangeSelectBrush": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "color": {
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "stroke": {
+                                "type": "string"
+                              },
+                              "strokeOpacity": {
+                                "type": "number"
+                              },
+                              "strokeWidth": {
+                                "type": "number"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "selectedMarks": {
                             "additionalProperties": false,
                             "properties": {
                               "color": {

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -27,17 +27,17 @@ export interface RangeMouseEventData extends CommonEventData {
 //
 // Add named events using a string union for `EventName`
 //
-// - Two different events ('mouseover' & 'my-event') with the same payload
+// - Two different events ('mouseOver' & 'my-event') with the same payload
 //
-// PubSubEvent<'mouseover' | 'my-event', { same: 'payload' }>
+// PubSubEvent<'mouseOver' | 'my-event', { same: 'payload' }>
 type PubSubEvent<EventName extends string, Payload> = {
     [Key in EventName]: Payload;
 };
 
 // New `PubSubEvent`s should be added to the `EventMap`...
-type EventMap = PubSubEvent<'mouseover' | 'click', PointMouseEventData> &
-    PubSubEvent<'rangeselect', RangeMouseEventData> &
-    PubSubEvent<'rawdata', CommonEventData>;
+type EventMap = PubSubEvent<'mouseOver' | 'click', PointMouseEventData> &
+    PubSubEvent<'rangeSelect', RangeMouseEventData> &
+    PubSubEvent<'rawData', CommonEventData>;
 
 /**
  * Information of suggested genes.
@@ -114,10 +114,10 @@ export function createApi(
     return {
         subscribe: (type, callback) => {
             switch (type) {
-                case 'mouseover':
+                case 'mouseOver':
                 case 'click':
-                case 'rawdata':
-                case 'rangeselect':
+                case 'rawData':
+                case 'rangeSelect':
                     return PubSub.subscribe(type, callback);
                 default: {
                     console.error(`Event type not recognized, got ${JSON.stringify(type)}.`);

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,43 +1,10 @@
 import * as PIXI from 'pixi.js';
-import type { Datum } from './gosling.schema';
 import type { HiGlassApi } from './higlass-component-wrapper';
 import type { HiGlassSpec } from './higlass.schema';
+import { subscribe, unsubscribe } from './pubsub';
 import { GET_CHROM_SIZES } from './utils/assembly';
 import type { CompleteThemeDeep } from './utils/theme';
 import { traverseViewsInViewConfig } from './utils/view-config';
-
-export interface CommonEventData {
-    /** Source visualization ID, i.e., `track.id` */
-    id: string;
-    /** Values in a JSON array that represent data after data transformation */
-    data: Datum[];
-}
-
-export interface PointMouseEventData extends CommonEventData {
-    /* A genomic coordinate, e.g., `chr1:100,000`. */
-    genomicPosition: string;
-}
-
-export interface RangeMouseEventData extends CommonEventData {
-    /* Start and end genomic coordinates, e.g., `chr1:100,000`. NULL if a range is deselected. */
-    genomicRange: [string, string] | null;
-}
-
-// Utility type for building strongly typed PubSub API.
-//
-// Add named events using a string union for `EventName`
-//
-// - Two different events ('mouseOver' & 'my-event') with the same payload
-//
-// PubSubEvent<'mouseOver' | 'my-event', { same: 'payload' }>
-type PubSubEvent<EventName extends string, Payload> = {
-    [Key in EventName]: Payload;
-};
-
-// New `PubSubEvent`s should be added to the `EventMap`...
-type EventMap = PubSubEvent<'mouseOver' | 'click', PointMouseEventData> &
-    PubSubEvent<'rangeSelect', RangeMouseEventData> &
-    PubSubEvent<'rawData', CommonEventData>;
 
 /**
  * Information of suggested genes.
@@ -51,11 +18,8 @@ interface geneSuggestion {
 }
 
 export interface GoslingApi {
-    subscribe<EventName extends keyof EventMap>(
-        type: EventName,
-        callback: (message: string, payload: EventMap[EventName]) => void
-    ): void;
-    unsubscribe(tokenOrFunction: string | ((...args: unknown[]) => unknown)): void;
+    subscribe: typeof subscribe;
+    unsubscribe: typeof unsubscribe;
     zoomTo(viewId: string, position: string, padding?: number, duration?: number): void;
     zoomToExtent(viewId: string, duration?: number): void;
     zoomToGene(viewId: string, gene: string, padding?: number, duration?: number): void;
@@ -112,20 +76,8 @@ export function createApi(
         };
     };
     return {
-        subscribe: (type, callback) => {
-            switch (type) {
-                case 'mouseOver':
-                case 'click':
-                case 'rawData':
-                case 'rangeSelect':
-                    return PubSub.subscribe(type, callback);
-                default: {
-                    console.error(`Event type not recognized, got ${JSON.stringify(type)}.`);
-                    return undefined;
-                }
-            }
-        },
-        unsubscribe: tokenOrFunction => PubSub.unsubscribe(tokenOrFunction),
+        subscribe,
+        unsubscribe,
         // TODO: Support assemblies (we can infer this from the spec)
         zoomTo: (viewId, position, padding = 0, duration = 1000) => {
             // Accepted input: 'chr1' or 'chr1:1-1000'

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -31,7 +31,8 @@ import type {
     StackedTracks,
     BAMData,
     Range,
-    TemplateTrack
+    TemplateTrack,
+    MouseEventsDeep
 } from './gosling.schema';
 import { SUPPORTED_CHANNELS } from './mark';
 import { isArray } from 'lodash-es';
@@ -307,4 +308,10 @@ export function IsYAxis(_: Track) {
         return isFound;
     }
     return false;
+}
+
+/* ----------------------------- MOUSE EVENT ----------------------------- */
+
+export function IsMouseEventsDeep(_?: boolean | MouseEventsDeep): _ is MouseEventsDeep {
+    return typeof _ === 'object';
 }

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -229,6 +229,42 @@ export type Mark =
     // being used to show title/subtitle internally
     | 'header';
 
+/* ----------------------------- API & MOUSE EVENTS ----------------------------- */
+interface CommonEventData {
+    /** Source visualization ID, i.e., `track.id` */
+    id: string;
+    /** Values in a JSON array that represent data after data transformation */
+    data: Datum[];
+}
+
+interface PointMouseEventData extends CommonEventData {
+    /* A genomic coordinate, e.g., `chr1:100,000`. */
+    genomicPosition: string;
+}
+
+interface RangeMouseEventData extends CommonEventData {
+    /* Start and end genomic coordinates, e.g., `chr1:100,000`. NULL if a range is deselected. */
+    genomicRange: [string, string] | null;
+}
+
+export type _EventMap = {
+    mouseOver: PointMouseEventData;
+    click: PointMouseEventData;
+    rangeSelect: RangeMouseEventData;
+    rawData: CommonEventData;
+};
+
+export type MouseEventsDeep = {
+    /* Turn on and off individual mouse events. */
+    [Event in keyof Omit<_EventMap, 'rawData'>]?: boolean;
+} & {
+    /* Group marks using keys in a data field. This affects how a set of marks are highlighted/selected by interaction. __Default__: `undefined` */
+    groupMarksByField?: string;
+
+    /* Determine whether all marks underneath the mouse point should be affected by mouse over. __Default__: `false` */
+    enableMouseOverOnMultipleMarks?: boolean;
+};
+
 /* ----------------------------- TRACK ----------------------------- */
 export type SingleTrack = SingleTrackBase & Encoding;
 
@@ -239,19 +275,6 @@ export interface BrushAndMarkHighlightingStyle {
     strokeOpacity: number;
     opacity: number;
 }
-
-// Mouse events
-type MouseEvent = 'click' | 'mouseOver' | 'rangeSelect';
-export type MouseEventsDeep = {
-    /* Turn on and off individual mouse events. */
-    [Event in MouseEvent]?: boolean;
-} & {
-    /* Group marks using keys in a data field. This affects how a set of marks are highlighted/selected by interaction. __Default__: `undefined` */
-    groupMarksByField?: string;
-
-    /* Determine whether all marks underneath the mouse point should be affected by mouse over. __Default__: `false` */
-    enableMouseOverOnMultipleMarks?: boolean;
-};
 
 interface SingleTrackBase extends CommonTrackDef {
     // Data

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -240,6 +240,19 @@ export interface BrushAndMarkHighlightingStyle {
     opacity: number;
 }
 
+// Mouse events
+type MouseEvent = 'click' | 'mouseOver' | 'rangeSelect';
+export type MouseEventsDeep = {
+    /* Turn on and off individual mouse events. */
+    [Event in MouseEvent]?: boolean;
+} & {
+    /* Group marks using keys in a data field. This affects how a set of marks are highlighted/selected by interaction. __Default__: `undefined` */
+    groupMarksByField?: string;
+
+    /* Determine whether all marks underneath the mouse point should be affected by mouse over. __Default__: `false` */
+    enableMouseOverOnMultipleMarks?: boolean;
+};
+
 interface SingleTrackBase extends CommonTrackDef {
     // Data
     data: DataDeep;
@@ -250,17 +263,17 @@ interface SingleTrackBase extends CommonTrackDef {
     // Tooltip
     tooltip?: Tooltip[];
 
-    // Mouse events
+    // Experimental
     experimental?: {
-        /* Group marks using keys in a field. This affects how a set of marks are highlighted/selected by interaction. */
-        groupMarksByField?: string;
+        // Mouse events
+        mouseEvents?: boolean | MouseEventsDeep;
 
-        hovering?: {
-            enableMultiHovering?: boolean;
+        // TODO: move all following style-related properties to `style` (June-02-2022)
+        mouseOveredMarks?: {
             showHoveringOnTheBack?: boolean;
         } & Partial<BrushAndMarkHighlightingStyle>;
-        selection?: { showOnTheBack?: boolean } & Partial<BrushAndMarkHighlightingStyle>;
-        brush?: Partial<BrushAndMarkHighlightingStyle>;
+        selectedMarks?: { showOnTheBack?: boolean } & Partial<BrushAndMarkHighlightingStyle>;
+        rangeSelectBrush?: Partial<BrushAndMarkHighlightingStyle>;
     };
 
     // Mark

--- a/src/core/pubsub.ts
+++ b/src/core/pubsub.ts
@@ -1,16 +1,18 @@
 import type { _EventMap } from './gosling.schema';
 
-export function publish<Name extends keyof _EventMap>(name: Name, data: _EventMap[Name]): void {
+type EventName = keyof _EventMap;
+
+export function publish<Name extends EventName>(name: Name, data: _EventMap[Name]): void {
     PubSub.publish(name, data);
 }
 
-export function subscribe<Name extends keyof _EventMap>(
+export function subscribe<Name extends EventName>(
     name: Name,
     callback: (msg: string, data: _EventMap[Name]) => void
 ): void {
     PubSub.subscribe(name, callback);
 }
 
-export function unsubscribe<Name extends keyof _EventMap>(name: Name): void {
+export function unsubscribe(name: EventName): void {
     PubSub.unsubscribe(name);
 }

--- a/src/core/pubsub.ts
+++ b/src/core/pubsub.ts
@@ -1,0 +1,16 @@
+import type { _EventMap } from './gosling.schema';
+
+export function publish<Name extends keyof _EventMap>(name: Name, data: _EventMap[Name]): void {
+    PubSub.publish(name, data);
+}
+
+export function subscribe<Name extends keyof _EventMap>(
+    name: Name,
+    callback: (msg: string, data: _EventMap[Name]) => void
+): void {
+    PubSub.subscribe(name, callback);
+}
+
+export function unsubscribe<Name extends keyof _EventMap>(name: Name): void {
+    PubSub.unsubscribe(name);
+}

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -84,7 +84,7 @@ export class LinearBrushModel {
             d3Drag: hgLibraries.d3Drag
         };
 
-        this.style = Object.assign(BRUSH_STYLE_DEFAULT, style);
+        this.style = Object.assign({}, BRUSH_STYLE_DEFAULT, style);
 
         this.brushSelection = selection
             .selectAll('.genomic-range-brush')
@@ -137,7 +137,6 @@ export class LinearBrushModel {
         const getWidth = (d: LinearBrushData[number]) => Math.abs(d.end - d.start); // the start and end can be minus values
         this.brushSelection
             .data(this.data)
-            .attr('visibility', 'visible')
             .attr('transform', d => `translate(${x + d.start}, ${y + 1})`)
             .attr('width', d => `${getWidth(d)}px`)
             .attr('height', `${height - 2}px`)
@@ -163,10 +162,18 @@ export class LinearBrushModel {
         return this;
     }
 
-    public clear() {
-        this.updateRange(null).drawBrush();
+    public visible() {
+        this.brushSelection.attr('visibility', 'visible');
+        return this;
+    }
+
+    public hidden() {
         this.brushSelection.attr('visibility', 'hidden');
-        this.disable();
+        return this;
+    }
+
+    public clear() {
+        this.updateRange(null).drawBrush().hidden().disable();
         return this;
     }
 

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -27,7 +27,7 @@ import {
 import { getTabularData } from './data-abstraction';
 import { getRelativeGenomicPosition } from '../core/utils/assembly';
 import { getTextStyle } from '../core/utils/text-style';
-import { Is2DTrack, IsChannelDeep, IsXAxis } from '../core/gosling.schema.guards';
+import { Is2DTrack, IsChannelDeep, IsMouseEventsDeep, IsXAxis } from '../core/gosling.schema.guards';
 import { spawn } from 'threads';
 import { HIGLASS_AXIS_SIZE } from '../core/higlass-model';
 import type { MouseEventData } from '../gosling-mouse-event/mouse-event-model';
@@ -85,7 +85,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
         private options!: GoslingTrackOption;
         private tileSize: number;
         private worker: any;
-        private isBrushActivated: boolean;
+        private isRangeBrushActivated: boolean;
         private mRangeBrush: LinearBrushModel;
         private _xScale!: ScaleLinear<number, number>;
         private _yScale!: ScaleLinear<number, number>;
@@ -152,14 +152,14 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             this.gLegend = HGC.libraries.d3Selection.select(this.context.svgElement).append('g');
 
             // Enable click event
-            this.isBrushActivated = false;
+            this.isRangeBrushActivated = false;
             this.pMask.interactive = true;
             this.gBrush = HGC.libraries.d3Selection.select(this.context.svgElement).append('g');
             this.mRangeBrush = new LinearBrushModel(
                 this.gBrush,
                 HGC.libraries,
                 this.onRangeBrush.bind(this),
-                this.options.spec.experimental?.brush
+                this.options.spec.experimental?.rangeSelectBrush
             );
             this.pMask.mousedown = (e: InteractionEvent) =>
                 this.onMouseDown(
@@ -1049,8 +1049,9 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             // TODO: `Omit` this properties in the schema of individual overlaid tracks.
             // These should be defined only once for a group of overlaid traks (09-May-2022)
             // See https://github.com/gosling-lang/gosling.js/issues/677
-            const multiHovering = this.options.spec.experimental?.hovering?.enableMultiHovering;
-            const idField = this.options.spec.experimental?.groupMarksByField;
+            const mouseEvents = this.options.spec.experimental?.mouseEvents;
+            const multiHovering = IsMouseEventsDeep(mouseEvents) && mouseEvents.enableMouseOverOnMultipleMarks;
+            const idField = IsMouseEventsDeep(mouseEvents) && mouseEvents.groupMarksByField;
 
             // Collect all mouse event data from tiles and overlaid tracks
             const mergedCapturedElements: MouseEventData[] = models
@@ -1075,7 +1076,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
         }
 
         /**
-         * Highlight marks that are either hovered or selected.
+         * Highlight marks that are either mouse overed or selected.
          */
         highlightMarks(
             g: Graphics,
@@ -1115,7 +1116,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             if (range === null) {
                 // brush just removed
                 if (!skipApiTrigger) {
-                    PubSub.publish('rangeselect', { id: this.viewUid, genomicRange: null, data: [] });
+                    PubSub.publish('rangeSelect', { id: this.viewUid, genomicRange: null, data: [] });
                 }
                 return;
             }
@@ -1134,7 +1135,8 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
             // Deselect marks if their siblings are not selected.
             // e.g., if only one exon is selected in a gene, we do not select it.
-            const idField = this.options.spec.experimental?.groupMarksByField;
+            const mouseEvents = this.options.spec.experimental?.mouseEvents;
+            const idField = IsMouseEventsDeep(mouseEvents) && mouseEvents.groupMarksByField;
             if (capturedElements.length !== 0 && idField) {
                 models.forEach(model => {
                     const siblings = model.getMouseEventModel().getSiblings(capturedElements, idField);
@@ -1147,7 +1149,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 // selection effect graphics
                 const g = this.pMouseSelection;
 
-                if (!this.options.spec.experimental?.selection?.showOnTheBack) {
+                if (!this.options.spec.experimental?.selectedMarks?.showOnTheBack) {
                     // place on the top
                     this.pMain.removeChild(g);
                     this.pMain.addChild(g);
@@ -1156,7 +1158,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 this.highlightMarks(
                     g,
                     capturedElements,
-                    Object.assign(DEFAULT_MARK_HIGHLIGHT_STYLE, this.options.spec.experimental?.selection)
+                    Object.assign({}, DEFAULT_MARK_HIGHLIGHT_STYLE, this.options.spec.experimental?.selectedMarks)
                 );
             }
 
@@ -1167,7 +1169,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                     getRelativeGenomicPosition(Math.floor(this._xScale.invert(endX)))
                 ];
 
-                PubSub.publish('rangeselect', {
+                PubSub.publish('rangeSelect', {
                     id: this.viewUid,
                     genomicRange,
                     data: capturedElements.map(d => d.value)
@@ -1177,11 +1179,16 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             this.forceDraw();
         }
 
-        onMouseDown(mouseX: number, mouseY: number, isAlt: boolean) {
+        onMouseDown(mouseX: number, mouseY: number, isAltPressed: boolean) {
             // Record these so that we do not triger click event when dragged.
             this.mouseDownX = mouseX;
             this.mouseDownY = mouseY;
-            this.isBrushActivated = isAlt;
+
+            // Determine whether to activate a range brush
+            const mouseEvents = this.options.spec.experimental?.mouseEvents;
+            const rangeSelectEnabled = !!mouseEvents || (IsMouseEventsDeep(mouseEvents) && !!mouseEvents.rangeSelect);
+            this.isRangeBrushActivated = rangeSelectEnabled && isAltPressed;
+
             this.pMouseHover.clear();
         }
 
@@ -1191,15 +1198,17 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 return;
             }
 
-            if (this.isBrushActivated) {
-                this.mRangeBrush.updateRange([mouseX, this.mouseDownX]).drawBrush().disable();
+            if (this.isRangeBrushActivated) {
+                this.mRangeBrush.updateRange([mouseX, this.mouseDownX]).drawBrush().visible().disable();
             }
         }
 
         onMouseUp(mouseX: number, mouseY: number) {
+            const mouseEvents = this.options.spec.experimental?.mouseEvents;
+            const clickEnabled = !!mouseEvents || (IsMouseEventsDeep(mouseEvents) && !!mouseEvents.click);
             const isDrag = Math.sqrt((this.mouseDownX - mouseX) ** 2 + (this.mouseDownY - mouseY) ** 2) > 1;
 
-            if (!this.isBrushActivated && !isDrag) {
+            if (!this.isRangeBrushActivated && !isDrag) {
                 // Clicking outside the brush should remove the brush and the selection.
                 this.mRangeBrush.clear();
                 this.pMouseSelection.clear();
@@ -1208,7 +1217,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 this.mRangeBrush.enable();
             }
 
-            this.isBrushActivated = false;
+            this.isRangeBrushActivated = false;
 
             if (!this.tilesetInfo) {
                 // Do not have enough information
@@ -1216,7 +1225,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             }
 
             // click API
-            if (!isDrag) {
+            if (!isDrag && clickEnabled) {
                 // Identify the current position
                 const genomicPosition = getRelativeGenomicPosition(Math.floor(this._xScale.invert(mouseX)));
 
@@ -1234,13 +1243,13 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
         }
 
         onMouseOut() {
-            this.isBrushActivated = false;
+            this.isRangeBrushActivated = false;
             document.body.style.cursor = 'default';
             this.pMouseHover.clear();
         }
 
         getMouseOverHtml(mouseX: number, mouseY: number) {
-            if (this.isBrushActivated) {
+            if (this.isRangeBrushActivated) {
                 // In the middle of drawing range brush.
                 return;
             }
@@ -1267,27 +1276,35 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             }
 
             if (capturedElements.length !== 0) {
-                // Rener mouse over effect graphics
-                const g = this.pMouseHover;
+                const mouseEvents = this.options.spec.experimental?.mouseEvents;
+                const mouseOverEnabled = !!mouseEvents || (IsMouseEventsDeep(mouseEvents) && !!mouseEvents.mouseOver);
+                if (mouseOverEnabled) {
+                    // Display mouse over effects
+                    const g = this.pMouseHover;
 
-                if (!this.options.spec.experimental?.hovering?.showHoveringOnTheBack) {
-                    // place on the top
-                    this.pMain.removeChild(g);
-                    this.pMain.addChild(g);
+                    if (!this.options.spec.experimental?.mouseOveredMarks?.showHoveringOnTheBack) {
+                        // place on the top
+                        this.pMain.removeChild(g);
+                        this.pMain.addChild(g);
+                    }
+
+                    this.highlightMarks(
+                        g,
+                        capturedElements,
+                        Object.assign(
+                            {},
+                            DEFAULT_MARK_HIGHLIGHT_STYLE,
+                            this.options.spec.experimental?.mouseOveredMarks
+                        )
+                    );
+
+                    // API call
+                    PubSub.publish('mouseOver', {
+                        id: this.viewUid,
+                        genomicPosition,
+                        data: capturedElements.map(d => d.value)
+                    });
                 }
-
-                this.highlightMarks(
-                    g,
-                    capturedElements,
-                    Object.assign(DEFAULT_MARK_HIGHLIGHT_STYLE, this.options.spec.experimental?.hovering)
-                );
-
-                // API call
-                PubSub.publish('mouseover', {
-                    id: this.viewUid,
-                    genomicPosition,
-                    data: capturedElements.map(d => d.value)
-                });
 
                 // Display a tooltip
                 const models = this.visibleAndFetchedTiles()

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -25,6 +25,7 @@ import {
     inferSvType
 } from '../core/utils/data-transform';
 import { getTabularData } from './data-abstraction';
+import { publish } from '../core/pubsub';
 import { getRelativeGenomicPosition } from '../core/utils/assembly';
 import { getTextStyle } from '../core/utils/text-style';
 import { Is2DTrack, IsChannelDeep, IsMouseEventsDeep, IsXAxis } from '../core/gosling.schema.guards';
@@ -827,10 +828,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
             const flatTileData = ([] as Datum[]).concat(...models.map(d => d.data()));
             if (flatTileData.length !== 0) {
-                PubSub.publish('rawdata', {
-                    id: this.viewUid,
-                    data: flatTileData
-                });
+                publish('rawData', { id: this.viewUid, data: flatTileData });
             }
 
             // console.log('processed gosling model', models);
@@ -961,6 +959,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                     });
                 }
 
+                // TODO: Remove the following block entirely and use the `rawData` API in the Editor (June-02-2022)
                 // Send data preview to the editor so that it can be shown to users.
                 try {
                     if (PubSub) {
@@ -1116,7 +1115,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             if (range === null) {
                 // brush just removed
                 if (!skipApiTrigger) {
-                    PubSub.publish('rangeSelect', { id: this.viewUid, genomicRange: null, data: [] });
+                    publish('rangeSelect', { id: this.viewUid, genomicRange: null, data: [] });
                 }
                 return;
             }
@@ -1164,12 +1163,12 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
             /* API call */
             if (!skipApiTrigger) {
-                const genomicRange = [
+                const genomicRange: [string, string] = [
                     getRelativeGenomicPosition(Math.floor(this._xScale.invert(startX))),
                     getRelativeGenomicPosition(Math.floor(this._xScale.invert(endX)))
                 ];
 
-                PubSub.publish('rangeSelect', {
+                publish('rangeSelect', {
                     id: this.viewUid,
                     genomicRange,
                     data: capturedElements.map(d => d.value)
@@ -1233,7 +1232,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 const capturedElements = this.getElementsWithinMouse(mouseX, mouseY);
 
                 if (capturedElements.length !== 0) {
-                    PubSub.publish('click', {
+                    publish('click', {
                         id: this.viewUid,
                         genomicPosition,
                         data: capturedElements.map(d => d.value)
@@ -1299,7 +1298,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                     );
 
                     // API call
-                    PubSub.publish('mouseOver', {
+                    publish('mouseOver', {
                         id: this.viewUid,
                         genomicPosition,
                         data: capturedElements.map(d => d.value)


### PR DESCRIPTION
- Use camelCases for API keys (e.g., `rangeSelect`, `mouseOver`)
- Change structure and rename of mouse events
```ts
type MouseEvent = 'click' | 'mouseOver' | 'rangeSelect'; // 'mouseOver' was 'hover'

{
  experimental?: {
    mouseEvents: boolean | {
      [Event in MouseEvent]: boolean;
      groupMarksByField?: string;
      enableMouseOverOnMultipleMarks?: boolean; // was 'enableMultiHovering'
    }
  }
}
```
- Do not call APIs and do not display relevant visual effects for mouse events when they are not turned on by a user, i.e., a brush for the range select does not appear unless either `experimental.mouseEvents === true` or `experimental.mouseEvents.rangeSelect === true`.

Toward #710