### PR TITLE
feat: add entry point for using experimental plugin data fetchers

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -534,6 +534,9 @@
         },
         {
           "$ref": "#/definitions/VCFData"
+        },
+        {
+          "$ref": "#/definitions/PluginData"
         }
       ]
     },
@@ -5560,6 +5563,30 @@
           "$ref": "#/definitions/ZoomLimits"
         }
       },
+      "type": "object"
+    },
+    "PluginData": {
+      "additionalProperties": false,
+      "description": "A data spec to use plugin data fetcher that are defined externally",
+      "properties": {
+        "name": {
+          "description": "The name of the plugin data that should match the `type` of a plugin data fetcher",
+          "type": "string"
+        },
+        "options": {
+          "description": "All custom options used in the plugin data fetcher",
+          "type": "object"
+        },
+        "type": {
+          "const": "experimentalPlugin",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name",
+        "options"
+      ],
       "type": "object"
     },
     "PredefinedColors": {

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -109,24 +109,21 @@ export function goslingToHiGlass(
             }
         };
 
-        if (
-            firstResolvedSpec.data &&
-            IsDataDeep(firstResolvedSpec.data) &&
-            (firstResolvedSpec.data.type === 'csv' ||
-                firstResolvedSpec.data.type === 'json' ||
-                firstResolvedSpec.data.type === 'bigwig' ||
-                firstResolvedSpec.data.type === 'bam' ||
-                firstResolvedSpec.data.type === 'vcf')
-        ) {
-            // use gosling's custom data fetchers
-            hgTrack.data = {
-                ...firstResolvedSpec.data,
-                // Additionally, add assembly, otherwise, a default genome build is used
-                assembly
-                // TODO: should look all sub tracks' `dataTransform` and apply OR operation.
-                // Add a data transformation spec so that the fetcher can properly sample datasets
-                // filter: (firstResolvedSpec as any).dataTransform?.filter((f: DataTransform) => f.type === 'filter')
-            };
+        if (firstResolvedSpec.data && IsDataDeep(firstResolvedSpec.data)) {
+            const dataType = firstResolvedSpec.data.type;
+            if (
+                dataType === 'csv' ||
+                dataType === 'json' ||
+                dataType === 'bigwig' ||
+                dataType === 'bam' ||
+                dataType === 'vcf'
+            ) {
+                // This means, we are using custom data fetchers defined internally
+                hgTrack.data = { ...firstResolvedSpec.data, assembly };
+            } else if (dataType === 'experimentalPlugin') {
+                // This means, we are using external data fetchers that the user implemented
+                hgTrack.data = { ...firstResolvedSpec.data.options, type: firstResolvedSpec.data.name, assembly };
+            }
         }
 
         // We use higlass 'heatmap' track instead of 'gosling-track' for rendering performance.

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -118,10 +118,10 @@ export function goslingToHiGlass(
                 dataType === 'bam' ||
                 dataType === 'vcf'
             ) {
-                // This means, we are using custom data fetchers defined internally
+                // This means we use data fetchers that are implemented in Gosling
                 hgTrack.data = { ...firstResolvedSpec.data, assembly };
             } else if (dataType === 'experimentalPlugin') {
-                // This means, we are using external data fetchers that the user implemented
+                // This means we use an external data fetcher that a user implemented
                 hgTrack.data = { ...firstResolvedSpec.data.options, type: firstResolvedSpec.data.name, assembly };
             }
         }

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -759,7 +759,8 @@ export type DataDeep =
     | VectorData
     | MatrixData
     | BAMData
-    | VCFData;
+    | VCFData
+    | PluginData;
 
 /** Values in the form of JSON. */
 export interface Datum {
@@ -1056,6 +1057,18 @@ export interface MatrixData {
 
     /** Determine the number of nearby cells to aggregate. __Default__: `1` */
     binSize?: number;
+}
+
+/** A data spec to use plugin data fetcher that are defined externally */
+export interface PluginData {
+    // TODO (7-Jul-2022): change to 'plugin' for official support
+    type: 'experimentalPlugin';
+
+    /** The name of the plugin data that should match the `type` of a plugin data fetcher */
+    name: string;
+
+    /** All custom options used in the plugin data fetcher */
+    options: Record<string, any>;
 }
 
 /* ----------------------------- DATA TRANSFORM ----------------------------- */


### PR DESCRIPTION
The motivation for this PR is that we want to enable users to implement their own data fetchers and use that in the grammar. For example, my use case in a [Cistrome](http://cistrome.org/) project is to directly use a Cistrome API in a data fetcher to load their data. Since this is a quite specific use case, I would want to implement the data fetcher outside Gosling.

This PR basically adds a new type of data (`experimentalPlugin`) in the Gosling schema to enable using externally implemented data fetchers in Gosling.

```ts
export interface PluginData {
    type: 'experimentalPlugin';

    /** The name of the plugin data that should match the `type` of a plugin data fetcher */
    name: string; // ← this is used as a `data.type` in a compiled HiGlass track viewConfig

    /** All custom options exposed to a plugin data fetcher */
    options: Record<string, any>; // ← a data fetcher can use these options (e.g., `this.dataConfig.cid`)
}
```

Actual usage example:

```js
// register the custom data-fetcher
hgRegister(
  { dataFetcher: CistromeDataFetcher, config: CistromeDataFetcher.config },
  { pluginType: "dataFetcher" }
);

// use the plugin data
function App() {
  return (
    <GoslingComponent spec={{
      tracks: [{
        data: {
          type: 'experimentalPlugin',
          name: 'cistrome',
          options: { cid: 1 } // custom options used in the plugin data fetcher
        },
        ...
      }]
    }}/>
  );
}
```

Example repo: https://github.com/sehilyi/gosling-plugin-datafetcher-example/blob/master/src/App.js