### PR TITLE
chore: add an experimental flag for using edge bundling

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -8394,7 +8394,8 @@
           "enum": [
             "elliptical",
             "circular",
-            "straight"
+            "straight",
+            "experimentalEdgeBundling"
           ],
           "type": "string"
         },

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -731,7 +731,8 @@
           "enum": [
             "elliptical",
             "circular",
-            "straight"
+            "straight",
+            "experimentalEdgeBundling"
           ],
           "type": "string"
         },

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -419,7 +419,7 @@ export interface Style {
      * The style of `withinLink` and `betweenLink` marks. __Default__: `'circular'`
      * `'elliptical'` will be used as a default option.
      */
-    linkStyle?: 'elliptical' | 'circular' | 'straight';
+    linkStyle?: 'elliptical' | 'circular' | 'straight' | 'experimentalEdgeBundling';
 
     /**
      * The minimum height of `withinLink` and `betweenLink` marks. Unit is a percentagle. __Default__: `0.5`


### PR DESCRIPTION
```ts
{ ..., style: { linkStyle: "experimentalEdgeBundling" } }
```

TODO: make a separate function for implementing edge bundling

The most relevant part of the source codes regarding the implementation of 'within-link' edge bunding is the following:

https://github.com/gosling-lang/gosling.js/blob/6addaef4b6a6263aa884703c77da2d054ee40708/src/core/mark/withinLink.ts#L256

<a href="https://gosling.js.org/?full=false&spec=(V'titleECqQ'descriptionEhttpjcq.ca%2Fin~o%2FJ_X%2FQ'layoutEcircularQ'static6~ue-'spacing61-'centerRadius60.3-UstackQ'style6('linkStyleEs~aight')-'~acksGA(A*UoverlayQBX6(ABurlEhttpsjraw.githubusercontent.com%2Fvigsterkr%2Fcq%2Fmaster%2FX%2F5%2Fsegdup.txtQKzcsvQKheaderNamesG'id'9chr'9MZPrefixEhsQKZFYEchrQKJFYsG'MseparatorE%20QKlongToWideIdEid'A*)-BopacityH60.4)-B~acksGA**(AKXTransformGA****('zfilter'9fYEchr'9oneOfG'hs1'%5D9not6~ue)A***%5D-*KmarkEwithinLinkQ*KxDp18xeDp1_28x1Dp28x1eDP2_28s~okeHElightgray')-*Ks~okeWidthH61)A**)A*%5D-Bwidth6700-Bheight6300A)V%5D%0A)*%20%20-%2CV6!%208'9zJ')-*K9%2C%20'AVK**'D6('fYEE6'G6%5BH6('valueJgenomicK*BMp1'9p2'%5D-KQ'-U'alignmentEV%0A*XdataYieldZchromosomej%3A%2F%2FqircosztypeE~tr%01~zqjZYXVUQMKJHGEDBA986-*_">Demo</a>