### PR TITLE
fix: include type definitions in the bundle; do not bundle types for editor codes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
         node: true
     },
     parserOptions: {
-        project: 'tsconfig.editor.json',
+        project: 'tsconfig.json',
         ecmaVersion: 6,
         sourceType: 'module'
     },

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "scripts": {
         "start": "vite --mode editor",
         "start-embed": "vite",
-        "build": "run-p build-types build-lib",
+        "build": "run-s build-clear build-types build-lib",
         "build-lib": "vite build --mode lib && node scripts/build-umd && node scripts/build-embed",
-        "build-types": "tsc --emitDeclarationOnly",
+        "build-types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build-editor": "node --max_old_space_size=4096 ./node_modules/vite/bin/vite.js build",
+        "build-clear": "rm -rf ./dist",
         "preview": "vite preview",
         "check": "tsc --noEmit",
         "test": "vitest",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "files": [
+        "src/index.ts",
+        "embed/index.ts"
+    ],
+    "exclude": ["**/*.test.ts"]
+}

--- a/tsconfig.editor.json
+++ b/tsconfig.editor.json
@@ -1,7 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "include": [
-        "src",
-        "editor"
-    ]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,7 @@
     "editor/index.tsx",
     "embed/index.ts"
   ],
-  "include": ["src", "src/**/*.d.ts"],
+  "include": ["src", "src/**/*.d.ts", "editor"],
   "exclude": [
     "node_modules",
     "public",

--- a/vite.config.js
+++ b/vite.config.js
@@ -68,6 +68,7 @@ const external = [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDepen
 
 const esm = defineConfig({
     build: {
+        emptyOutDir: false,
         outDir: 'dist',
         minify: false,
         target: 'es2018',


### PR DESCRIPTION
Fix #735 

- Correctly bundle type definitions
- Do not bundle types for `\editor` (which was bundled previously)

I basically turned off the default behavior of Vite that made a `dist` folder empty before bundling (https://vitejs.dev/config/#build-emptyoutdir), which led to removing already created type definitions.

You can now find the `src` folder that contains types after running `yarn build`:

<img width="300" alt="Screen Shot 2022-07-03 at 17 28 21" src="https://user-images.githubusercontent.com/9922882/177058137-3df1df89-9e94-4b6d-9af3-1a8f17bc9c36.png">