### PR TITLE
add types for `@higlass/tracks`

### DIFF
--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -126,7 +126,7 @@ export function createApi(
                 const a = document.createElement('a');
                 document.body.append(a);
                 a.download = 'gosling-visualization';
-                a.href = URL.createObjectURL(blob);
+                a.href = URL.createObjectURL(blob!);
                 a.click();
                 a.remove();
             }, 'image/png');

--- a/src/core/mark/area.ts
+++ b/src/core/mark/area.ts
@@ -8,12 +8,7 @@ import colorToHex from '../utils/color-to-hex';
 /**
  * Draw area marks
  */
-export function drawArea(
-    HGC: typeof import('@higlass/available-for-plugins'),
-    trackInfo: any,
-    tile: any,
-    model: GoslingTrackModel
-) {
+export function drawArea(HGC: import('@higlass/types').HGC, trackInfo: any, tile: any, model: GoslingTrackModel) {
     /* track spec */
     const spec = model.spec();
 

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -135,7 +135,7 @@ export function drawLinearYAxis(
  * Draw linear scale Y axis
  */
 export function drawCircularYAxis(
-    HGC: typeof import('@higlass/available-for-plugins'),
+    HGC: import('@higlass/types').HGC,
     trackInfo: any,
     tile: any,
     gos: GoslingTrackModel,

--- a/src/core/mark/background.ts
+++ b/src/core/mark/background.ts
@@ -5,7 +5,7 @@ import colorToHex from '../utils/color-to-hex';
 import type { CompleteThemeDeep } from '../utils/theme';
 
 export function drawBackground(
-    HGC: typeof import('@higlass/available-for-plugins'),
+    HGC: import('@higlass/types').HGC,
     trackInfo: any,
     tile: any,
     tm: GoslingTrackModel,

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -49,12 +49,7 @@ export const RESOLUTION = 4;
 /**
  * Draw a track based on the track specification in a Gosling grammar.
  */
-export function drawMark(
-    HGC: typeof import('@higlass/available-for-plugins'),
-    trackInfo: any,
-    tile: any,
-    model: GoslingTrackModel
-) {
+export function drawMark(HGC: import('@higlass/types').HGC, trackInfo: any, tile: any, model: GoslingTrackModel) {
     if (!HGC || !trackInfo || !tile) {
         // We did not receive parameters correctly.
         return;
@@ -136,7 +131,7 @@ export function drawMark(
  * Draw chart embellishments before rendering marks.
  */
 export function drawPreEmbellishment(
-    HGC: typeof import('@higlass/available-for-plugins'),
+    HGC: import('@higlass/types').HGC,
     trackInfo: any,
     tile: any,
     model: GoslingTrackModel,
@@ -182,7 +177,7 @@ export function drawPreEmbellishment(
  * Draw chart embellishments after rendering marks.
  */
 export function drawPostEmbellishment(
-    HGC: typeof import('@higlass/available-for-plugins'),
+    HGC: import('@higlass/types').HGC,
     trackInfo: any,
     tile: any,
     model: GoslingTrackModel,

--- a/src/core/mark/outline-circular.ts
+++ b/src/core/mark/outline-circular.ts
@@ -5,7 +5,7 @@ import colorToHex from '../utils/color-to-hex';
 import type { CompleteThemeDeep } from '../utils/theme';
 
 export function drawCircularOutlines(
-    HGC: typeof import('@higlass/available-for-plugins'),
+    HGC: import('@higlass/types').HGC,
     trackInfo: any,
     tile: any,
     tm: GoslingTrackModel,

--- a/src/core/mark/outline.ts
+++ b/src/core/mark/outline.ts
@@ -13,7 +13,7 @@ export const TITLE_STYLE = {
 };
 
 export function drawChartOutlines(
-    HGC: typeof import('@higlass/available-for-plugins'),
+    HGC: import('@higlass/types').HGC,
     trackInfo: any,
     tm: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>

--- a/src/core/mark/rect.ts
+++ b/src/core/mark/rect.ts
@@ -4,12 +4,7 @@ import type { PIXIVisualProperty } from '../visual-property.schema';
 import colorToHex from '../utils/color-to-hex';
 import { IsChannelDeep } from '../gosling.schema.guards';
 
-export function drawRect(
-    HGC: typeof import('@higlass/available-for-plugins'),
-    trackInfo: any,
-    tile: any,
-    model: GoslingTrackModel
-) {
+export function drawRect(HGC: import('@higlass/types').HGC, trackInfo: any, tile: any, model: GoslingTrackModel) {
     /* track spec */
     const spec = model.spec();
 

--- a/src/core/mark/rule.ts
+++ b/src/core/mark/rule.ts
@@ -4,12 +4,7 @@ import { getValueUsingChannel } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
 
-export function drawRule(
-    HGC: typeof import('@higlass/available-for-plugins'),
-    trackInfo: any,
-    tile: any,
-    model: GoslingTrackModel
-) {
+export function drawRule(HGC: import('@higlass/types').HGC, trackInfo: any, tile: any, model: GoslingTrackModel) {
     /* track spec */
     const spec = model.spec();
 

--- a/src/core/mark/text.ts
+++ b/src/core/mark/text.ts
@@ -16,12 +16,7 @@ export const TEXT_STYLE_GLOBAL = {
     strokeThickness: 0
 } as const;
 
-export function drawText(
-    HGC: typeof import('@higlass/available-for-plugins'),
-    trackInfo: any,
-    tile: any,
-    model: GoslingTrackModel
-) {
+export function drawText(HGC: import('@higlass/types').HGC, trackInfo: any, tile: any, model: GoslingTrackModel) {
     /* track spec */
     const spec = model.spec();
 

--- a/src/core/mark/title.ts
+++ b/src/core/mark/title.ts
@@ -6,7 +6,7 @@ import type { CompleteThemeDeep } from '../utils/theme';
 import { getTextStyle } from '../utils/text-style';
 
 export function drawCircularTitle(
-    HGC: typeof import('@higlass/available-for-plugins'),
+    HGC: import('@higlass/types').HGC,
     trackInfo: any,
     tile: any,
     gos: GoslingTrackModel,

--- a/src/core/utils/define-plugin-track.ts
+++ b/src/core/utils/define-plugin-track.ts
@@ -1,0 +1,34 @@
+import type * as HiGlass from '@higlass/types';
+
+type TrackConfig<Options extends HiGlass.TrackOptions> = {
+    type: string;
+    datatype: string[];
+    local: boolean;
+    orientation: string;
+    thumbnail: Element;
+    availableOptions: string[]; // (keyof Options)[]
+    defaultOptions: Options;
+};
+
+type PluginTrack<Options extends HiGlass.TrackOptions> = {
+    new (HGC: HiGlass.HGC, context: HiGlass.Context<Options>, options: Options): HiGlass.Track;
+    config: TrackConfig<Options>;
+};
+
+export function definePluginTrack<Options extends HiGlass.TrackOptions>(
+    config: TrackConfig<Options>,
+    factory: (
+        HGC: HiGlass.HGC,
+        context: HiGlass.Context<Options>,
+        options: Options & Partial<Record<string, any>>
+    ) => HiGlass.Track
+) {
+    function ctr(HGC: HiGlass.HGC, context: HiGlass.Context<Options>, options: Options) {
+        if (!new.target) {
+            throw new Error('Uncaught TypeError: Class constructor cannot be invoked without "new"');
+        }
+        return factory(HGC, context, options);
+    }
+    ctr.config = config;
+    return ctr as unknown as PluginTrack<Options>;
+}

--- a/src/core/utils/define-plugin-track.ts
+++ b/src/core/utils/define-plugin-track.ts
@@ -1,12 +1,13 @@
 import type * as HiGlass from '@higlass/types';
+export type { TrackConfig } from '@higlass/types';
 
-type AsConstructor<T> = T extends (...args: infer Args) => infer Ret ? { new (...args: Args): Ret } : never;
-
-type PluginTrackFactory<Options extends HiGlass.TrackOptions> = (
+export type PluginTrackFactory<Options extends HiGlass.TrackOptions> = (
     HGC: HiGlass.HGC,
     context: HiGlass.Context<Options>,
     options: Options
 ) => HiGlass.Track;
+
+type AsConstructor<T> = T extends (...args: infer Args) => infer Ret ? { new (...args: Args): Ret } : never;
 
 type PluginTrack<Options extends HiGlass.TrackOptions> = AsConstructor<PluginTrackFactory<Options>> & {
     config: HiGlass.TrackConfig<Options>;

--- a/src/core/utils/define-plugin-track.ts
+++ b/src/core/utils/define-plugin-track.ts
@@ -33,10 +33,3 @@ export function definePluginTrack<Options extends HiGlass.TrackOptions>(
         };
     };
 }
-
-definePluginTrack(
-    {
-        type: 'trevor'
-    },
-    {} as any
-);

--- a/src/core/utils/scalable-rendering.ts
+++ b/src/core/utils/scalable-rendering.ts
@@ -13,7 +13,7 @@ const createColorTexture = (PIXI: typeof import('pixi.js'), colors: ColorRGBA[])
     return [PIXI.Texture.fromBuffer(rgba, colorTexRes, colorTexRes), colorTexRes] as const;
 };
 
-export function setUpShaderAndTextures(HGC: typeof import('@higlass/available-for-plugins'), colorRGBAs: ColorRGBA[]) {
+export function setUpShaderAndTextures(HGC: import('@higlass/types').HGC, colorRGBAs: ColorRGBA[]) {
     // console.log(colorRGBAs);
 
     const [colorMapTex, colorMapTexRes] = createColorTexture(HGC.libraries.PIXI, colorRGBAs);

--- a/src/core/utils/text-style.ts
+++ b/src/core/utils/text-style.ts
@@ -1,5 +1,3 @@
-import type * as PIXI from 'pixi.js';
-
 export type TextStyle = {
     color?: string;
     size?: number;
@@ -18,15 +16,20 @@ export const DEFAULT_TEXT_STYLE: Required<TextStyle> = {
     strokeThickness: 0
 };
 
-export function getTextStyle(style: TextStyle = DEFAULT_TEXT_STYLE): Partial<PIXI.ITextStyle> {
-    const fontWeight = style.fontWeight ?? DEFAULT_TEXT_STYLE.fontWeight;
-    return {
-        fontSize: `${style.size ?? DEFAULT_TEXT_STYLE.size}px`,
-        fontFamily: style.fontFamily ?? DEFAULT_TEXT_STYLE.fontFamily,
-        fontWeight: fontWeight === 'light' ? 'lighter' : fontWeight,
-        fill: style.color ?? DEFAULT_TEXT_STYLE.color,
+export function getTextStyle(style: TextStyle = {}) {
+    const merged: Required<TextStyle> = { ...DEFAULT_TEXT_STYLE, ...style };
+    // Use `const` to get object literal which is compatible with `Partial<PIXI.ITextStyle>`
+    const pixiTextStyle = {
+        fontSize: `${merged.size}px`,
+        fontFamily: merged.fontFamily,
+        fontWeight: merged.fontWeight === 'light' ? 'lighter' : merged.fontWeight,
+        fill: merged.color,
         lineJoin: 'round',
-        stroke: style.stroke ?? DEFAULT_TEXT_STYLE.stroke,
-        strokeThickness: style.strokeThickness ?? DEFAULT_TEXT_STYLE.strokeThickness
+        stroke: merged.stroke,
+        strokeThickness: merged.strokeThickness
+    } as const;
+    // Allow returned object to be mutable (strip `readonly` modifier from `const`)
+    return pixiTextStyle as {
+        -readonly [K in keyof typeof pixiTextStyle]: typeof pixiTextStyle[K];
     };
 }

--- a/src/data-fetcher/bigwig/higlass-bigwig-datafetcher.js
+++ b/src/data-fetcher/bigwig/higlass-bigwig-datafetcher.js
@@ -6,7 +6,7 @@ import { BigWig } from '@gmod/bbi';
 import { RemoteFile } from 'generic-filehandle';
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 
-/** @param {typeof import('@higlass/available-for-plugins')} HGC */
+/** @param {import('@higlass/types').HGC} HGC */
 function BBIDataFetcher(HGC, ...args) {
     if (!new.target) {
         throw new Error('Uncaught TypeError: Class constructor cannot be invoked without "new"');

--- a/src/data-fetcher/vcf/gosling-vcf-data.ts
+++ b/src/data-fetcher/vcf/gosling-vcf-data.ts
@@ -25,7 +25,7 @@ class GoslingVcfData {
     private tbiIndexed: any;
     private tbiVCFParser: any;
 
-    constructor(HGC: typeof import('@higlass/available-for-plugins'), dataConfig: VcfDataConfig, worker: any) {
+    constructor(HGC: import('@higlass/types').HGC, dataConfig: VcfDataConfig, worker: any) {
         this.dataConfig = dataConfig;
         this.uid = HGC.libraries.slugid.nice();
         this.worker = worker;

--- a/src/gosling-genomic-axis/axis-track.ts
+++ b/src/gosling-genomic-axis/axis-track.ts
@@ -20,7 +20,7 @@ type TickLabelInfo = {
     rope?: PIXI.SimpleRope;
 };
 
-function AxisTrack(HGC: typeof import('@higlass/available-for-plugins'), ...args: any[]): any {
+function AxisTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
     if (!new.target) {
         throw new Error('Uncaught TypeError: Class constructor cannot be invoked without "new"');
     }

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -72,7 +72,7 @@ interface GoslingTrackOption {
  * @param args
  * @returns
  */
-function GoslingTrack(HGC: typeof import('@higlass/available-for-plugins'), ...args: any[]): any {
+function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
     if (!new.target) {
         throw new Error('Uncaught TypeError: Class constructor cannot be invoked without "new"');
     }

--- a/src/missing-types.d.ts
+++ b/src/missing-types.d.ts
@@ -120,9 +120,6 @@ declare module '@higlass/tracks' {
 
     type TrackOptions = Record<string, unknown>;
 
-    type Track = any;
-    export const BarTrack: Track;
-
     interface OnMouseMoveZoomOptions {
         trackId: string;
         data: number;

--- a/src/missing-types.d.ts
+++ b/src/missing-types.d.ts
@@ -99,7 +99,7 @@ declare module '@higlass/services' {
 }
 
 declare module '@higlass/tracks' {
-    // TODO(2022-06-28): type out `BarTrack`
+    // TODO(2022-06-28): type out `BarTrack
     type Track = any;
     export const BarTrack: Track;
 
@@ -123,6 +123,32 @@ declare module '@higlass/tracks' {
     type Track = any;
     export const BarTrack: Track;
 
+    interface OnMouseMoveZoomOptions {
+        trackId: string;
+        data: number;
+        absX: number;
+        absY: number;
+        relX: number;
+        relY: number;
+        dataX: number;
+        dataY: number;
+    }
+
+    interface OnMouseMoveZoomOptions1D extends OnMouseMoveZoomOptions {
+        orientation: '1d-horizontal' | '1d-vertical';
+    }
+
+    interface OnMouseMoveZoomOptions2D extends OnMouseMoveZoomOptions {
+        orientation: '2d';
+        dataLens: ArrayLike<number>;
+        dim: number;
+        toRgb: [number, number, number, number];
+        center: [number, number];
+        xRange: [number, number];
+        yRange: [number, number];
+        isGenomicCoords: boolean;
+    }
+
     export type Context<Options> = {
         id: string;
         viewUid: string;
@@ -137,8 +163,7 @@ declare module '@higlass/tracks' {
         isValueScaleLocked(): boolean;
         onValueScaleChanged(): void;
         onTrackOptionsChanged(newOptions: Options): void;
-        // TODO: not sure what the props are here
-        onMouseMoveZoom(props: unknown): void;
+        onMouseMoveZoom(opts: OnMouseMoveZoomOptions1D | OnMouseMoveZoomOptions2D): void;
         chromInfoPath: string;
         isShowGlobalMousePosition(): boolean;
         getTheme(): string;

--- a/src/missing-types.d.ts
+++ b/src/missing-types.d.ts
@@ -99,6 +99,7 @@ declare module '@higlass/services' {
 }
 
 declare module '@higlass/tracks' {
+    // TODO(2022-06-28): type out `BarTrack`
     type Track = any;
     export const BarTrack: Track;
 

--- a/src/missing-types.d.ts
+++ b/src/missing-types.d.ts
@@ -98,8 +98,10 @@ declare module '@higlass/services' {
     };
 }
 
-// TODO(06-21-22)
 declare module '@higlass/tracks' {
+    type Track = any;
+    export const BarTrack: Track;
+
     import type { ScaleContinuousNumeric } from 'd3-scale';
     import type * as PIXI from 'pixi.js';
 
@@ -118,7 +120,6 @@ declare module '@higlass/tracks' {
     type TrackOptions = Record<string, unknown>;
 
     type Track = any;
-    export const PixiTrack: Track;
     export const BarTrack: Track;
 
     export type Context<Options> = {
@@ -194,7 +195,7 @@ declare module '@higlass/tracks' {
     type DataFetcher = Record<string, any>;
     type TilesetInfo = Record<string, any>;
 
-    export class _PixiTrack<Options extends TrackOptions> extends _Track {
+    export class PixiTrack<Options extends TrackOptions> extends _Track {
         /* Properties */
         delayDrawing: boolean;
         scene: PIXI.Graphics;
@@ -274,7 +275,7 @@ declare module '@higlass/tracks' {
         defaultOptions?: Options;
         availableOptions?: (keyof Options)[];
         name?: string;
-        datatype?: LiteralUnion<DataType>[];
+        datatype?: readonly LiteralUnion<DataType>[];
         aliases?: string[];
         local?: boolean;
         orientation?: Orientation;
@@ -306,7 +307,7 @@ declare module '@higlass/utils' {
         chrInfo: ChromInfo<string>
     ): [chr: string, chrPositon: number, offset: number, insertPoint: number];
     export function chrToAbs<Name>(chrom: Name, chromPos: number, chromInfo: ChromInfo<Name>): number;
-    export function colorToHex(colorValue: string): number;
+    export function colorToHex(colorValue: string | number): number;
     export function pixiTextToSvg(text: import('pixi.js').Text): HTMLElement;
     export function svgLine(
         x1: number,


### PR DESCRIPTION
This PR:

- Replaces `typeof import('@higlass/avaiable-for-plugins')` with `import('@higlass/types').HGC`
- Add types for `HGC.tracks.PixiTrack` and `HGC.tracks.Track`
- Adds `definePluginTrack` utility

```typescript
export default definePluginTrack({
  type: "my-track",
  defaultOptions: {
     foo: "bar",
  }
}, (HGC, context, options) => {
  
  HGC // { libraries: ..., tracks: ..., ... }

  context // { id: string, ... } from https://github.com/higlass/higlass/blob/0b2cac5a770db6d55370a61d5dbbe09c4f577c68/app/scripts/TrackRenderer.js#L1507-L1536

  options // inferred from `defaultOptions` above
  options.foo // string
  
  class MyTrack extends HGC.tracks.PixiTrack { /* ... */ };

  return new MyTrack();
})
```