### PR TITLE
feat: make `column`, `position`, `row` properties optional for `bigwig`, `vector`, and `multivec`

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -195,15 +195,15 @@
           "type": "number"
         },
         "column": {
-          "description": "Assign a field name of the middle position of genomic intervals.",
+          "description": "Assign a field name of the middle position of genomic intervals. __Default__: `\"position\"`",
           "type": "string"
         },
         "end": {
-          "description": "Assign a field name of the end position of genomic intervals.",
+          "description": "Assign a field name of the end position of genomic intervals. __Default__: `\"end\"`",
           "type": "string"
         },
         "start": {
-          "description": "Assign a field name of the start position of genomic intervals.",
+          "description": "Assign a field name of the start position of genomic intervals. __Default__: `\"start\"`",
           "type": "string"
         },
         "type": {
@@ -215,7 +215,7 @@
           "type": "string"
         },
         "value": {
-          "description": "Assign a field name of quantitative values.",
+          "description": "Assign a field name of quantitative values. __Default__: `\"value\"`",
           "type": "string"
         }
       },
@@ -3736,19 +3736,19 @@
           "type": "array"
         },
         "column": {
-          "description": "Assign a field name of the middle position of genomic intervals.",
+          "description": "Assign a field name of the middle position of genomic intervals. __Default__: `\"position\"`",
           "type": "string"
         },
         "end": {
-          "description": "Assign a field name of the end position of genomic intervals.",
+          "description": "Assign a field name of the end position of genomic intervals. __Default__: `\"end\"`",
           "type": "string"
         },
         "row": {
-          "description": "Assign a field name of samples.",
+          "description": "Assign a field name of samples. __Default__: `\"category\"`",
           "type": "string"
         },
         "start": {
-          "description": "Assign a field name of the start position of genomic intervals.",
+          "description": "Assign a field name of the start position of genomic intervals. __Default__: `\"start\"`",
           "type": "string"
         },
         "type": {
@@ -3760,7 +3760,7 @@
           "type": "string"
         },
         "value": {
-          "description": "Assign a field name of quantitative values.",
+          "description": "Assign a field name of quantitative values. __Default__: `\"value\"`",
           "type": "string"
         }
       },
@@ -8811,15 +8811,15 @@
           "type": "number"
         },
         "column": {
-          "description": "Assign a field name of the middle position of genomic intervals.",
+          "description": "Assign a field name of the middle position of genomic intervals. __Default__: `\"position\"`",
           "type": "string"
         },
         "end": {
-          "description": "Assign a field name of the end position of genomic intervals.",
+          "description": "Assign a field name of the end position of genomic intervals. __Default__: `\"end\"`",
           "type": "string"
         },
         "start": {
-          "description": "Assign a field name of the start position of genomic intervals.",
+          "description": "Assign a field name of the start position of genomic intervals. __Default__: `\"start\"`",
           "type": "string"
         },
         "type": {
@@ -8831,7 +8831,7 @@
           "type": "string"
         },
         "value": {
-          "description": "Assign a field name of quantitative values.",
+          "description": "Assign a field name of quantitative values. __Default__: `\"position\"`",
           "type": "string"
         }
       },

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -8831,7 +8831,7 @@
           "type": "string"
         },
         "value": {
-          "description": "Assign a field name of quantitative values. __Default__: `\"position\"`",
+          "description": "Assign a field name of quantitative values. __Default__: `\"value\"`",
           "type": "string"
         }
       },

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -221,9 +221,7 @@
       },
       "required": [
         "type",
-        "url",
-        "column",
-        "value"
+        "url"
       ],
       "type": "object"
     },
@@ -3768,10 +3766,7 @@
       },
       "required": [
         "type",
-        "url",
-        "column",
-        "row",
-        "value"
+        "url"
       ],
       "type": "object"
     },
