### PR TITLE
refactor: move mouse event styles under the style property

### DIFF
--- a/editor/example/json-spec/mouse-event.ts
+++ b/editor/example/json-spec/mouse-event.ts
@@ -47,7 +47,9 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                         mouseEvents: {
                             mouseOver: true,
                             rangeSelect: true
-                        },
+                        }
+                    },
+                    style: {
                         mouseOveredMarks: {
                             color: 'blue',
                             opacity: 0.5,
@@ -75,7 +77,9 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                             mouseOver: true,
                             rangeSelect: true,
                             groupMarksByField: 'smaple'
-                        },
+                        }
+                    },
+                    style: {
                         mouseOveredMarks: {
                             color: 'blue',
                             opacity: 0.5,
@@ -103,7 +107,9 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                             mouseOver: true,
                             rangeSelect: true,
                             groupMarksByField: 'position'
-                        },
+                        }
+                    },
+                    style: {
                         mouseOveredMarks: {
                             color: 'blue',
                             opacity: 0.5,
@@ -166,9 +172,11 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                             mouseOver: true,
                             rangeSelect: true,
                             groupMarksByField: 'name'
-                        },
+                        }
+                    },
+                    style: {
                         mouseOveredMarks: {
-                            showHoveringOnTheBack: true,
+                            showOnTheBack: true,
                             color: '#E0E0E0',
                             stroke: '#E0E0E0',
                             strokeWidth: 4
@@ -198,7 +206,9 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                             mouseOver: true,
                             rangeSelect: true,
                             groupMarksByField: 'Chr.'
-                        },
+                        }
+                    },
+                    style: {
                         mouseOveredMarks: {
                             color: 'blue',
                             opacity: 0.5,

--- a/editor/example/json-spec/mouse-event.ts
+++ b/editor/example/json-spec/mouse-event.ts
@@ -176,13 +176,13 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                     },
                     style: {
                         mouseOver: {
-                            showOnTheBack: true,
+                            arrange: 'behind',
                             color: '#E0E0E0',
                             stroke: '#E0E0E0',
                             strokeWidth: 4
                         },
                         select: {
-                            showOnTheBack: true,
+                            arrange: 'behind',
                             color: '#B9D4FA',
                             stroke: '#B9D4FA',
                             strokeWidth: 4

--- a/editor/example/json-spec/mouse-event.ts
+++ b/editor/example/json-spec/mouse-event.ts
@@ -50,16 +50,16 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                         }
                     },
                     style: {
-                        mouseOveredMarks: {
+                        mouseOver: {
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
                         },
-                        selectedMarks: {
+                        select: {
                             color: 'red',
                             opacity: 0.5
                         },
-                        rangeSelectBrush: {
+                        brush: {
                             color: 'purple',
                             stroke: 'purple'
                         }
@@ -80,16 +80,16 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                         }
                     },
                     style: {
-                        mouseOveredMarks: {
+                        mouseOver: {
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
                         },
-                        selectedMarks: {
+                        select: {
                             color: 'red',
                             opacity: 0.5
                         },
-                        rangeSelectBrush: {
+                        brush: {
                             color: 'green',
                             stroke: 'green'
                         }
@@ -110,16 +110,16 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                         }
                     },
                     style: {
-                        mouseOveredMarks: {
+                        mouseOver: {
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
                         },
-                        selectedMarks: {
+                        select: {
                             color: 'red',
                             opacity: 0.5
                         },
-                        rangeSelectBrush: {
+                        brush: {
                             color: 'yellow',
                             stroke: 'yellow'
                         }
@@ -175,13 +175,13 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                         }
                     },
                     style: {
-                        mouseOveredMarks: {
+                        mouseOver: {
                             showOnTheBack: true,
                             color: '#E0E0E0',
                             stroke: '#E0E0E0',
                             strokeWidth: 4
                         },
-                        selectedMarks: {
+                        select: {
                             showOnTheBack: true,
                             color: '#B9D4FA',
                             stroke: '#B9D4FA',
@@ -209,12 +209,12 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                         }
                     },
                     style: {
-                        mouseOveredMarks: {
+                        mouseOver: {
                             color: 'blue',
                             opacity: 0.5,
                             strokeWidth: 0
                         },
-                        selectedMarks: {
+                        select: {
                             color: 'red',
                             opacity: 0.5,
                             strokeWidth: 0

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -897,13 +897,6 @@
       ],
       "type": "object"
     },
-    "EventArrange": {
-      "enum": [
-        "behind",
-        "front"
-      ],
-      "type": "string"
-    },
     "EventStyle": {
       "additionalProperties": false,
       "properties": {
@@ -8393,7 +8386,11 @@
           "description": "Customize visual effects of mouse over events on marks.",
           "properties": {
             "arrange": {
-              "$ref": "#/definitions/EventArrange"
+              "enum": [
+                "behind",
+                "front"
+              ],
+              "type": "string"
             },
             "color": {
               "type": "string"
@@ -8424,7 +8421,11 @@
           "description": "Customize visual effects selection events on marks with range brushes.",
           "properties": {
             "arrange": {
-              "$ref": "#/definitions/EventArrange"
+              "enum": [
+                "behind",
+                "front"
+              ],
+              "type": "string"
             },
             "color": {
               "type": "string"

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -234,6 +234,27 @@
       ],
       "type": "string"
     },
+    "BrushAndMarkHighlightingStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "opacity": {
+          "type": "number"
+        },
+        "stroke": {
+          "type": "string"
+        },
+        "strokeOpacity": {
+          "type": "number"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
     "CSVData": {
       "additionalProperties": false,
       "description": "Any small enough tabular data files, such as tsv, csv, BED, BEDPE, and GFF, can be loaded using \"csv\" data specification.",
@@ -570,6 +591,22 @@
         "endAngle": {
           "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
           "type": "number"
+        },
+        "experimental": {
+          "additionalProperties": false,
+          "properties": {
+            "mouseEvents": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            }
+          },
+          "type": "object"
         },
         "height": {
           "description": "Specify the track height in pixels.",
@@ -1101,75 +1138,6 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
-                },
-                "mouseOveredMarks": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "showHoveringOnTheBack": {
-                      "type": "boolean"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "rangeSelectBrush": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "selectedMarks": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "showOnTheBack": {
-                      "type": "boolean"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
                 }
               },
               "type": "object"
@@ -1316,75 +1284,6 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
-                          },
-                          "mouseOveredMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showHoveringOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "rangeSelectBrush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "selectedMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
                           }
                         },
                         "type": "object"
@@ -1997,75 +1896,6 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
-                },
-                "mouseOveredMarks": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "showHoveringOnTheBack": {
-                      "type": "boolean"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "rangeSelectBrush": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "selectedMarks": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "showOnTheBack": {
-                      "type": "boolean"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
                 }
               },
               "type": "object"
@@ -2212,75 +2042,6 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
-                          },
-                          "mouseOveredMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showHoveringOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "rangeSelectBrush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "selectedMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
                           }
                         },
                         "type": "object"
@@ -2844,6 +2605,22 @@
             "description": {
               "type": "string"
             },
+            "experimental": {
+              "additionalProperties": false,
+              "properties": {
+                "mouseEvents": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/MouseEventsDeep"
+                    }
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -2944,75 +2721,6 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
-                          },
-                          "mouseOveredMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showHoveringOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "rangeSelectBrush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "selectedMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
                           }
                         },
                         "type": "object"
@@ -3425,6 +3133,22 @@
             "description": {
               "type": "string"
             },
+            "experimental": {
+              "additionalProperties": false,
+              "properties": {
+                "mouseEvents": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/MouseEventsDeep"
+                    }
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -3478,6 +3202,22 @@
                       "centerRadius": {
                         "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
                         "type": "number"
+                      },
+                      "experimental": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          }
+                        },
+                        "type": "object"
                       },
                       "layout": {
                         "$ref": "#/definitions/Layout",
@@ -3939,6 +3679,22 @@
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
           "type": "number"
         },
+        "experimental": {
+          "additionalProperties": false,
+          "properties": {
+            "mouseEvents": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
         "layout": {
           "$ref": "#/definitions/Layout",
           "description": "Specify the layout type of all tracks."
@@ -4224,75 +3980,6 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
-            },
-            "mouseOveredMarks": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "showHoveringOnTheBack": {
-                  "type": "boolean"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "rangeSelectBrush": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "selectedMarks": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "showOnTheBack": {
-                  "type": "boolean"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
             }
           },
           "type": "object"
@@ -4408,75 +4095,6 @@
                         "$ref": "#/definitions/MouseEventsDeep"
                       }
                     ]
-                  },
-                  "mouseOveredMarks": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "color": {
-                        "type": "string"
-                      },
-                      "opacity": {
-                        "type": "number"
-                      },
-                      "showHoveringOnTheBack": {
-                        "type": "boolean"
-                      },
-                      "stroke": {
-                        "type": "string"
-                      },
-                      "strokeOpacity": {
-                        "type": "number"
-                      },
-                      "strokeWidth": {
-                        "type": "number"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "rangeSelectBrush": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "color": {
-                        "type": "string"
-                      },
-                      "opacity": {
-                        "type": "number"
-                      },
-                      "stroke": {
-                        "type": "string"
-                      },
-                      "strokeOpacity": {
-                        "type": "number"
-                      },
-                      "strokeWidth": {
-                        "type": "number"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "selectedMarks": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "color": {
-                        "type": "string"
-                      },
-                      "opacity": {
-                        "type": "number"
-                      },
-                      "showOnTheBack": {
-                        "type": "boolean"
-                      },
-                      "stroke": {
-                        "type": "string"
-                      },
-                      "strokeOpacity": {
-                        "type": "number"
-                      },
-                      "strokeWidth": {
-                        "type": "number"
-                      }
-                    },
-                    "type": "object"
                   }
                 },
                 "type": "object"
@@ -5041,75 +4659,6 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
-            },
-            "mouseOveredMarks": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "showHoveringOnTheBack": {
-                  "type": "boolean"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "rangeSelectBrush": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "selectedMarks": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "showOnTheBack": {
-                  "type": "boolean"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
             }
           },
           "type": "object"
@@ -5471,75 +5020,6 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
-            },
-            "mouseOveredMarks": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "showHoveringOnTheBack": {
-                  "type": "boolean"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "rangeSelectBrush": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "selectedMarks": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "showOnTheBack": {
-                  "type": "boolean"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
             }
           },
           "type": "object"
