### PR TITLE
refactor(data-fetchers): scope worker imports to data-fetchers

### DIFF
--- a/src/data-fetcher/bam/bam-datafetcher.ts
+++ b/src/data-fetcher/bam/bam-datafetcher.ts
@@ -7,7 +7,15 @@ import Worker from './bam-worker.ts?worker&inline';
 
 import type { Assembly } from '../../core/gosling.schema';
 import type { ModuleThread } from 'threads';
-import type { WorkerApi, TilesetInfo, Tiles, DataConfig as WorkerDataConfig } from './bam-worker';
+import type {
+    WorkerApi,
+    TilesetInfo,
+    Tiles,
+    DataConfig as WorkerDataConfig,
+    Segment,
+    SegmentWithMate,
+    Junction
+} from './bam-worker';
 
 const DEBOUNCE_TIME = 200;
 
@@ -83,7 +91,7 @@ class BAMDataFetcher {
         (await this.worker).fetchTilesDebounced(this.uid, tileIds).then(receivedTiles);
     }
 
-    async getTabularData(uid: string, tileIds: string[]): Promise<any[]> {
+    async getTabularData(uid: string, tileIds: string[]): Promise<Segment[] | SegmentWithMate[] | Junction[]> {
         const buf = await (await this.worker).getTabularData(uid, tileIds);
         return JSON.parse(new TextDecoder().decode(buf));
     }

--- a/src/data-fetcher/bam/bam-worker.ts
+++ b/src/data-fetcher/bam/bam-worker.ts
@@ -430,7 +430,7 @@ const init = (
         // cache by bamUrl
         chromSizes[chromSizesUrl] = new Promise(resolve => {
             ChromosomeInfo(chromSizesUrl, resolve);
-        }); 
+        });
     }
 
     dataConfs[uid] = { bamUrl, chromSizesUrl, loadMates, maxInsertSize, extractJunction, junctionMinCoverage };
