### PR TITLE
chore: fix css-element-queries import

### DIFF
--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import { HiGlassApi, HiGlassComponentWrapper } from './higlass-component-wrapper';
 import React, { useState, useEffect, useMemo, useRef, forwardRef, useCallback } from 'react';
-import { ResizeSensor } from 'css-element-queries';
+import ResizeSensor from 'css-element-queries/src/ResizeSensor';
 import * as gosling from '..';
 import { getTheme, Theme } from './utils/theme';
 import { createApi, GoslingApi } from './api';


### PR DESCRIPTION
The `css-element-queries` package is causing real issues in `gosling-widget` (and likely and other systems using requirejs).

- https://github.com/gosling-lang/gosling-widget/issues/1

It seems to stem from this annonymous `define` in `ElementQueries.js`.

https://github.com/marcj/css-element-queries/blob/4eae4654f4683923153d8dd8f5c0d1bc2067b2a8/src/ElementQueries.js#L10

When importing from `css-element-queries`, the `index.js` file is commonjs with two exports:

```javascript
module.exports = {
    ResizeSensor: require('./src/ResizeSensor'),
    ElementQueries: require('./src/ElementQueries')
};
```

Commonjs modules cannot be tree-shaken, so **all** the code for `ResizeSensor` and `ElementQueries` end up in resulting bundles even though we don't use `ElementQueries` at all in the code.

The error in `gosling-widget` arises as a side-effect `./src/ElementQueries.js` inspects the global namespace for `define` _when loaded_. We don't see this in the Editor or when loading gosling via a script tag since `define` is not provided as a global.

I think we can avoid this issue all together with changes suggested in the PR by avoiding the import for `ElementQueries` all together.


As a side note, we should be thoughtful when adding new NPM dependencies since how they are packaged can have serious implications on where `gosling.js` can work. I would look for dependencies which are widely used, adhere to modern standards, and frequently updated.