@@ -5655,75 +5135,6 @@
                         "$ref": "#/definitions/MouseEventsDeep"
                       }
                     ]
-                  },
-                  "mouseOveredMarks": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "color": {
-                        "type": "string"
-                      },
-                      "opacity": {
-                        "type": "number"
-                      },
-                      "showHoveringOnTheBack": {
-                        "type": "boolean"
-                      },
-                      "stroke": {
-                        "type": "string"
-                      },
-                      "strokeOpacity": {
-                        "type": "number"
-                      },
-                      "strokeWidth": {
-                        "type": "number"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "rangeSelectBrush": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "color": {
-                        "type": "string"
-                      },
-                      "opacity": {
-                        "type": "number"
-                      },
-                      "stroke": {
-                        "type": "string"
-                      },
-                      "strokeOpacity": {
-                        "type": "number"
-                      },
-                      "strokeWidth": {
-                        "type": "number"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "selectedMarks": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "color": {
-                        "type": "string"
-                      },
-                      "opacity": {
-                        "type": "number"
-                      },
-                      "showOnTheBack": {
-                        "type": "boolean"
-                      },
-                      "stroke": {
-                        "type": "string"
-                      },
-                      "strokeOpacity": {
-                        "type": "number"
-                      },
-                      "strokeWidth": {
-                        "type": "number"
-                      }
-                    },
-                    "type": "object"
                   }
                 },
                 "type": "object"
