### PR TITLE
docs: add description for some properties

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -5696,6 +5696,7 @@
           "type": "string"
         },
         "threshold": {
+          "description": "Threshold in the unit of pixels.",
           "type": "number"
         }
       },
@@ -8719,16 +8720,20 @@
       "additionalProperties": false,
       "properties": {
         "alt": {
+          "description": "Name of the data field for showing in the tooltip. Will use the field name if not specified.",
           "type": "string"
         },
         "field": {
+          "description": "Specifiy a data field whose value will show in the tooltip.",
           "type": "string"
         },
         "format": {
+          "description": "format of the data value.",
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/FieldType"
+          "$ref": "#/definitions/FieldType",
+          "description": "Type of the data filed."
         }
       },
       "required": [

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -899,6 +899,7 @@
     },
     "EventStyle": {
       "additionalProperties": false,
+      "description": "The styles defined here will be applied to the targets of mouse events, such as a point mark after user click mouse.",
       "properties": {
         "arrange": {
           "description": "Show event effects behind or in front of marks.",
@@ -909,18 +910,22 @@
           "type": "string"
         },
         "color": {
+          "description": "color of the marks when mouse events are triggered",
           "type": "string"
         },
         "opacity": {
+          "description": "opacity of the marks when mouse events are triggered",
           "type": "number"
         },
         "stroke": {
+          "description": "stroke color of the marks when mouse events are triggered",
           "type": "string"
         },
         "strokeOpacity": {
           "type": "number"
         },
         "strokeWidth": {
+          "description": "stroke width of the marks when mouse events are triggered",
           "type": "number"
         }
       },
@@ -3581,9 +3586,11 @@
           "type": "boolean"
         },
         "enableMouseOverOnMultipleMarks": {
+          "description": "Determine whether all marks underneath the mouse point should be affected by mouse over. __Default__: `false`",
           "type": "boolean"
         },
         "groupMarksByField": {
+          "description": "Group marks using keys in a data field. This affects how a set of marks are highlighted/selected by interaction. __Default__: `undefined`",
           "type": "string"
         },
         "mouseOver": {
@@ -8291,21 +8298,25 @@
         },
         "brush": {
           "additionalProperties": false,
-          "description": "Customize the style of range brushes.",
+          "description": "Customize the style of the brush mark in the `rangeSelect` mouse event.",
           "properties": {
             "color": {
+              "description": "color of the marks when mouse events are triggered",
               "type": "string"
             },
             "opacity": {
+              "description": "opacity of the marks when mouse events are triggered",
               "type": "number"
             },
             "stroke": {
+              "description": "stroke color of the marks when mouse events are triggered",
               "type": "string"
             },
             "strokeOpacity": {
               "type": "number"
             },
             "strokeWidth": {
+              "description": "stroke width of the marks when mouse events are triggered",
               "type": "number"
             }
           },
@@ -8410,7 +8421,7 @@
         },
         "mouseOver": {
           "$ref": "#/definitions/EventStyle",
-          "description": "Customize visual effects of mouse over events on marks."
+          "description": "Customize visual effects of `mouseOver` events on marks."
         },
         "outline": {
           "type": "string"
@@ -8420,7 +8431,7 @@
         },
         "select": {
           "$ref": "#/definitions/EventStyle",
-          "description": "Customize visual effects selection events on marks with range brushes."
+          "description": "Customize visual effects of `rangeSelect` events on marks ."
         },
         "textAnchor": {
           "description": "Specify the alignment of `text` marks to a given point.",

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -35,6 +35,7 @@ export type SelectivityCondition = {
      */
     target?: 'self' | 'container';
     measure: 'width' | 'height' | 'aspectRatio';
+    /** Threshold in the unit of pixels. */
     threshold: number;
 };
 
@@ -243,13 +244,13 @@ export interface GenomicPosition {
 }
 
 interface PointMouseEventData extends CommonEventData {
-    /* A genomic coordinate, e.g., `chr1:100,000`. */
+    /** A genomic coordinate, e.g., `chr1:100,000`. */
     genomicPosition: GenomicPosition;
 }
 
 interface RangeMouseEventData extends CommonEventData {
     // NOTE: We could include this type to `GenomicDomain`, i.e., enabling users to display genomic range across multiple chromosomes
-    /* Start and end genomic coordinates. Null if a range is deselected. */
+    /** Start and end genomic coordinates. Null if a range is deselected. */
     genomicRange: [GenomicPosition, GenomicPosition] | null;
 }
 
@@ -261,13 +262,13 @@ export type _EventMap = {
 };
 
 export type MouseEventsDeep = {
-    /* Turn on and off individual mouse events. */
+    /** Turn on and off individual mouse events. */
     [Event in keyof Omit<_EventMap, 'rawData'>]?: boolean;
 } & {
-    /* Group marks using keys in a data field. This affects how a set of marks are highlighted/selected by interaction. __Default__: `undefined` */
+    /** Group marks using keys in a data field. This affects how a set of marks are highlighted/selected by interaction. __Default__: `undefined` */
     groupMarksByField?: string;
 
-    /* Determine whether all marks underneath the mouse point should be affected by mouse over. __Default__: `false` */
+    /** Determine whether all marks underneath the mouse point should be affected by mouse over. __Default__: `false` */
     enableMouseOverOnMultipleMarks?: boolean;
 };
 
@@ -331,9 +332,13 @@ export interface Encoding {
 }
 
 export interface Tooltip {
+    /** Specifiy a data field whose value will show in the tooltip. */
     field: string;
+    /** Type of the data filed. */
     type: FieldType;
+    /** Name of the data field for showing in the tooltip. Will use the field name if not specified. */
     alt?: string;
+    /** format of the data value. */
     format?: string;
 }
 
@@ -359,14 +364,18 @@ export type OverlaidTrack = Partial<SingleTrack> &
         overlay: Partial<Omit<SingleTrack, 'height' | 'width' | 'layout' | 'title' | 'subtitle'>>[];
     };
 
