### PR TITLE
refactor(utils): remove use of `any` in array utils

### DIFF
--- a/src/core/utils/array.ts
+++ b/src/core/utils/array.ts
@@ -1,7 +1,7 @@
 /**
  * Repeat elements in the array until its size becomes to `targetLength`.
  */
-export function arrayRepeat(base: Array<any>, targetLength: number) {
+export function arrayRepeat<T>(base: T[], targetLength: number): T[] {
     if (base.length === targetLength) return base;
     else if (base.length > targetLength) return base.slice(0, targetLength);
     else {
@@ -20,8 +20,7 @@ export function arrayRepeat(base: Array<any>, targetLength: number) {
  * @prop {any} item Item to be inserted.
  * @returns Updated array.
  */
-export function insertItemToArray(array: any[], index: number, item: any) {
-    if (!array) array = [];
+export function insertItemToArray<T>(array: T[], index: number, item: T): T[] {
     return [...array.slice(0, index), item, ...array.slice(index)];
 }
 
@@ -32,7 +31,7 @@ export function insertItemToArray(array: any[], index: number, item: any) {
  * @prop {any} item Item to be inserted.
  * @returns Updated array.
  */
-export function modifyItemInArray(array: any[], index: number, item: any) {
+export function modifyItemInArray<T>(array: T[], index: number, item: T): T[] {
     return [...array.slice(0, index), item, ...array.slice(index + 1)];
 }
 
@@ -42,7 +41,7 @@ export function modifyItemInArray(array: any[], index: number, item: any) {
  * @prop {number} index Index of an item to be removed.
  * @returns Updated array.
  */
-export function removeItemFromArray(array: any[], index: number) {
+export function removeItemFromArray<T>(array: T[], index: number): T[] {
     return [...array.slice(0, index), ...array.slice(index + 1)];
 }
 
@@ -51,10 +50,10 @@ export function removeItemFromArray(array: any[], index: number) {
  * @prop {array} array Array to be used.
  * @returns Updated array.
  */
-export const flatArrayToPairArray: (array: number[]) => [number, number][] = array => {
-    const output: [number, number][] = [];
+export function flatArrayToPairArray<T>(array: T[]): [T, T][] {
+    const output: [T, T][] = [];
     for (let i = 0; i < array.length; i += 2) {
         output.push([array[i], array[i + 1]]);
     }
     return output;
-};
+}

--- a/src/core/utils/array.ts
+++ b/src/core/utils/array.ts
@@ -15,9 +15,9 @@ export function arrayRepeat<T>(base: T[], targetLength: number): T[] {
 
 /**
  * Insert item to an array and return it.
- * @prop {array} array Array to be updated.
- * @prop {number} index Index of array to insert new item.
- * @prop {any} item Item to be inserted.
+ * @param array Array to be updated.
+ * @param index Index of array to insert new item.
+ * @param item Item to be inserted.
  * @returns Updated array.
  */
 export function insertItemToArray<T>(array: T[], index: number, item: T): T[] {
@@ -26,9 +26,9 @@ export function insertItemToArray<T>(array: T[], index: number, item: T): T[] {
 
 /**
  * Insert item to an array and return it.
- * @prop {array} array Array to be updated.
- * @prop {number} index Index of array to change item.
- * @prop {any} item Item to be inserted.
+ * @param array Array to be updated.
+ * @param index Index of array to change item.
+ * @param item Item to be inserted.
  * @returns Updated array.
  */
 export function modifyItemInArray<T>(array: T[], index: number, item: T): T[] {
@@ -37,8 +37,8 @@ export function modifyItemInArray<T>(array: T[], index: number, item: T): T[] {
 
 /**
  * Remove item from an array stored in a certain index.
- * @prop {array} array Array to be updated.
- * @prop {number} index Index of an item to be removed.
+ * @param array Array to be updated.
+ * @param index Index of an item to be removed.
  * @returns Updated array.
  */
 export function removeItemFromArray<T>(array: T[], index: number): T[] {
@@ -47,7 +47,7 @@ export function removeItemFromArray<T>(array: T[], index: number): T[] {
 
 /**
  * Convert 1D array into 2D array where each pair of elements are grouped.
- * @prop {array} array Array to be used.
+ * @param array Array to be used.
  * @returns Updated array.
  */
 export function flatArrayToPairArray<T>(array: T[]): [T, T][] {


### PR DESCRIPTION
Preserves array item type information in array utils and removes use of `any`.