@@ -6427,75 +5838,6 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
-            },
-            "mouseOveredMarks": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "showHoveringOnTheBack": {
-                  "type": "boolean"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "rangeSelectBrush": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "selectedMarks": {
-              "additionalProperties": false,
-              "properties": {
-                "color": {
-                  "type": "string"
-                },
-                "opacity": {
-                  "type": "number"
-                },
-                "showOnTheBack": {
-                  "type": "boolean"
-                },
-                "stroke": {
-                  "type": "string"
-                },
-                "strokeOpacity": {
-                  "type": "number"
-                },
-                "strokeWidth": {
-                  "type": "number"
-                }
-              },
-              "type": "object"
             }
           },
           "type": "object"
@@ -6851,75 +6193,6 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
-                },
-                "mouseOveredMarks": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "showHoveringOnTheBack": {
-                      "type": "boolean"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "rangeSelectBrush": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "selectedMarks": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "showOnTheBack": {
-                      "type": "boolean"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
                 }
               },
               "type": "object"
@@ -7062,75 +6335,6 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
-                          },
-                          "mouseOveredMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showHoveringOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "rangeSelectBrush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "selectedMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
                           }
                         },
                         "type": "object"
@@ -7740,75 +6944,6 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
-                },
-                "mouseOveredMarks": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "showHoveringOnTheBack": {
-                      "type": "boolean"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "rangeSelectBrush": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
-                },
-                "selectedMarks": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "color": {
-                      "type": "string"
-                    },
-                    "opacity": {
-                      "type": "number"
-                    },
-                    "showOnTheBack": {
-                      "type": "boolean"
-                    },
-                    "stroke": {
-                      "type": "string"
-                    },
-                    "strokeOpacity": {
-                      "type": "number"
-                    },
-                    "strokeWidth": {
-                      "type": "number"
-                    }
-                  },
-                  "type": "object"
                 }
               },
               "type": "object"
@@ -7951,75 +7086,6 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
-                          },
-                          "mouseOveredMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showHoveringOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "rangeSelectBrush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "selectedMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
                           }
                         },
                         "type": "object"
@@ -8580,6 +7646,22 @@
               "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
               "type": "number"
             },
+            "experimental": {
+              "additionalProperties": false,
+              "properties": {
+                "mouseEvents": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/MouseEventsDeep"
+                    }
+                  ]
+                }
+              },
+              "type": "object"
+            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -8676,75 +7758,6 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
-                          },
-                          "mouseOveredMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showHoveringOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "rangeSelectBrush": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "selectedMarks": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "color": {
-                                "type": "string"
-                              },
-                              "opacity": {
-                                "type": "number"
-                              },
-                              "showOnTheBack": {
-                                "type": "boolean"
-                              },
-                              "stroke": {
-                                "type": "string"
-                              },
-                              "strokeOpacity": {
-                                "type": "number"
-                              },
-                              "strokeWidth": {
-                                "type": "number"
-                              }
-                            },
-                            "type": "object"
                           }
                         },
                         "type": "object"
@@ -9460,11 +8473,65 @@
           ],
           "type": "string"
         },
