### PR TITLE
fix: override RemoteFile.read to be more flexible

### DIFF
--- a/src/data-fetcher/bam/bam-worker.ts
+++ b/src/data-fetcher/bam/bam-worker.ts
@@ -6,7 +6,7 @@ import QuickLRU from 'quick-lru';
 import type { ChromInfo, TilesetInfo } from '@higlass/types';
 import type { BamRecord } from '@gmod/bam';
 
-import { fetchChromInfo } from '../utils';
+import { fetchChromInfo, RemoteFile } from '../utils';
 
 function parseMD(mdString: string, useCounts: true): { type: string; length: number }[];
 function parseMD(mdString: string, useCounts: false): { pos: number; base: string; length: 1; bamSeqShift: number }[];
@@ -349,10 +349,10 @@ const init = (
     if (!bamFiles[bamUrl]) {
         // we do not yet have this file cached
         bamFiles[bamUrl] = new BamFile({
-            bamUrl,
-            baiUrl
-            // fetchSizeLimit: 500000000,
-            // chunkSizeLimit: 100000000 ,
+            bamFilehandle: new RemoteFile(bamUrl),
+            baiFilehandle: new RemoteFile(baiUrl),
+            // fetchSizeLimit: 500000000, 
+            // chunkSizeLimit: 100000000 , 
             // yieldThreadTime: 1000
         });
 

--- a/src/data-fetcher/bigwig/higlass-bigwig-datafetcher.ts
+++ b/src/data-fetcher/bigwig/higlass-bigwig-datafetcher.ts
@@ -4,8 +4,8 @@
  */
 import { BigWig } from '@gmod/bbi';
 import type { Assembly } from '@gosling.schema';
-import { RemoteFile } from 'generic-filehandle';
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
+import { RemoteFile } from '../utils';
 
 import type { Feature } from '@gmod/bbi';
 import type { ChromInfo, TilesetInfo } from '@higlass/types';

--- a/src/data-fetcher/vcf/vcf-worker.ts
+++ b/src/data-fetcher/vcf/vcf-worker.ts
@@ -5,10 +5,9 @@
 import VCF from '@gmod/vcf';
 import { TabixIndexedFile } from '@gmod/tabix';
 import { expose, Transfer } from 'threads/worker';
-import { RemoteFile } from 'generic-filehandle';
 import { sampleSize } from 'lodash-es';
 
-import { fetchChromInfo } from '../utils';
+import { fetchChromInfo, RemoteFile } from '../utils';
 
 import type { TilesetInfo } from '@higlass/types';
 import type { ExtendedChromInfo } from '../utils';


### PR DESCRIPTION
Client-side loading of `bigwig`/`bam`/`vcf` is currently block when using the local data-server in Gos _within_ **Google Colab**. However, CSV and other data sources are supported. What gives? Spoiler: Partial content & 200 vs 206 HTTP status codes.

The issue is related to how HTTP requests are proxied by Google Colab. Colab aims to be _very_ flexible by allowing the client-side JavaScript to make requests to `localhost` on the remote machine. Normally a request to `http://localhost:{port}` from the browser would ping the users local machine, but Colab proxies these requests to forward to the _remote machine_. 

After some digging, I discovered that this proxing is accomplished via a custom [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) client-side, that redirects all `fetch` requests with appropriate auth (pretty cool). Unfortunately, it seems that this proxing overrides the HTTP response header from a 206 to a 200 even if the content is actually partial (via `content-size` header). This subtly causes `generic-filehandle` to throw an error in `RemoteFile.read`

https://github.com/GMOD/generic-filehandle/blob/0e8209be25e3097307bd15e964edd8c017e808d7/src/remoteFile.ts#L134-L158

This PR overrides the `read` method to be more flexible and just read the content of any 200 or 206 response, which should solve this weird bug with Colab. I guess we could add an additional check which asserts that the `content-size` is what is expected if we asked for partial content but received a 200, but this was the most simple fix.

cc: @cmdcolin