### PR TITLE
fix(data-fetchers): ignore `NaN`  values when filtering data

### DIFF
--- a/editor/example/json-spec/circos.ts
+++ b/editor/example/json-spec/circos.ts
@@ -127,7 +127,7 @@ export const EX_SPEC_CIRCOS: GoslingSpec = {
                     x: { field: 'p1', type: 'genomic' },
                     xe: { field: 'p1_2', type: 'genomic' },
                     x1: { field: 'p2', type: 'genomic' },
-                    x1e: { field: 'P2_2', type: 'genomic' },
+                    x1e: { field: 'p2_2', type: 'genomic' },
                     stroke: { value: 'lightgray' },
                     strokeWidth: { value: 1 }
                 },
@@ -137,7 +137,7 @@ export const EX_SPEC_CIRCOS: GoslingSpec = {
                     x: { field: 'p1', type: 'genomic' },
                     xe: { field: 'p1_2', type: 'genomic' },
                     x1: { field: 'p2', type: 'genomic' },
-                    x1e: { field: 'P2_2', type: 'genomic' },
+                    x1e: { field: 'p2_2', type: 'genomic' },
                     stroke: {
                         field: 'chr_2',
                         type: 'nominal',

--- a/src/data-fetchers/utils.ts
+++ b/src/data-fetchers/utils.ts
@@ -34,9 +34,9 @@ export function filterUsingGenoPos(
             return minX < value && value <= maxX;
         } else {
             // filter based on two genomic positions, i.e., check overlaps
-            const values = definedXFields.map(f => +d[f]);
-            const maxValue = Math.max(...values);
+            const values = definedXFields.map(f => +d[f]).filter(v => +v);
             const minValue = Math.min(...values);
+            const maxValue = Math.max(...values);
             return minX <= maxValue && minValue <= maxX;
         }
     });


### PR DESCRIPTION
Also, fix the Circos example by using the correct field names `P_2` → `p_2`