@@ -483,7 +483,7 @@ const tilesetInfo = (uid: string) => {
 
 const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]> => {
     const MAX_TILE_WIDTH = 200000;
-    const { bamUrl, chromSizesUrl, loadMates } = dataConfs[uid];
+    const { bamUrl, loadMates } = dataConfs[uid];
     const bamFile = bamFiles[bamUrl];
 
     const info = await tilesetInfo(uid);

--- a/src/data-fetcher/bam/bam-worker.ts
+++ b/src/data-fetcher/bam/bam-worker.ts
@@ -63,7 +63,7 @@ type Substitution = {
     variant?: string;
 };
 
-type Segment = {
+export type Segment = {
     // if two segments have the same name but different id, they are paired reads.
     // https://github.com/GMOD/bam-js/blob/7a57d24b6aef08a1366cca86ba5092254c7a7f56/src/bamFile.ts#L386
     id: string;
@@ -585,7 +585,7 @@ const groupBy = <T, K extends keyof T>(xs: readonly T[], key: K): Record<string,
         return rv;
     }, {});
 
-type SegmentWithMate = Segment & {
+export type SegmentWithMate = Segment & {
     mateIds: string[];
     foundMate: boolean;
     insertSize: number;
@@ -594,10 +594,6 @@ type SegmentWithMate = Segment & {
     numMates: number;
 };
 
-/**
- * @param {string} uid data config UID
- * @param {Segment[]} segments
- */
 const findMates = (segments: Segment[], maxInsertSize = 0) => {
     // @ts-expect-error This methods mutates this above aob
     const segmentsByReadName: Record<string, SegmentWithMate[]> = groupBy(segments, 'name');
@@ -652,7 +648,7 @@ const findMates = (segments: Segment[], maxInsertSize = 0) => {
     return segmentsByReadName;
 };
 
-type Junction = { start: number; end: number; score: number };
+export type Junction = { start: number; end: number; score: number };
 
 const findJunctions = (segments: { start: number; end: number; substitutions: string }[], minCoverage = 0) => {
     const junctions: Junction[] = [];

--- a/src/data-fetcher/vcf/gosling-vcf-data.ts
+++ b/src/data-fetcher/vcf/gosling-vcf-data.ts
@@ -2,6 +2,9 @@
  * This document is heavily based on the following repo by @alexander-veit:
  * https://github.com/dbmi-bgm/higlass-sv/blob/main/src/sv-fetcher.js
  */
+import { spawn } from 'threads';
+import Worker from './vcf-worker.ts?worker&inline';
+
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 
 import type { ModuleThread } from 'threads';
@@ -13,21 +16,22 @@ const DEBOUNCE_TIME = 200;
 type VcfDataConfig = VCFData & { assembly: Assembly };
 
 class GoslingVcfData {
-    private uid: string;
+    uid: string;
+    worker: Promise<ModuleThread<WorkerApi>>
+    prevRequestTime: number;
+    initPromise: Promise<unknown>;
+    track?: any;
+
     private assembly: Assembly;
     private toFetch: Set<string>;
     private fetchTimeout?: ReturnType<typeof setTimeout>;
-    private track: any;
-
-    prevRequestTime: number;
-    initPromise: Promise<unknown>;
 
     constructor(
         HGC: import('@higlass/types').HGC,
         public dataConfig: VcfDataConfig,
-        public worker: Promise<ModuleThread<WorkerApi>>
     ) {
         this.uid = HGC.libraries.slugid.nice();
+        this.worker = spawn(new Worker);
         this.prevRequestTime = 0;
         this.assembly = dataConfig.assembly;
         this.toFetch = new Set();
@@ -80,6 +84,11 @@ class GoslingVcfData {
 
     async sendFetch(receivedTiles: (tiles: Record<string, Tile>) => void, tileIds: string[]) {
         (await this.worker).fetchTilesDebounced(this.uid, tileIds).then(receivedTiles);
+    }
+
+    async getTabularData(uid: string, tileIds: string[]): Promise<any[]> {
+        const buf = await (await this.worker).getTabularData(uid, tileIds);
+        return JSON.parse(new TextDecoder().decode(buf));
     }
 }
 

--- a/src/data-fetcher/vcf/gosling-vcf-data.ts
+++ b/src/data-fetcher/vcf/gosling-vcf-data.ts
@@ -35,8 +35,8 @@ class GoslingVcfData {
         this.prevRequestTime = 0;
         this.assembly = dataConfig.assembly;
         this.toFetch = new Set();
-        this.initPromise = this.worker.then((tileFunctions: any) => {
-            return tileFunctions
+        this.initPromise = this.worker.then(api => {
+            return api
                 .init(
                     this.uid,
                     dataConfig.url,
@@ -70,7 +70,7 @@ class GoslingVcfData {
 
         this.track.drawLoadingCue();
 
-        tileIds.forEach((tileId: any) => this.toFetch.add(tileId));
+        tileIds.forEach((tileId) => this.toFetch.add(tileId));
 
         if (this.fetchTimeout) {
             clearTimeout(this.fetchTimeout);
@@ -86,7 +86,7 @@ class GoslingVcfData {
         (await this.worker).fetchTilesDebounced(this.uid, tileIds).then(receivedTiles);
     }
 
-    async getTabularData(uid: string, tileIds: string[]): Promise<any[]> {
+    async getTabularData(uid: string, tileIds: string[]): Promise<Tile[]> {
         const buf = await (await this.worker).getTabularData(uid, tileIds);
         return JSON.parse(new TextDecoder().decode(buf));
     }


### PR DESCRIPTION
The instantiation & use of the BAM or VCF data-fetcher `Worker` directly in `gosling-track.ts` is somewhat of a leaky abstraction. Ideally the data-fetcher alone provides a unified API for fetching data, rather than a mix of `worker` and `dataFetcher`. 

This PR refactors the BAM and VCF data-fetchers to:

1.) Instantiate their own workers (within the constructor).
2.) Hide the use of a web `Worker` behind the public data fetcher API. Instead an async `getTabularData` method is added (which can be called by `GoslingTrack`) and internally calls out to the worker.

This refactor provides a more consistent data fetching interface, and allows for `getTabularData` to be implemented in other data-fetchers without requiring the use of `threads` module and a web worker.

Perhaps this makes the most sense to review/merge after #739, #740, #741.