-/*
- * The styles of the effects of mouse events, such as mouse over on marks.
+/**
+ * The styles defined here will be applied to the targets of mouse events, such as a point mark after user click mouse.
  */
 export interface EventStyle {
+    /** color of the marks when mouse events are triggered */
     color?: string;
+    /** stroke color of the marks when mouse events are triggered */
     stroke?: string;
+    /** stroke width of the marks when mouse events are triggered */
     strokeWidth?: number;
     strokeOpacity?: number;
+    /** opacity of the marks when mouse events are triggered */
     opacity?: number;
 
     /** Show event effects behind or in front of marks. */
@@ -469,17 +478,17 @@ export interface Style {
     matrixExtent?: 'full' | 'upper-right' | 'lower-left';
 
     /**
-     * Customize visual effects of mouse over events on marks.
+     * Customize visual effects of `mouseOver` events on marks.
      */
     mouseOver?: EventStyle;
 
     /**
-     * Customize visual effects selection events on marks with range brushes.
+     * Customize visual effects of `rangeSelect` events on marks .
      */
     select?: EventStyle;
 
     /**
-     * Customize the style of range brushes.
+     * Customize the style of the brush mark in the `rangeSelect` mouse event.
      */
     brush?: Omit<EventStyle, 'arrange'>;
 }

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -365,7 +365,7 @@ export type OverlaidTrack = Partial<SingleTrack> &
     };
 
 /**
- * The styles defined here will be applied to the targets of mouse events, such as a point mark after user click mouse.
+ * The styles defined here will be applied to the target marks of mouse events, such as a point mark after the user clicks on it.
  */
 export interface EventStyle {
     /** color of the marks when mouse events are triggered */


### PR DESCRIPTION
Fix #751 

## Change List
 - add descriptions for properties in EventStyle
 - add descriptions for properties in Tooltip
 - fix the descriptions for properties in MouseEvents by changing `/*   */` to `/** */`. The former one will not generate descriptions

