### PR TITLE
feat: enable adding a root level aria-label using `description`

### DIFF
--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -175,7 +175,8 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
                             ? props.spec?.responsiveSize
                             : props.spec.responsiveSize.width,
                     responsiveHeight,
-                    background: theme.root.background
+                    background: theme.root.background,
+                    alt: props.spec?.description
                 }}
             />
         ),

--- a/src/core/gosling-embed.ts
+++ b/src/core/gosling-embed.ts
@@ -73,7 +73,11 @@ export function embed(element: HTMLElement, spec: GoslingSpec, opts: GoslingEmbe
         }
 
         const theme = getTheme(opts.theme || 'light');
-        const options = { ...opts, background: theme.root.background };
+        const options = {
+            ...opts,
+            background: theme.root.background,
+            alt: opts.alt ?? spec.description ?? 'Gosling visualization'
+        };
 
         compile(
             spec,

--- a/src/core/higlass-component-wrapper.tsx
+++ b/src/core/higlass-component-wrapper.tsx
@@ -30,6 +30,7 @@ export interface HiGlassComponentWrapperProps {
         background?: string;
         responsiveWidth?: boolean;
         responsiveHeight?: boolean;
+        alt?: string;
     };
     id?: string;
     className?: string;
@@ -76,7 +77,13 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
         );
 
         // Styling
-        const { padding = 60, margin = 0, border = 'none', background } = props.options || {};
+        const {
+            padding = 60,
+            margin = 0,
+            border = 'none',
+            background,
+            alt = 'Gosling visualization'
+        } = props.options || {};
         return (
             <>
                 <div
@@ -92,6 +99,9 @@ export const HiGlassComponentWrapper = forwardRef<HiGlassApi | undefined, HiGlas
                         height: props.options.responsiveHeight ? `calc(100% - ${padding * 2}px)` : props.size.height,
                         textAlign: 'left'
                     }}
+                    aria-label={alt}
+                    role={'graphics-document'} // https://www.w3.org/TR/graphics-aria-1.0/#graphics-document
+                    aria-roledescription="visualization"
                 >
                     <div
                         key={JSON.stringify(viewConfig)}


### PR DESCRIPTION

<img width="1450" alt="alt-with-voice-over" src="https://user-images.githubusercontent.com/9922882/172727535-19f79093-c7cd-43b4-be45-230ae026b388.png">




Fix #718 