### PR TITLE
fix: change worker path (`.js` →  `.ts`) to correctly inject the buffer shim

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,3 @@
 public
 build
 dist
-
-bam-worker.js

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,7 +35,7 @@ const bundleWebWorker = {
 const manualInlineWorker = {
     apply: 'build',
     async transform(code, id) {
-        if (id.endsWith('bam-worker.js?worker&inline') || id.endsWith('vcf-worker.js?worker&inline')) {
+        if (id.endsWith('bam-worker.ts?worker&inline') || id.endsWith('vcf-worker.ts?worker&inline')) {
             const bundle = await bundleWebWorker.transform(code, id + '?worker_file');
             const base64 = Buffer.from(bundle).toString('base64');
             // https://github.com/vitejs/vite/blob/72cb33e947e7aa72d27ed0c5eacb2457d523dfbf/packages/vite/src/node/plugins/worker.ts#L78-L87


### PR DESCRIPTION
Fix #762

Fixed the path to the workers (from `.js` to `.ts`) to inject the buffer shim for production.