@@ -8842,9 +8837,7 @@
       },
       "required": [
         "type",
-        "url",
-        "column",
-        "value"
+        "url"
       ],
       "type": "object"
     },

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -873,17 +873,17 @@ export interface MultivecData {
     /**
      * Assign a field name of the middle position of genomic intervals.
      */
-    column: string;
+    column?: string;
 
     /**
      * Assign a field name of samples.
      */
-    row: string;
+    row?: string;
 
     /**
      * Assign a field name of quantitative values.
      */
-    value: string;
+    value?: string;
 
     /**
      *  assign names of individual samples.
@@ -920,12 +920,13 @@ export interface BIGWIGData {
     /**
      * Assign a field name of the middle position of genomic intervals.
      */
-    column: string;
+    column?: string;
 
     /**
      * Assign a field name of quantitative values.
      */
-    value: string;
+    value?: string;
+
     /**
      * Assign a field name of the start position of genomic intervals.
      */
@@ -958,10 +959,10 @@ export interface VectorData {
     url: string;
 
     /** Assign a field name of the middle position of genomic intervals. */
-    column: string;
+    column?: string;
 
     /** Assign a field name of quantitative values. */
-    value: string;
+    value?: string;
 
     /** Assign a field name of the start position of genomic intervals. */
     start?: string;

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -961,7 +961,7 @@ export interface VectorData {
     /** Assign a field name of the middle position of genomic intervals. __Default__: `"position"` */
     column?: string;
 
-    /** Assign a field name of quantitative values. __Default__: `"position"` */
+    /** Assign a field name of quantitative values. __Default__: `"value"` */
     value?: string;
 
     /** Assign a field name of the start position of genomic intervals. __Default__: `"start"` */

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -871,17 +871,17 @@ export interface MultivecData {
     url: string;
 
     /**
-     * Assign a field name of the middle position of genomic intervals.
+     * Assign a field name of the middle position of genomic intervals. __Default__: `"position"`
      */
     column?: string;
 
     /**
-     * Assign a field name of samples.
+     * Assign a field name of samples. __Default__: `"category"`
      */
     row?: string;
 
     /**
-     * Assign a field name of quantitative values.
+     * Assign a field name of quantitative values. __Default__: `"value"`
      */
     value?: string;
 
@@ -891,12 +891,12 @@ export interface MultivecData {
     categories?: string[];
 
     /**
-     * Assign a field name of the start position of genomic intervals.
+     * Assign a field name of the start position of genomic intervals. __Default__: `"start"`
      */
     start?: string;
 
     /**
-     * Assign a field name of the end position of genomic intervals.
+     * Assign a field name of the end position of genomic intervals. __Default__: `"end"`
      */
     end?: string;
 
@@ -918,22 +918,22 @@ export interface BIGWIGData {
     url: string;
 
     /**
-     * Assign a field name of the middle position of genomic intervals.
+     * Assign a field name of the middle position of genomic intervals. __Default__: `"position"`
      */
     column?: string;
 
     /**
-     * Assign a field name of quantitative values.
+     * Assign a field name of quantitative values. __Default__: `"value"`
      */
     value?: string;
 
     /**
-     * Assign a field name of the start position of genomic intervals.
+     * Assign a field name of the start position of genomic intervals. __Default__: `"start"`
      */
     start?: string;
 
     /**
-     * Assign a field name of the end position of genomic intervals.
+     * Assign a field name of the end position of genomic intervals. __Default__: `"end"`
      */
     end?: string;
 
@@ -958,16 +958,16 @@ export interface VectorData {
      */
     url: string;
 
-    /** Assign a field name of the middle position of genomic intervals. */
+    /** Assign a field name of the middle position of genomic intervals. __Default__: `"position"` */
     column?: string;
 
-    /** Assign a field name of quantitative values. */
+    /** Assign a field name of quantitative values. __Default__: `"position"` */
     value?: string;
 
-    /** Assign a field name of the start position of genomic intervals. */
+    /** Assign a field name of the start position of genomic intervals. __Default__: `"start"` */
     start?: string;
 
-    /** Assign a field name of the end position of genomic intervals. */
+    /** Assign a field name of the end position of genomic intervals. __Default__: `"end"` */
     end?: string;
 
     /** Binning the genomic interval in tiles (unit size: 256). */
@@ -983,6 +983,7 @@ export interface VectorData {
  */
 export interface BEDDBData {
     type: 'beddb';
+
     /** Specify the URL address of the data file. */
     url: string;
 

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -524,11 +524,16 @@ export function overrideDataTemplates(spec: GoslingSpec) {
         switch (t.data.type) {
             case 'vector':
             case 'bigwig':
-                ts[i] = Object.assign(getVectorTemplate(t.data.column, t.data.value), t);
+                ts[i] = Object.assign(getVectorTemplate(t.data.column ?? 'position', t.data.value ?? 'value'), t);
                 break;
             case 'multivec':
                 ts[i] = Object.assign(
-                    getMultivecTemplate(t.data.row, t.data.column, t.data.value, t.data.categories),
+                    getMultivecTemplate(
+                        t.data.row ?? 'category',
+                        t.data.column ?? 'position',
+                        t.data.value ?? 'value',
+                        t.data.categories
+                    ),
                     t
                 );
                 break;

--- a/src/gosling-track/data-abstraction.ts
+++ b/src/gosling-track/data-abstraction.ts
@@ -27,11 +27,6 @@ export function getTabularData(
     }
 
     if (spec.data.type === 'vector' || spec.data.type === 'bigwig') {
-        if (!spec.data.column || !spec.data.value) {
-            console.warn('Proper data configuration is not provided. Please specify the name of data fields.');
-            return;
-        }
-
         if (!data.dense) {
             // we did not get sufficient data.
             return;
@@ -43,8 +38,8 @@ export function getTabularData(
         const numOfGenomicPositions = data.tileSize;
         const tileUnitSize = data.tileWidth / data.tileSize;
 
-        const valueName = spec.data.value;
-        const columnName = spec.data.column;
+        const valueName = spec.data.value ?? 'value';
+        const columnName = spec.data.column ?? 'position';
         const startName = spec.data.start ?? 'start';
         const endName = spec.data.end ?? 'end';
 
@@ -111,11 +106,6 @@ export function getTabularData(
             }
         });
     } else if (spec.data.type === 'multivec') {
-        if (!spec.data.row || !spec.data.column || !spec.data.value) {
-            console.warn('Proper data configuration is not provided. Please specify the name of data fields.');
-            return;
-        }
-
         if (!data.dense || data.shape === undefined) {
             // we did not get sufficient data.
             return;
@@ -129,9 +119,9 @@ export function getTabularData(
         const numOfGenomicPositions = data.shape[1];
         const tileUnitSize = data.tileWidth / data.tileSize;
 
-        const rowName = spec.data.row;
-        const valueName = spec.data.value;
-        const columnName = spec.data.column;
+        const rowName = spec.data.row ?? 'category';
+        const valueName = spec.data.value ?? 'value';
+        const columnName = spec.data.column ?? 'position';
         const startName = spec.data.start ?? 'start';
         const endName = spec.data.end ?? 'end';
 


### PR DESCRIPTION
Fix #768 

```diff
// multivec
"data": {
  "url": "https://server.gosling-lang.org/api/v1/tileset_info/?d=cistrome-multivec",
  "type": "multivec",
-  "row": "category",
-  "column": "position",
-  "value": "value",
  "binSize": 4
},

// bigwig or vector
"data": {
  "url": "https://s3.amazonaws.com/gosling-lang.org/data/DopaNeurons_Cluster10_AllFrags_projSUNI2_insertions_bin100_RIPnorm.bw",
  "type": "bigwig",
-  "column": "position",
-  "value": "peak"
},
```