### PR TITLE
fix: fix json track errors due to using undefined mRangeBrush

### DIFF
--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -218,6 +218,9 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
 
         /* ----------------------------------- RENDERING CYCLE ----------------------------------- */
 
+        // !! Be aware that this function is called in the middle of `constructor()` by a parent class (i.e., `super(...)`).
+        // https://github.com/higlass/higlass/blob/387a03e877dcfa4c2cfeabc0869375b58c0b362d/app/scripts/TiledPixiTrack.js#L216
+        // This means, some class properties can be still `undefined`.
         /**
          * Draw all tiles from the bottom.
          * (https://github.com/higlass/higlass/blob/54f5aae61d3474f9e868621228270f0c90ef9343/app/scripts/TiledPixiTrack.js#L727)
@@ -259,7 +262,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
             }
 
             // Based on the updated marks, update range selection
-            this.mRangeBrush.drawBrush(true);
+            this.mRangeBrush?.drawBrush(true);
         }
 
         /*


### PR DESCRIPTION
I found that JSON tracks are making errors by using a class property `mRangeBrush` in `draw()` before defining it in the constructor, i.e., the parent class were calling `draw()` ([code](https://github.com/higlass/higlass/blob/387a03e877dcfa4c2cfeabc0869375b58c0b362d/app/scripts/TiledPixiTrack.js#L216)). 

All other non-JSON tracks seem to work okay since loading non-JSON data takes some times and the `draw()` function returns early.

![Screen Shot 2022-06-03 at 17 05 33](https://user-images.githubusercontent.com/9922882/172025493-61285361-ede8-485a-98bf-b114dbb1a38b.png)

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'drawBrush')
    at GoslingTrackClass.draw (gosling-track.ts:265:30)
    at GoslingTrackClass.receivedTiles (hglib.js:12016:14)
    at higlass-raw-datafetcher.ts:137:17
```
