### PR TITLE
refactor: give chromosome and position info. separately to API consumers

### DIFF
--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -304,10 +304,12 @@ function Editor(props: RouteComponentProps) {
             // console.log('click', data.data);
             // TODO: show messages on the right-bottom of the editor
             // gosRef.current.api.subscribe('mouseOver', (type, eventData) => {
-            //     setMouseEventInfo({ type: 'mouseOver', data: eventData.data, position: eventData.genomicPosition });
+            //     console.warn(type, eventData.id, eventData.genomicPosition, eventData.data);
+            //     // setMouseEventInfo({ type: 'mouseOver', data: eventData.data, position: eventData.genomicPosition });
             // });
             // gosRef.current.api.subscribe('click', (type, eventData) => {
-            //     setMouseEventInfo({ type: 'click', data: eventData.data, position: eventData.genomicPosition });
+            //     console.warn(type, eventData.id, eventData.genomicPosition, eventData.data);
+            //     // setMouseEventInfo({ type: 'click', data: eventData.data, position: eventData.genomicPosition });
             // });
             // Range Select API
             // gosRef.current.api.subscribe('rangeSelect', (type, eventData) => {
@@ -315,8 +317,8 @@ function Editor(props: RouteComponentProps) {
             // });
         }
         return () => {
-            // gosRef.current.api.unsubscribe('mouseOver');
-            // gosRef.current.api.unsubscribe('click');
+            // gosRef.current?.api.unsubscribe('mouseOver');
+            // gosRef.current?.api.unsubscribe('click');
             // gosRef.current?.api.unsubscribe('rangeSelect');
         };
     }, [gosRef.current]);

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -900,6 +900,14 @@
     "EventStyle": {
       "additionalProperties": false,
       "properties": {
+        "arrange": {
+          "description": "Show event effects behind or in front of marks.",
+          "enum": [
+            "behind",
+            "front"
+          ],
+          "type": "string"
+        },
         "color": {
           "type": "string"
         },
@@ -8282,8 +8290,26 @@
           "type": "number"
         },
         "brush": {
-          "$ref": "#/definitions/EventStyle",
-          "description": "Customize the style of range brushes."
+          "additionalProperties": false,
+          "description": "Customize the style of range brushes.",
+          "properties": {
+            "color": {
+              "type": "string"
+            },
+            "opacity": {
+              "type": "number"
+            },
+            "stroke": {
+              "type": "string"
+            },
+            "strokeOpacity": {
+              "type": "number"
+            },
+            "strokeWidth": {
+              "type": "number"
+            }
+          },
+          "type": "object"
         },
         "curve": {
           "description": "Specify the curve of `rule` marks.",
@@ -8382,33 +8408,8 @@
           "type": "string"
         },
         "mouseOver": {
-          "additionalProperties": false,
-          "description": "Customize visual effects of mouse over events on marks.",
-          "properties": {
-            "arrange": {
-              "enum": [
-                "behind",
-                "front"
-              ],
-              "type": "string"
-            },
-            "color": {
-              "type": "string"
-            },
-            "opacity": {
-              "type": "number"
-            },
-            "stroke": {
-              "type": "string"
-            },
-            "strokeOpacity": {
-              "type": "number"
-            },
-            "strokeWidth": {
-              "type": "number"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/EventStyle",
+          "description": "Customize visual effects of mouse over events on marks."
         },
         "outline": {
           "type": "string"
@@ -8417,33 +8418,8 @@
           "type": "number"
         },
         "select": {
-          "additionalProperties": false,
-          "description": "Customize visual effects selection events on marks with range brushes.",
-          "properties": {
-            "arrange": {
-              "enum": [
-                "behind",
-                "front"
-              ],
-              "type": "string"
-            },
-            "color": {
-              "type": "string"
-            },
-            "opacity": {
-              "type": "number"
-            },
-            "stroke": {
-              "type": "string"
-            },
-            "strokeOpacity": {
-              "type": "number"
-            },
-            "strokeWidth": {
-              "type": "number"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/EventStyle",
+          "description": "Customize visual effects selection events on marks with range brushes."
         },
         "textAnchor": {
           "description": "Specify the alignment of `text` marks to a given point.",

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -469,6 +469,14 @@
     "EventStyle": {
       "additionalProperties": false,
       "properties": {
+        "arrange": {
+          "description": "Show event effects behind or in front of marks.",
+          "enum": [
+            "behind",
+            "front"
+          ],
+          "type": "string"
+        },
         "color": {
           "type": "string"
         },
@@ -619,8 +627,26 @@
           "type": "number"
         },
         "brush": {
-          "$ref": "#/definitions/EventStyle",
-          "description": "Customize the style of range brushes."
+          "additionalProperties": false,
+          "description": "Customize the style of range brushes.",
+          "properties": {
+            "color": {
+              "type": "string"
+            },
+            "opacity": {
+              "type": "number"
+            },
+            "stroke": {
+              "type": "string"
+            },
+            "strokeOpacity": {
+              "type": "number"
+            },
+            "strokeWidth": {
+              "type": "number"
+            }
+          },
+          "type": "object"
         },
         "curve": {
           "description": "Specify the curve of `rule` marks.",
@@ -719,33 +745,8 @@
           "type": "string"
         },
         "mouseOver": {
-          "additionalProperties": false,
-          "description": "Customize visual effects of mouse over events on marks.",
-          "properties": {
-            "arrange": {
-              "enum": [
-                "behind",
-                "front"
-              ],
-              "type": "string"
-            },
-            "color": {
-              "type": "string"
-            },
-            "opacity": {
-              "type": "number"
-            },
-            "stroke": {
-              "type": "string"
-            },
-            "strokeOpacity": {
-              "type": "number"
-            },
-            "strokeWidth": {
-              "type": "number"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/EventStyle",
+          "description": "Customize visual effects of mouse over events on marks."
         },
         "outline": {
           "type": "string"
@@ -754,33 +755,8 @@
           "type": "number"
         },
         "select": {
-          "additionalProperties": false,
-          "description": "Customize visual effects selection events on marks with range brushes.",
-          "properties": {
-            "arrange": {
-              "enum": [
-                "behind",
-                "front"
-              ],
-              "type": "string"
-            },
-            "color": {
-              "type": "string"
-            },
-            "opacity": {
-              "type": "number"
-            },
-            "stroke": {
-              "type": "string"
-            },
-            "strokeOpacity": {
-              "type": "number"
-            },
-            "strokeWidth": {
-              "type": "number"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/EventStyle",
+          "description": "Customize visual effects selection events on marks with range brushes."
         },
         "textAnchor": {
           "description": "Specify the alignment of `text` marks to a given point.",

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -237,14 +237,20 @@ interface CommonEventData {
     data: Datum[];
 }
 
+export interface GenomicPosition {
+    chromosome: string;
+    position: number;
+}
+
 interface PointMouseEventData extends CommonEventData {
     /* A genomic coordinate, e.g., `chr1:100,000`. */
-    genomicPosition: string;
+    genomicPosition: GenomicPosition;
 }
 
 interface RangeMouseEventData extends CommonEventData {
-    /* Start and end genomic coordinates, e.g., `chr1:100,000`. NULL if a range is deselected. */
-    genomicRange: [string, string] | null;
+    // NOTE: We could include this type to `GenomicDomain`, i.e., enabling users to display genomic range across multiple chromosomes
+    /* Start and end genomic coordinates. Null if a range is deselected. */
+    genomicRange: [GenomicPosition, GenomicPosition] | null;
 }
 
 export type _EventMap = {
@@ -362,13 +368,8 @@ export interface EventStyle {
     strokeWidth?: number;
     strokeOpacity?: number;
     opacity?: number;
-}
 
-/*
- * Show event effects behind or in front of marks.
- * __Default__: `'front'`
- */
-export interface EventArrange {
+    /** Show event effects behind or in front of marks. */
     arrange?: 'behind' | 'front';
 }
 
@@ -470,17 +471,17 @@ export interface Style {
     /**
      * Customize visual effects of mouse over events on marks.
      */
-    mouseOver?: EventArrange & EventStyle;
+    mouseOver?: EventStyle;
 
     /**
      * Customize visual effects selection events on marks with range brushes.
      */
-    select?: EventArrange & EventStyle;
+    select?: EventStyle;
 
     /**
      * Customize the style of range brushes.
      */
-    brush?: EventStyle;
+    brush?: Omit<EventStyle, 'arrange'>;
 }
 
 /* ----------------------------- SEMANTIC ZOOM ----------------------------- */

--- a/src/core/utils/assembly.test.ts
+++ b/src/core/utils/assembly.test.ts
@@ -1,4 +1,4 @@
-import { getChromInterval, getChromTotalSize, GET_CHROM_SIZES } from './assembly';
+import { getChromInterval, getChromTotalSize, getRelativeGenomicPosition, GET_CHROM_SIZES } from './assembly';
 import { CHROM_SIZE_HG38 } from './chrom-size';
 
 describe('Assembly', () => {
@@ -15,5 +15,11 @@ describe('Assembly', () => {
     });
     it('Chromosome interval calculation', () => {
         expect(getChromInterval({ 1: 111, 2: 222 })).toEqual({ 1: [0, 111], 2: [111, 333] });
+    });
+    it('Absolute to relative genomic position', () => {
+        expect(getRelativeGenomicPosition(CHROM_SIZE_HG38.chr1 + 1, 'hg38')).toEqual({
+            chromosome: 'chr2',
+            position: 1
+        });
     });
 });

--- a/src/core/utils/assembly.test.ts
+++ b/src/core/utils/assembly.test.ts
@@ -21,5 +21,10 @@ describe('Assembly', () => {
             chromosome: 'chr2',
             position: 1
         });
+        const outOfPos = GET_CHROM_SIZES('hg38').total + 1;
+        expect(getRelativeGenomicPosition(outOfPos, 'hg38')).toEqual({
+            chromosome: 'unknown',
+            position: outOfPos
+        });
     });
 });

--- a/src/core/utils/assembly.ts
+++ b/src/core/utils/assembly.ts
@@ -17,22 +17,20 @@ export interface ChromSize {
 }
 
 /**
- * Get relative chromosome position (e.g., `100` => `chr:100`)
+ * Get relative chromosome position (e.g., `100` => `{ chromosome: 'chr1', position: 100 }`)
  */
 export function getRelativeGenomicPosition(absPos: number, assembly?: string): GenomicPosition {
-    const chrAndRange = Object.entries(GET_CHROM_SIZES(assembly).interval).find(d => {
-        const [, [start, end]] = d;
+    const [chromosome, absInterval] = Object.entries(GET_CHROM_SIZES(assembly).interval).find(d => {
+        const [start, end] = d[1];
         return start <= absPos && absPos < end;
-    });
+    }) ?? [null, null];
 
-    if (!chrAndRange) {
+    if (!chromosome || !absInterval) {
         // The number is out of range
         return { chromosome: 'unknown', position: absPos };
     }
 
-    const chromosome = chrAndRange[0];
-    const position = absPos - chrAndRange[1][0];
-    return { chromosome, position };
+    return { chromosome, position: absPos - absInterval[0] };
 }
 
 /**

--- a/src/core/utils/assembly.ts
+++ b/src/core/utils/assembly.ts
@@ -1,4 +1,4 @@
-import { format } from 'd3-format';
+import type { GenomicPosition } from '@gosling.schema';
 import {
     CHROM_SIZE_HG16,
     CHROM_SIZE_HG17,
@@ -19,7 +19,7 @@ export interface ChromSize {
 /**
  * Get relative chromosome position (e.g., `100` => `chr:100`)
  */
-export function getRelativeGenomicPosition(absPos: number, assembly?: string): string {
+export function getRelativeGenomicPosition(absPos: number, assembly?: string): GenomicPosition {
     const chrAndRange = Object.entries(GET_CHROM_SIZES(assembly).interval).find(d => {
         const [, [start, end]] = d;
         return start <= absPos && absPos < end;
@@ -27,11 +27,12 @@ export function getRelativeGenomicPosition(absPos: number, assembly?: string): s
 
     if (!chrAndRange) {
         // The number is out of range
-        return `${absPos}`;
+        return { chromosome: 'unknown', position: absPos };
     }
 
-    const pos = format(',')(absPos - chrAndRange[1][0]);
-    return `${chrAndRange[0]}:${pos}`;
+    const chromosome = chrAndRange[0];
+    const position = absPos - chrAndRange[1][0];
+    return { chromosome, position };
 }
 
 /**

--- a/src/gosling-brush/linear-brush-model.ts
+++ b/src/gosling-brush/linear-brush-model.ts
@@ -29,7 +29,7 @@ export interface LinearBrushEndEdgeData extends LinearBrushDataCommon {
 export type OnBrushCallbackFn = (start: number, end: number) => void;
 
 // default styles for brush
-const BRUSH_STYLE_DEFAULT: Required<EventStyle> = {
+const BRUSH_STYLE_DEFAULT: Required<Omit<EventStyle, 'arrange'>> = {
     color: '#777',
     stroke: '#777',
     strokeWidth: 1,
@@ -43,7 +43,7 @@ const BRUSH_STYLE_DEFAULT: Required<EventStyle> = {
 export class LinearBrushModel {
     /* graphical elements */
     private brushSelection: D3Selection.Selection<SVGRectElement, LinearBrushData[number], SVGGElement, any>;
-    private readonly style: Required<EventStyle>;
+    private readonly style: Required<Omit<EventStyle, 'arrange'>>;
 
     /* data */
     private range: [number, number] | null;


### PR DESCRIPTION
This PR changes the format of genomic position or range that are exposed to the consumers of mouse event APIs (i.e., 'rangeSelect', 'mouseOver', 'click'). Previously, we used string values (i.e., `chr1:10,000`), and this PR separates the chromosome from the position:

```ts
// Event data for `click` or 'mouseOver' that is exposed to API consumers
genomicPosition: { chromosome: 'chr1', position: 10000 },
...
```

For the `rangeSelect` event:

```ts
// Event data for `rangeSelect` that is exposed to API consumers
genomicRange: [
  { chromosome: 'chr1', position: 10000 },
  { chromosome: 'chr11', position: 2000 }
],
...
```

- refactor: use object instead of string for genomic range and position
- test: add a test for abs to rel genomic position

Fix #711
Fix https://github.com/gosling-lang/gosling.js/pull/717#discussion_r891411407