### PR TITLE
fix(data-fetchers): fix error when using `Buffer` in VCF worker

### DIFF
--- a/src/data-fetcher/vcf/vcf-worker.ts
+++ b/src/data-fetcher/vcf/vcf-worker.ts
@@ -300,7 +300,7 @@ const getTabularData = (uid: string, tileIds: string[]) => {
         output = sampleSize(output, sampleLength / 2.0).concat(highPriority);
     }
 
-    const buffer = Buffer.from(JSON.stringify(output)).buffer;
+    const buffer = new TextEncoder().encode(JSON.stringify(output)).buffer;
     return Transfer(buffer, [buffer]);
 };
 


### PR DESCRIPTION
Fix #755

Loading VCF files in the online editor is making errors (#755), and I think replacing `Buffer` with `new TextEncoder()` will address the issue. I think we already replaced it with TextEncoder (https://github.com/gosling-lang/gosling.js/pull/742) but somehow this was reverted.

## Change List
 - Replace Buffer with `new TextEncoder()` in the VCF worker

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
