### PR TITLE
fix: fix error when using latest gosling.js by pinning generic-filehandle

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
         "vitest": "^0.10.0"
     },
     "resolutions": {
-        "slugid": "^3.0.0"
+        "slugid": "^3.0.0",
+        "generic-filehandle": "2.2.1"
     },
     "browserslist": {
         "production": [

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "d3-scale-chromatic": "^2.0.0",
         "d3-shape": "^2.0.0",
         "fflate": "^0.7.1",
-        "generic-filehandle": "^2.2.1",
+        "generic-filehandle": "2.2.1",
         "gosling-theme": "^0.0.10",
         "higlass": "^1.11.8",
         "higlass-register": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4070,6 +4070,15 @@ genbank-parser@^1.0.0:
   resolved "https://registry.yarnpkg.com/genbank-parser/-/genbank-parser-1.2.4.tgz#ee2f9c32f66875024af0c09ee0ec5e10fb231802"
   integrity sha512-r3pTgKHZx/rol90v2cezrNhfMhq3yHWCnBYyETNIJkvnJk+cwx/D/ZVgAy1SX8zwtnfvYQmFbqlpbh2f4t0h2w==
 
+generic-filehandle@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-2.2.1.tgz#395ecf5e44113ec33472df86e1c0a4f64fbb1012"
+  integrity sha512-aI1uusDj0zrAvz8t7DfWKn2hjWEZBXhqW063MJB8gsvgCt8LOBJkuNOPXhWik237NMqI2m/ffQ4oKbaO+32vqg==
+  dependencies:
+    "@babel/runtime" "^7.9.6"
+    es6-promisify "^6.1.1"
+    file-uri-to-path "^2.0.0"
+
 generic-filehandle@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-2.2.0.tgz#d3d17f0ee5d6813e6bcb60396be28802a7158d1f"
@@ -4084,15 +4093,6 @@ generic-filehandle@^2.0.1:
   resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-2.2.2.tgz#6493f4e8c0f9fc26d4086fbfa5d51879d0046f40"
   integrity sha512-/YRwruMy53YNTNISJa7YWYVCKqSUzx1v+17xi/bYFX9TjBKNm4otuXZ8eXXeaf4S48ncufU8ihmsvHoi0RzJHA==
   dependencies:
-    es6-promisify "^6.1.1"
-    file-uri-to-path "^2.0.0"
-
-generic-filehandle@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-2.2.1.tgz#395ecf5e44113ec33472df86e1c0a4f64fbb1012"
-  integrity sha512-aI1uusDj0zrAvz8t7DfWKn2hjWEZBXhqW063MJB8gsvgCt8LOBJkuNOPXhWik237NMqI2m/ffQ4oKbaO+32vqg==
-  dependencies:
-    "@babel/runtime" "^7.9.6"
     es6-promisify "^6.1.1"
     file-uri-to-path "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4070,29 +4070,12 @@ genbank-parser@^1.0.0:
   resolved "https://registry.yarnpkg.com/genbank-parser/-/genbank-parser-1.2.4.tgz#ee2f9c32f66875024af0c09ee0ec5e10fb231802"
   integrity sha512-r3pTgKHZx/rol90v2cezrNhfMhq3yHWCnBYyETNIJkvnJk+cwx/D/ZVgAy1SX8zwtnfvYQmFbqlpbh2f4t0h2w==
 
-generic-filehandle@2.2.1:
+generic-filehandle@2.2.1, generic-filehandle@^2.0.0, generic-filehandle@^2.0.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-2.2.1.tgz#395ecf5e44113ec33472df86e1c0a4f64fbb1012"
   integrity sha512-aI1uusDj0zrAvz8t7DfWKn2hjWEZBXhqW063MJB8gsvgCt8LOBJkuNOPXhWik237NMqI2m/ffQ4oKbaO+32vqg==
   dependencies:
     "@babel/runtime" "^7.9.6"
-    es6-promisify "^6.1.1"
-    file-uri-to-path "^2.0.0"
-
-generic-filehandle@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-2.2.0.tgz#d3d17f0ee5d6813e6bcb60396be28802a7158d1f"
-  integrity sha512-cFmLs1ptKALiBs2ExsobnjQ8Y9x/YbiRmynhYiB87Xyrpuk3HV4uR+EpwBiUKS/1C6TXjR+GkWxL58PP1C2hKA==
-  dependencies:
-    "@babel/runtime" "^7.9.6"
-    es6-promisify "^6.1.1"
-    file-uri-to-path "^2.0.0"
-
-generic-filehandle@^2.0.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/generic-filehandle/-/generic-filehandle-2.2.2.tgz#6493f4e8c0f9fc26d4086fbfa5d51879d0046f40"
-  integrity sha512-/YRwruMy53YNTNISJa7YWYVCKqSUzx1v+17xi/bYFX9TjBKNm4otuXZ8eXXeaf4S48ncufU8ihmsvHoi0RzJHA==
-  dependencies:
     es6-promisify "^6.1.1"
     file-uri-to-path "^2.0.0"
 


### PR DESCRIPTION
Towards #735 

(@manzt unsure if this is related to the Google Colab issue with BAM/BigWig files)

## Change List
 - pin generic-filehandle to `v2.2.1`

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
