### PR TITLE
chore: add no-warning-comments rule for `XXX`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
         'no-unused-vars': 'off', // must disable the base rule as it can report incorrect errors
+        // https://www.executeprogram.com/blog/the-code-is-the-to-do-list
         "no-warning-comments": ["error", { terms: ["xxx"], location: "anywhere" }],
         '@typescript-eslint/no-unused-vars': [
             'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
         'no-unused-vars': 'off', // must disable the base rule as it can report incorrect errors
+        "no-warning-comments": ["error", { terms: ["xxx"], location: "anywhere" }],
         '@typescript-eslint/no-unused-vars': [
             'error',
             {


### PR DESCRIPTION
Looks useful for managing to-dos.

https://www.executeprogram.com/blog/the-code-is-the-to-do-list (Thanks for sharing @manzt)
https://eslint.org/docs/latest/rules/no-warning-comments 