+        "mouseOveredMarks": {
+          "additionalProperties": false,
+          "description": "Customize visual effects of mouse over events on marks.",
+          "properties": {
+            "color": {
+              "type": "string"
+            },
+            "opacity": {
+              "type": "number"
+            },
+            "showOnTheBack": {
+              "type": "boolean"
+            },
+            "stroke": {
+              "type": "string"
+            },
+            "strokeOpacity": {
+              "type": "number"
+            },
+            "strokeWidth": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
         "outline": {
           "type": "string"
         },
         "outlineWidth": {
           "type": "number"
+        },
+        "rangeSelectBrush": {
+          "$ref": "#/definitions/BrushAndMarkHighlightingStyle",
+          "description": "Customize the style of range brushes."
+        },
+        "selectedMarks": {
+          "additionalProperties": false,
+          "description": "Customize visual effects selection events on marks with range brushes.",
+          "properties": {
+            "color": {
+              "type": "string"
+            },
+            "opacity": {
+              "type": "number"
+            },
+            "showOnTheBack": {
+              "type": "boolean"
+            },
+            "stroke": {
+              "type": "string"
+            },
+            "strokeOpacity": {
+              "type": "number"
+            },
+            "strokeWidth": {
+              "type": "number"
+            }
+          },
+          "type": "object"
         },
         "textAnchor": {
           "description": "Specify the alignment of `text` marks to a given point.",
@@ -9598,6 +8665,22 @@
         "endAngle": {
           "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
           "type": "number"
+        },
+        "experimental": {
+          "additionalProperties": false,
+          "properties": {
+            "mouseEvents": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            }
+          },
+          "type": "object"
         },
         "height": {
           "description": "Specify the track height in pixels.",

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -234,27 +234,6 @@
       ],
       "type": "string"
     },
-    "BrushAndMarkHighlightingStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "color": {
-          "type": "string"
-        },
-        "opacity": {
-          "type": "number"
-        },
-        "stroke": {
-          "type": "string"
-        },
-        "strokeOpacity": {
-          "type": "number"
-        },
-        "strokeWidth": {
-          "type": "number"
-        }
-      },
-      "type": "object"
-    },
     "CSVData": {
       "additionalProperties": false,
       "description": "Any small enough tabular data files, such as tsv, csv, BED, BEDPE, and GFF, can be loaded using \"csv\" data specification.",
@@ -916,6 +895,34 @@
       "required": [
         "interval"
       ],
+      "type": "object"
+    },
+    "EventArrange": {
+      "enum": [
+        "behind",
+        "front"
+      ],
+      "type": "string"
+    },
+    "EventStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "opacity": {
+          "type": "number"
+        },
+        "stroke": {
+          "type": "string"
+        },
+        "strokeOpacity": {
+          "type": "number"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
       "type": "object"
     },
     "ExonSplitTransform": {
@@ -8281,6 +8288,10 @@
         "backgroundOpacity": {
           "type": "number"
         },
+        "brush": {
+          "$ref": "#/definitions/EventStyle",
+          "description": "Customize the style of range brushes."
+        },
         "curve": {
           "description": "Specify the curve of `rule` marks.",
           "enum": [
@@ -8377,18 +8388,18 @@
           ],
           "type": "string"
         },
-        "mouseOveredMarks": {
+        "mouseOver": {
           "additionalProperties": false,
           "description": "Customize visual effects of mouse over events on marks.",
           "properties": {
+            "arrange": {
+              "$ref": "#/definitions/EventArrange"
+            },
             "color": {
               "type": "string"
             },
             "opacity": {
               "type": "number"
-            },
-            "showOnTheBack": {
-              "type": "boolean"
             },
             "stroke": {
               "type": "string"
@@ -8408,22 +8419,18 @@
         "outlineWidth": {
           "type": "number"
         },
-        "rangeSelectBrush": {
-          "$ref": "#/definitions/BrushAndMarkHighlightingStyle",
-          "description": "Customize the style of range brushes."
-        },
-        "selectedMarks": {
+        "select": {
           "additionalProperties": false,
           "description": "Customize visual effects selection events on marks with range brushes.",
           "properties": {
+            "arrange": {
+              "$ref": "#/definitions/EventArrange"
+            },
             "color": {
               "type": "string"
             },
             "opacity": {
               "type": "number"
-            },
-            "showOnTheBack": {
-              "type": "boolean"
             },
             "stroke": {
               "type": "string"

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -592,22 +592,6 @@
           "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
           "type": "number"
         },
-        "experimental": {
-          "additionalProperties": false,
-          "properties": {
-            "mouseEvents": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "$ref": "#/definitions/MouseEventsDeep"
-                }
-              ]
-            }
-          },
-          "type": "object"
-        },
         "height": {
           "description": "Specify the track height in pixels.",
           "type": "number"
@@ -2605,22 +2589,6 @@
             "description": {
               "type": "string"
             },
-            "experimental": {
-              "additionalProperties": false,
-              "properties": {
-                "mouseEvents": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "$ref": "#/definitions/MouseEventsDeep"
-                    }
-                  ]
-                }
-              },
-              "type": "object"
-            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -3133,22 +3101,6 @@
             "description": {
               "type": "string"
             },
-            "experimental": {
-              "additionalProperties": false,
-              "properties": {
-                "mouseEvents": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "$ref": "#/definitions/MouseEventsDeep"
-                    }
-                  ]
-                }
-              },
-              "type": "object"
-            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -3202,22 +3154,6 @@
                       "centerRadius": {
                         "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
                         "type": "number"
-                      },
-                      "experimental": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "mouseEvents": {
-                            "anyOf": [
-                              {
-                                "type": "boolean"
-                              },
-                              {
-                                "$ref": "#/definitions/MouseEventsDeep"
-                              }
-                            ]
-                          }
-                        },
-                        "type": "object"
                       },
                       "layout": {
                         "$ref": "#/definitions/Layout",
@@ -3678,22 +3614,6 @@
         "centerRadius": {
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
           "type": "number"
-        },
-        "experimental": {
-          "additionalProperties": false,
-          "properties": {
-            "mouseEvents": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "$ref": "#/definitions/MouseEventsDeep"
-                }
-              ]
-            }
-          },
-          "type": "object"
         },
         "layout": {
           "$ref": "#/definitions/Layout",
@@ -7646,22 +7566,6 @@
               "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
               "type": "number"
             },
-            "experimental": {
-              "additionalProperties": false,
-              "properties": {
-                "mouseEvents": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "$ref": "#/definitions/MouseEventsDeep"
-                    }
-                  ]
-                }
-              },
-              "type": "object"
-            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -8665,22 +8569,6 @@
         "endAngle": {
           "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
           "type": "number"
-        },
-        "experimental": {
-          "additionalProperties": false,
-          "properties": {
-            "mouseEvents": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "$ref": "#/definitions/MouseEventsDeep"
-                }
-              ]
-            }
-          },
-          "type": "object"
         },
         "height": {
           "description": "Specify the track height in pixels.",

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -25,6 +25,27 @@
       ],
       "type": "string"
     },
+    "BrushAndMarkHighlightingStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "opacity": {
+          "type": "number"
+        },
+        "stroke": {
+          "type": "string"
+        },
+        "strokeOpacity": {
+          "type": "number"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
     "ChannelWithBase": {
       "anyOf": [
         {
@@ -521,6 +542,27 @@
       ],
       "type": "string"
     },
+    "MouseEventsDeep": {
+      "additionalProperties": false,
+      "properties": {
+        "click": {
+          "type": "boolean"
+        },
+        "enableMouseOverOnMultipleMarks": {
+          "type": "boolean"
+        },
+        "groupMarksByField": {
+          "type": "string"
+        },
+        "mouseOver": {
+          "type": "boolean"
+        },
+        "rangeSelect": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "Orientation": {
       "enum": [
         "horizontal",
@@ -693,11 +735,65 @@
           ],
           "type": "string"
         },
+        "mouseOveredMarks": {
+          "additionalProperties": false,
+          "description": "Customize visual effects of mouse over events on marks.",
+          "properties": {
+            "color": {
+              "type": "string"
+            },
+            "opacity": {
+              "type": "number"
+            },
+            "showOnTheBack": {
+              "type": "boolean"
+            },
+            "stroke": {
+              "type": "string"
+            },
+            "strokeOpacity": {
+              "type": "number"
+            },
+            "strokeWidth": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
         "outline": {
           "type": "string"
         },
         "outlineWidth": {
           "type": "number"
+        },
+        "rangeSelectBrush": {
+          "$ref": "#/definitions/BrushAndMarkHighlightingStyle",
+          "description": "Customize the style of range brushes."
+        },
+        "selectedMarks": {
+          "additionalProperties": false,
+          "description": "Customize visual effects selection events on marks with range brushes.",
+          "properties": {
+            "color": {
+              "type": "string"
+            },
+            "opacity": {
+              "type": "number"
+            },
+            "showOnTheBack": {
+              "type": "boolean"
+            },
+            "stroke": {
+              "type": "string"
+            },
+            "strokeOpacity": {
+              "type": "number"
+            },
+            "strokeWidth": {
+              "type": "number"
+            }
+          },
+          "type": "object"
         },
         "textAnchor": {
           "description": "Specify the alignment of `text` marks to a given point.",
@@ -800,6 +896,22 @@
         "endAngle": {
           "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
           "type": "number"
+        },
+        "experimental": {
+          "additionalProperties": false,
+          "properties": {
+            "mouseEvents": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            }
+          },
+          "type": "object"
         },
         "flipY": {
           "type": "boolean"

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -25,27 +25,6 @@
       ],
       "type": "string"
     },
-    "BrushAndMarkHighlightingStyle": {
-      "additionalProperties": false,
-      "properties": {
-        "color": {
-          "type": "string"
-        },
-        "opacity": {
-          "type": "number"
-        },
-        "stroke": {
-          "type": "string"
-        },
-        "strokeOpacity": {
-          "type": "number"
-        },
-        "strokeWidth": {
-          "type": "number"
-        }
-      },
-      "type": "object"
-    },
     "ChannelWithBase": {
       "anyOf": [
         {
@@ -487,6 +466,34 @@
       ],
       "type": "object"
     },
+    "EventArrange": {
+      "enum": [
+        "behind",
+        "front"
+      ],
+      "type": "string"
+    },
+    "EventStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "opacity": {
+          "type": "number"
+        },
+        "stroke": {
+          "type": "string"
+        },
+        "strokeOpacity": {
+          "type": "number"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
     "FieldType": {
       "enum": [
         "genomic",
@@ -618,6 +625,10 @@
         "backgroundOpacity": {
           "type": "number"
         },
+        "brush": {
+          "$ref": "#/definitions/EventStyle",
+          "description": "Customize the style of range brushes."
+        },
         "curve": {
           "description": "Specify the curve of `rule` marks.",
           "enum": [
@@ -714,18 +725,18 @@
           ],
           "type": "string"
         },
-        "mouseOveredMarks": {
+        "mouseOver": {
           "additionalProperties": false,
           "description": "Customize visual effects of mouse over events on marks.",
           "properties": {
+            "arrange": {
+              "$ref": "#/definitions/EventArrange"
+            },
             "color": {
               "type": "string"
             },
             "opacity": {
               "type": "number"
-            },
-            "showOnTheBack": {
-              "type": "boolean"
             },
             "stroke": {
               "type": "string"
@@ -745,22 +756,18 @@
         "outlineWidth": {
           "type": "number"
         },
-        "rangeSelectBrush": {
-          "$ref": "#/definitions/BrushAndMarkHighlightingStyle",
-          "description": "Customize the style of range brushes."
-        },
-        "selectedMarks": {
+        "select": {
           "additionalProperties": false,
           "description": "Customize visual effects selection events on marks with range brushes.",
           "properties": {
+            "arrange": {
+              "$ref": "#/definitions/EventArrange"
+            },
             "color": {
               "type": "string"
             },
             "opacity": {
               "type": "number"
-            },
-            "showOnTheBack": {
-              "type": "boolean"
             },
             "stroke": {
               "type": "string"

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -542,27 +542,6 @@
       ],
       "type": "string"
     },
-    "MouseEventsDeep": {
-      "additionalProperties": false,
-      "properties": {
-        "click": {
-          "type": "boolean"
-        },
-        "enableMouseOverOnMultipleMarks": {
-          "type": "boolean"
-        },
-        "groupMarksByField": {
-          "type": "string"
-        },
-        "mouseOver": {
-          "type": "boolean"
-        },
-        "rangeSelect": {
-          "type": "boolean"
-        }
-      },
-      "type": "object"
-    },
     "Orientation": {
       "enum": [
         "horizontal",
@@ -896,22 +875,6 @@
         "endAngle": {
           "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
           "type": "number"
-        },
-        "experimental": {
-          "additionalProperties": false,
-          "properties": {
-            "mouseEvents": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "$ref": "#/definitions/MouseEventsDeep"
-                }
-              ]
-            }
-          },
-          "type": "object"
         },
         "flipY": {
           "type": "boolean"

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -466,13 +466,6 @@
       ],
       "type": "object"
     },
-    "EventArrange": {
-      "enum": [
-        "behind",
-        "front"
-      ],
-      "type": "string"
-    },
     "EventStyle": {
       "additionalProperties": false,
       "properties": {
@@ -730,7 +723,11 @@
           "description": "Customize visual effects of mouse over events on marks.",
           "properties": {
             "arrange": {
-              "$ref": "#/definitions/EventArrange"
+              "enum": [
+                "behind",
+                "front"
+              ],
+              "type": "string"
             },
             "color": {
               "type": "string"
@@ -761,7 +758,11 @@
           "description": "Customize visual effects selection events on marks with range brushes.",
           "properties": {
             "arrange": {
-              "$ref": "#/definitions/EventArrange"
+              "enum": [
+                "behind",
+                "front"
+              ],
+              "type": "string"
             },
             "color": {
               "type": "string"

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -138,6 +138,14 @@ export interface CommonViewDef {
      */
     centerRadius?: number;
 
+    // Experimental
+    experimental?: {
+        /*
+         * Determine whether to use mouse events, such as click and mouse over on marks. __Default__: `false`
+         */
+        mouseEvents?: boolean | MouseEventsDeep;
+    };
+
     /**
      * Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views.
      * Will be overriden by the style of children elements (e.g., view, track).
@@ -268,14 +276,6 @@ export type MouseEventsDeep = {
 /* ----------------------------- TRACK ----------------------------- */
 export type SingleTrack = SingleTrackBase & Encoding;
 
-export interface BrushAndMarkHighlightingStyle {
-    color: string;
-    stroke: string;
-    strokeWidth: number;
-    strokeOpacity: number;
-    opacity: number;
-}
-
 interface SingleTrackBase extends CommonTrackDef {
     // Data
     data: DataDeep;
@@ -285,19 +285,6 @@ interface SingleTrackBase extends CommonTrackDef {
 
     // Tooltip
     tooltip?: Tooltip[];
-
-    // Experimental
-    experimental?: {
-        // Mouse events
-        mouseEvents?: boolean | MouseEventsDeep;
-
-        // TODO: move all following style-related properties to `style` (June-02-2022)
-        mouseOveredMarks?: {
-            showHoveringOnTheBack?: boolean;
-        } & Partial<BrushAndMarkHighlightingStyle>;
-        selectedMarks?: { showOnTheBack?: boolean } & Partial<BrushAndMarkHighlightingStyle>;
-        rangeSelectBrush?: Partial<BrushAndMarkHighlightingStyle>;
-    };
 
     // Mark
     mark: Mark;
@@ -365,6 +352,14 @@ export type OverlaidTrack = Partial<SingleTrack> &
         // This is a property internally used when compiling
         overlay: Partial<Omit<SingleTrack, 'height' | 'width' | 'layout' | 'title' | 'subtitle'>>[];
     };
+
+export interface BrushAndMarkHighlightingStyle {
+    color?: string;
+    stroke?: string;
+    strokeWidth?: number;
+    strokeOpacity?: number;
+    opacity?: number;
+}
 
 export interface Style {
     // Top-level Styles
@@ -460,6 +455,21 @@ export interface Style {
      * Determine to show only one side of the diagonal in a HiGlass matrix. __Default__: `"full"`
      */
     matrixExtent?: 'full' | 'upper-right' | 'lower-left';
+
+    /**
+     * Customize visual effects of mouse over events on marks.
+     */
+    mouseOveredMarks?: { showOnTheBack?: boolean } & BrushAndMarkHighlightingStyle;
+
+    /**
+     * Customize visual effects selection events on marks with range brushes.
+     */
+    selectedMarks?: { showOnTheBack?: boolean } & BrushAndMarkHighlightingStyle;
+
+    /**
+     * Customize the style of range brushes.
+     */
+    rangeSelectBrush?: BrushAndMarkHighlightingStyle;
 }
 
 /* ----------------------------- SEMANTIC ZOOM ----------------------------- */

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -353,13 +353,22 @@ export type OverlaidTrack = Partial<SingleTrack> &
         overlay: Partial<Omit<SingleTrack, 'height' | 'width' | 'layout' | 'title' | 'subtitle'>>[];
     };
 
-export interface BrushAndMarkHighlightingStyle {
+/*
+ * The styles of the effects of mouse events, such as mouse over on marks.
+ */
+export interface EventStyle {
     color?: string;
     stroke?: string;
     strokeWidth?: number;
     strokeOpacity?: number;
     opacity?: number;
 }
+
+/*
+ * Show event effects behind or in front of marks.
+ * __Default__: `'front'`
+ */
+export type EventArrange = 'behind' | 'front';
 
 export interface Style {
     // Top-level Styles
@@ -459,17 +468,17 @@ export interface Style {
     /**
      * Customize visual effects of mouse over events on marks.
      */
-    mouseOveredMarks?: { showOnTheBack?: boolean } & BrushAndMarkHighlightingStyle;
+    mouseOver?: { arrange?: EventArrange } & EventStyle;
 
     /**
      * Customize visual effects selection events on marks with range brushes.
      */
-    selectedMarks?: { showOnTheBack?: boolean } & BrushAndMarkHighlightingStyle;
+    select?: { arrange?: EventArrange } & EventStyle;
 
     /**
      * Customize the style of range brushes.
      */
-    rangeSelectBrush?: BrushAndMarkHighlightingStyle;
+    brush?: EventStyle;
 }
 
 /* ----------------------------- SEMANTIC ZOOM ----------------------------- */

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -368,7 +368,9 @@ export interface EventStyle {
  * Show event effects behind or in front of marks.
  * __Default__: `'front'`
  */
-export type EventArrange = 'behind' | 'front';
+export interface EventArrange {
+    arrange?: 'behind' | 'front';
+}
 
 export interface Style {
     // Top-level Styles
@@ -468,12 +470,12 @@ export interface Style {
     /**
      * Customize visual effects of mouse over events on marks.
      */
-    mouseOver?: { arrange?: EventArrange } & EventStyle;
+    mouseOver?: EventArrange & EventStyle;
 
     /**
      * Customize visual effects selection events on marks with range brushes.
      */
-    select?: { arrange?: EventArrange } & EventStyle;
+    select?: EventArrange & EventStyle;
 
     /**
      * Customize the style of range brushes.

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -138,14 +138,6 @@ export interface CommonViewDef {
      */
     centerRadius?: number;
 
-    // Experimental
-    experimental?: {
-        /*
-         * Determine whether to use mouse events, such as click and mouse over on marks. __Default__: `false`
-         */
-        mouseEvents?: boolean | MouseEventsDeep;
-    };
-
     /**
      * Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views.
      * Will be overriden by the style of children elements (e.g., view, track).
@@ -285,6 +277,14 @@ interface SingleTrackBase extends CommonTrackDef {
 
     // Tooltip
     tooltip?: Tooltip[];
+
+    // Experimental
+    experimental?: {
+        /*
+         * Determine whether to use mouse events, such as click and mouse over on marks. __Default__: `false`
+         */
+        mouseEvents?: boolean | MouseEventsDeep;
+    };
 
     // Mark
     mark: Mark;

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -29,7 +29,7 @@ export interface LinearBrushEndEdgeData extends LinearBrushDataCommon {
 export type OnBrushCallbackFn = (start: number, end: number) => void;
 
 // default styles for brush
-const BRUSH_STYLE_DEFAULT = {
+const BRUSH_STYLE_DEFAULT: Required<BrushAndMarkHighlightingStyle> = {
     color: '#777',
     stroke: '#777',
     strokeWidth: 1,
@@ -43,7 +43,7 @@ const BRUSH_STYLE_DEFAULT = {
 export class LinearBrushModel {
     /* graphical elements */
     private brushSelection: D3Selection.Selection<SVGRectElement, LinearBrushData[number], SVGGElement, any>;
-    private readonly style: BrushAndMarkHighlightingStyle;
+    private readonly style: Required<BrushAndMarkHighlightingStyle>;
 
     /* data */
     private range: [number, number] | null;
@@ -70,7 +70,7 @@ export class LinearBrushModel {
         selection: D3Selection.Selection<SVGGElement, unknown, HTMLElement, unknown>,
         hgLibraries: any,
         onBrush: (range: [number, number] | null, skipApiTrigger: boolean) => void,
-        style: Partial<BrushAndMarkHighlightingStyle> = {}
+        style: BrushAndMarkHighlightingStyle = {}
     ) {
         this.range = null;
         this.prevExtent = [0, 0];

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -1,6 +1,6 @@
 import type * as D3Selection from 'd3-selection';
 import type * as D3Drag from 'd3-drag';
-import type { BrushAndMarkHighlightingStyle } from '@gosling.schema';
+import type { EventStyle } from '@gosling.schema';
 
 const HIDDEN_BRUSH_EDGE_SIZE = 3;
 
@@ -29,7 +29,7 @@ export interface LinearBrushEndEdgeData extends LinearBrushDataCommon {
 export type OnBrushCallbackFn = (start: number, end: number) => void;
 
 // default styles for brush
-const BRUSH_STYLE_DEFAULT: Required<BrushAndMarkHighlightingStyle> = {
+const BRUSH_STYLE_DEFAULT: Required<EventStyle> = {
     color: '#777',
     stroke: '#777',
     strokeWidth: 1,
@@ -43,7 +43,7 @@ const BRUSH_STYLE_DEFAULT: Required<BrushAndMarkHighlightingStyle> = {
 export class LinearBrushModel {
     /* graphical elements */
     private brushSelection: D3Selection.Selection<SVGRectElement, LinearBrushData[number], SVGGElement, any>;
-    private readonly style: Required<BrushAndMarkHighlightingStyle>;
+    private readonly style: Required<EventStyle>;
 
     /* data */
     private range: [number, number] | null;
@@ -70,7 +70,7 @@ export class LinearBrushModel {
         selection: D3Selection.Selection<SVGGElement, unknown, HTMLElement, unknown>,
         hgLibraries: any,
         onBrush: (range: [number, number] | null, skipApiTrigger: boolean) => void,
-        style: BrushAndMarkHighlightingStyle = {}
+        style: EventStyle = {}
     ) {
         this.range = null;
         this.prevExtent = [0, 0];

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -4,7 +4,7 @@ import * as uuid from 'uuid';
 import { isEqual, sampleSize, uniqBy } from 'lodash-es';
 import { format } from 'd3-format';
 import type { ScaleLinear } from 'd3-scale';
-import type { SingleTrack, OverlaidTrack, Datum, BrushAndMarkHighlightingStyle } from '@gosling.schema';
+import type { SingleTrack, OverlaidTrack, Datum, EventStyle } from '@gosling.schema';
 import type { CompleteThemeDeep } from 'src/core/utils/theme';
 import { drawMark, drawPostEmbellishment, drawPreEmbellishment } from '../core/mark';
 import { GoslingTrackModel } from '../core/gosling-track-model';
@@ -52,7 +52,7 @@ function usePrereleaseRendering(spec: SingleTrack | OverlaidTrack) {
 // Refer to the following already supported graphics:
 // https://github.com/higlass/higlass/blob/54f5aae61d3474f9e868621228270f0c90ef9343/app/scripts/PixiTrack.js#L115
 
-const DEFAULT_MARK_HIGHLIGHT_STYLE: Required<BrushAndMarkHighlightingStyle> = {
+const DEFAULT_MARK_HIGHLIGHT_STYLE: Required<EventStyle> = {
     stroke: 'black',
     strokeWidth: 1,
     strokeOpacity: 1,
@@ -160,7 +160,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 this.gBrush,
                 HGC.libraries,
                 this.onRangeBrush.bind(this),
-                this.options.spec.style?.rangeSelectBrush
+                this.options.spec.style?.brush
             );
             this.pMask.mousedown = (e: InteractionEvent) =>
                 this.onMouseDown(
@@ -1148,7 +1148,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 // selection effect graphics
                 const g = this.pMouseSelection;
 
-                if (!this.options.spec.style?.selectedMarks?.showOnTheBack) {
+                if (this.options.spec.style?.select?.arrange !== 'behind') {
                     // place on the top
                     this.pMain.removeChild(g);
                     this.pMain.addChild(g);
@@ -1157,7 +1157,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 this.highlightMarks(
                     g,
                     capturedElements,
-                    Object.assign({}, DEFAULT_MARK_HIGHLIGHT_STYLE, this.options.spec.style?.selectedMarks)
+                    Object.assign({}, DEFAULT_MARK_HIGHLIGHT_STYLE, this.options.spec.style?.select)
                 );
             }
 
@@ -1281,7 +1281,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                     // Display mouse over effects
                     const g = this.pMouseHover;
 
-                    if (!this.options.spec.style?.mouseOveredMarks?.showOnTheBack) {
+                    if (this.options.spec.style?.mouseOver?.arrange !== 'behind') {
                         // place on the top
                         this.pMain.removeChild(g);
                         this.pMain.addChild(g);
@@ -1290,7 +1290,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                     this.highlightMarks(
                         g,
                         capturedElements,
-                        Object.assign({}, DEFAULT_MARK_HIGHLIGHT_STYLE, this.options.spec.style?.mouseOveredMarks)
+                        Object.assign({}, DEFAULT_MARK_HIGHLIGHT_STYLE, this.options.spec.style?.mouseOver)
                     );
 
                     // API call

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -4,7 +4,7 @@ import * as uuid from 'uuid';
 import { isEqual, sampleSize, uniqBy } from 'lodash-es';
 import { format } from 'd3-format';
 import type { ScaleLinear } from 'd3-scale';
-import type { SingleTrack, OverlaidTrack, Datum } from '@gosling.schema';
+import type { SingleTrack, OverlaidTrack, Datum, BrushAndMarkHighlightingStyle } from '@gosling.schema';
 import type { CompleteThemeDeep } from 'src/core/utils/theme';
 import { drawMark, drawPostEmbellishment, drawPreEmbellishment } from '../core/mark';
 import { GoslingTrackModel } from '../core/gosling-track-model';
@@ -52,7 +52,7 @@ function usePrereleaseRendering(spec: SingleTrack | OverlaidTrack) {
 // Refer to the following already supported graphics:
 // https://github.com/higlass/higlass/blob/54f5aae61d3474f9e868621228270f0c90ef9343/app/scripts/PixiTrack.js#L115
 
-const DEFAULT_MARK_HIGHLIGHT_STYLE = {
+const DEFAULT_MARK_HIGHLIGHT_STYLE: Required<BrushAndMarkHighlightingStyle> = {
     stroke: 'black',
     strokeWidth: 1,
     strokeOpacity: 1,
@@ -160,7 +160,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 this.gBrush,
                 HGC.libraries,
                 this.onRangeBrush.bind(this),
-                this.options.spec.experimental?.rangeSelectBrush
+                this.options.spec.style?.rangeSelectBrush
             );
             this.pMask.mousedown = (e: InteractionEvent) =>
                 this.onMouseDown(
@@ -1148,7 +1148,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 // selection effect graphics
                 const g = this.pMouseSelection;
 
-                if (!this.options.spec.experimental?.selectedMarks?.showOnTheBack) {
+                if (!this.options.spec.style?.selectedMarks?.showOnTheBack) {
                     // place on the top
                     this.pMain.removeChild(g);
                     this.pMain.addChild(g);
@@ -1157,7 +1157,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                 this.highlightMarks(
                     g,
                     capturedElements,
-                    Object.assign({}, DEFAULT_MARK_HIGHLIGHT_STYLE, this.options.spec.experimental?.selectedMarks)
+                    Object.assign({}, DEFAULT_MARK_HIGHLIGHT_STYLE, this.options.spec.style?.selectedMarks)
                 );
             }
 
@@ -1281,7 +1281,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                     // Display mouse over effects
                     const g = this.pMouseHover;
 
-                    if (!this.options.spec.experimental?.mouseOveredMarks?.showHoveringOnTheBack) {
+                    if (!this.options.spec.style?.mouseOveredMarks?.showOnTheBack) {
                         // place on the top
                         this.pMain.removeChild(g);
                         this.pMain.addChild(g);
@@ -1290,11 +1290,7 @@ function GoslingTrack(HGC: any, ...args: any[]): any {
                     this.highlightMarks(
                         g,
                         capturedElements,
-                        Object.assign(
-                            {},
-                            DEFAULT_MARK_HIGHLIGHT_STYLE,
-                            this.options.spec.experimental?.mouseOveredMarks
-                        )
+                        Object.assign({}, DEFAULT_MARK_HIGHLIGHT_STYLE, this.options.spec.style?.mouseOveredMarks)
                     );
 
                     // API call


### PR DESCRIPTION
This PR moves all styling properties for mouse events (i.e., mouse over and selection effects and the range brush) under the `style` property. Users can specify this at the track level

```ts
{
  mark: 'point', ..., // track definition
  style: {
    mouseOver: {
      color: 'blue',
      opacity: 0.5,
      strokeWidth: 0,
      arrange: 'behind'
    },
    select: {
      color: 'red',
      opacity: 0.5,
      arrange: 'behind'
    },
    brush: {
      color: 'purple',
      stroke: 'purple'
    }
  }
}
```

or at the any upper level

```ts
{
  title: 'gos visualization', ..., // root-level gosling spec
  style: {
    mouseOver: {
      color: 'blue',
      opacity: 0.5,
      strokeWidth: 0,
      arrange: 'behind'
    },
    select: {
      color: 'red',
      opacity: 0.5,
      arrange: 'behind'
    },
    brush: {
      color: 'purple',
      stroke: 'purple'
    },
    arrange: 'behind'
  },
  views: [...] // all children use the same style unless they are defined at lower levels.
}
```

Fix #710 