### PR TITLE
chore: remove use of Node.js `Buffer` in favor of `TextEncoder`/`TextDecoder`

### DIFF
--- a/src/data-fetcher/bam/bam-worker.js
+++ b/src/data-fetcher/bam/bam-worker.js
@@ -582,7 +582,7 @@ const getTabularData = (uid, tileIds) => {
         output = findJunctions(uid, output);
     }
 
-    const buffer = Buffer.from(JSON.stringify(output)).buffer;
+    const buffer = new TextEncoder().encode(JSON.stringify(output)).buffer;
     return Transfer(buffer, [buffer]);
 };
 

--- a/src/data-fetcher/vcf/vcf-worker.js
+++ b/src/data-fetcher/vcf/vcf-worker.js
@@ -328,7 +328,7 @@ const getTabularData = (uid, tileIds) => {
         output = sampleSize(output, sampleLength / 2.0).concat(highPriority);
     }
 
-    const buffer = Buffer.from(JSON.stringify(output)).buffer;
+    const buffer = new TextEncoder().encode(JSON.stringify(output)).buffer;
     return Transfer(buffer, [buffer]);
 };
 

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -464,7 +464,7 @@ function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
                         this.drawLoadingCue();
                         const tiles = this.visibleAndFetchedTiles();
 
-                        const tabularData = JSON.parse(Buffer.from(toRender).toString());
+                        const tabularData = JSON.parse(new TextDecoder().decode(toRender));
                         if (tiles?.[0]) {
                             const tile = tiles[0];
                             tile.tileData.tabularData = tabularData;


### PR DESCRIPTION
In the same vein as https://github.com/gosling-lang/gosling.js/pull/714#issuecomment-1146488723, this PR removes the use of `Buffer` from our source code.

We still need to patch `Buffer` in some of our modules (since it is used by `@gmod/*` modules liberally), but the usage I found in our codebase is extremely minimal and can easily be substituted with standard WebAPIs that don't require a polyfill. Also, the folks working on GMOD have suggested that they'd like to move away from `Buffer` as well, so hopefully that is something to come (as it will greatly simplify bundling Gosling).
