### PR TITLE
fix: use consistent letter case for data types (e.g., `JSONData` → `JsonData`)

### DIFF
--- a/editor/example/spec/corces.ts
+++ b/editor/example/spec/corces.ts
@@ -1,4 +1,4 @@
-import type { GoslingSpec, PartialTrack, View, BIGWIGData, BEDDBData } from '@gosling.schema';
+import type { GoslingSpec, PartialTrack, View, BigWigData, BeddbData } from '@gosling.schema';
 
 const width = 400;
 
@@ -66,7 +66,7 @@ const ideogram: View = {
     ]
 };
 
-const getBigwigData = (name: string): BIGWIGData => {
+const getBigwigData = (name: string): BigWigData => {
     return {
         url: `https://s3.amazonaws.com/gosling-lang.org/data/${name}insertions_bin100_RIPnorm.bw`,
         type: 'bigwig',
@@ -216,7 +216,7 @@ const geneAnnotationTrack: View = {
     height: 80
 };
 
-const getBeddbData = (name: string): BEDDBData => {
+const getBeddbData = (name: string): BeddbData => {
     return {
         url: `https://server.gosling-lang.org/api/v1/tileset_info/?d=${name}-plac-seq-bedpe`,
         type: 'beddb',

--- a/editor/example/spec/rule.ts
+++ b/editor/example/spec/rule.ts
@@ -1,4 +1,4 @@
-import type { PartialTrack, GoslingSpec, JSONData } from '@gosling.schema';
+import type { PartialTrack, GoslingSpec, JsonData } from '@gosling.schema';
 
 const barTrack: PartialTrack = {
     data: {
@@ -17,7 +17,7 @@ const barTrack: PartialTrack = {
     color: { value: 'lightgray' }
 };
 
-const referenceData: JSONData = {
+const referenceData: JsonData = {
     type: 'json',
     values: [
         { c: 'chr2', p: 100000, v: 0.0001 },

--- a/editor/example/spec/sashimi.ts
+++ b/editor/example/spec/sashimi.ts
@@ -1,6 +1,6 @@
-import type { BAMData, GoslingSpec } from '@gosling.schema';
+import type { BamData, GoslingSpec } from '@gosling.schema';
 
-const bamData: BAMData = {
+const bamData: BamData = {
     type: 'bam',
     url: 'https://s3.amazonaws.com/gosling-lang.org/data/sashimi/ENCFF088HTJ.chr10_27035000_27050000.bam',
     indexUrl: 'https://s3.amazonaws.com/gosling-lang.org/data/sashimi/ENCFF088HTJ.chr10_27035000_27050000.bam.bai'

--- a/editor/example/spec/vertical-band.ts
+++ b/editor/example/spec/vertical-band.ts
@@ -1,5 +1,5 @@
-import type { GoslingSpec, CSVData, Track } from '@gosling.schema';
-const data: CSVData = {
+import type { GoslingSpec, CsvData, Track } from '@gosling.schema';
+const data: CsvData = {
     type: 'csv',
     url: 'https://raw.githubusercontent.com/sehilyi/gemini-datasets/master/data/circos-segdup-edited.txt',
     chromosomeField: 'c2',

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -372,14 +372,9 @@
         },
         "scaleOffset": {
           "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -712,7 +707,7 @@
           "$ref": "#/definitions/CoverageTransform"
         },
         {
-          "$ref": "#/definitions/JSONParseTransform"
+          "$ref": "#/definitions/JsonParseTransform"
         }
       ]
     },
@@ -825,14 +820,9 @@
           "description": "If specified, only showing a certain interval in a chromosome."
         },
         "interval": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -853,14 +843,9 @@
               "type": "string"
             },
             {
-              "items": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "string"
-                }
-              ],
+              "items": {
+                "type": "string"
+              },
               "maxItems": 2,
               "minItems": 2,
               "type": "array"
@@ -878,14 +863,9 @@
       "properties": {
         "interval": {
           "description": "Show a certain interval within entire chromosome",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -3370,40 +3350,6 @@
       ],
       "type": "object"
     },
-    "JSONParseTransform": {
-      "additionalProperties": false,
-      "description": "Parse JSON Object Array and append vertically",
-      "properties": {
-        "baseGenomicField": {
-          "description": "Base genomic position when parsing relative position.",
-          "type": "string"
-        },
-        "field": {
-          "description": "The field that contains the JSON object array.",
-          "type": "string"
-        },
-        "genomicField": {
-          "description": "Relative genomic position to parse.",
-          "type": "string"
-        },
-        "genomicLengthField": {
-          "description": "Length of genomic interval.",
-          "type": "string"
-        },
-        "type": {
-          "const": "subjson",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type",
-        "field",
-        "baseGenomicField",
-        "genomicField",
-        "genomicLengthField"
-      ],
-      "type": "object"
-    },
     "JsonData": {
       "additionalProperties": false,
       "description": "The JSON data format allows users to include data directly in the Gosling's JSON specification.",
@@ -3462,6 +3408,40 @@
       "required": [
         "type",
         "values"
+      ],
+      "type": "object"
+    },
+    "JsonParseTransform": {
+      "additionalProperties": false,
+      "description": "Parse JSON Object Array and append vertically",
+      "properties": {
+        "baseGenomicField": {
+          "description": "Base genomic position when parsing relative position.",
+          "type": "string"
+        },
+        "field": {
+          "description": "The field that contains the JSON object array.",
+          "type": "string"
+        },
+        "genomicField": {
+          "description": "Relative genomic position to parse.",
+          "type": "string"
+        },
+        "genomicLengthField": {
+          "description": "Length of genomic interval.",
+          "type": "string"
+        },
+        "type": {
+          "const": "subjson",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "field",
+        "baseGenomicField",
+        "genomicField",
+        "genomicLengthField"
       ],
       "type": "object"
     },
@@ -8223,14 +8203,9 @@
         },
         "scaleOffset": {
           "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -8331,14 +8306,9 @@
         },
         "dashed": {
           "description": "Specify the pattern of dashes and gaps for `rule` marks.",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -9005,20 +8975,12 @@
       "type": "object"
     },
     "ZoomLimits": {
-      "items": [
-        {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        {
-          "type": [
-            "number",
-            "null"
-          ]
-        }
-      ],
+      "items": {
+        "type": [
+          "number",
+          "null"
+        ]
+      },
       "maxItems": 2,
       "minItems": 2,
       "type": "array"

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -35,7 +35,7 @@
       ],
       "type": "string"
     },
-    "BAMData": {
+    "BamData": {
       "additionalProperties": false,
       "description": "Binary Alignment Map (BAM) is the comprehensive raw data of genome sequencing; it consists of the lossless, compressed binary representation of the Sequence Alignment Map-files.",
       "properties": {
@@ -75,7 +75,7 @@
       ],
       "type": "object"
     },
-    "BEDDBData": {
+    "BeddbData": {
       "additionalProperties": false,
       "description": "Regular BED or similar files can be pre-aggregated for the scalable data exploration. Find our more about this format at [HiGlass Docs](https://docs.higlass.io/data_preparation.html#bed-files).",
       "properties": {
@@ -183,7 +183,7 @@
       ],
       "type": "object"
     },
-    "BIGWIGData": {
+    "BigWigData": {
       "additionalProperties": false,
       "properties": {
         "aggregation": {
@@ -231,82 +231,6 @@
         "sum"
       ],
       "type": "string"
-    },
-    "CSVData": {
-      "additionalProperties": false,
-      "description": "Any small enough tabular data files, such as tsv, csv, BED, BEDPE, and GFF, can be loaded using \"csv\" data specification.",
-      "properties": {
-        "chromosomeField": {
-          "description": "Specify the name of chromosome data fields.",
-          "type": "string"
-        },
-        "chromosomePrefix": {
-          "description": "experimental",
-          "type": "string"
-        },
-        "genomicFields": {
-          "description": "Specify the name of genomic data fields.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "genomicFieldsToConvert": {
-          "description": "experimental",
-          "items": {
-            "additionalProperties": false,
-            "properties": {
-              "chromosomeField": {
-                "type": "string"
-              },
-              "genomicFields": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "chromosomeField",
-              "genomicFields"
-            ],
-            "type": "object"
-          },
-          "type": "array"
-        },
-        "headerNames": {
-          "description": "Specify the names of data fields if a CSV file does not contain a header.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "longToWideId": {
-          "description": "experimental",
-          "type": "string"
-        },
-        "sampleLength": {
-          "description": "Specify the number of rows loaded from the URL.\n\n__Default:__ `1000`",
-          "type": "number"
-        },
-        "separator": {
-          "description": "Specify file separator, __Default:__ ','",
-          "type": "string"
-        },
-        "type": {
-          "const": "csv",
-          "type": "string"
-        },
-        "url": {
-          "description": "Specify the URL address of the data file.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type",
-        "url"
-      ],
-      "type": "object"
     },
     "Channel": {
       "anyOf": [
@@ -504,22 +428,98 @@
       ],
       "type": "object"
     },
+    "CsvData": {
+      "additionalProperties": false,
+      "description": "Any small enough tabular data files, such as tsv, csv, BED, BEDPE, and GFF, can be loaded using \"csv\" data specification.",
+      "properties": {
+        "chromosomeField": {
+          "description": "Specify the name of chromosome data fields.",
+          "type": "string"
+        },
+        "chromosomePrefix": {
+          "description": "experimental",
+          "type": "string"
+        },
+        "genomicFields": {
+          "description": "Specify the name of genomic data fields.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "genomicFieldsToConvert": {
+          "description": "experimental",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "chromosomeField": {
+                "type": "string"
+              },
+              "genomicFields": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "chromosomeField",
+              "genomicFields"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "headerNames": {
+          "description": "Specify the names of data fields if a CSV file does not contain a header.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "longToWideId": {
+          "description": "experimental",
+          "type": "string"
+        },
+        "sampleLength": {
+          "description": "Specify the number of rows loaded from the URL.\n\n__Default:__ `1000`",
+          "type": "number"
+        },
+        "separator": {
+          "description": "Specify file separator, __Default:__ ','",
+          "type": "string"
+        },
+        "type": {
+          "const": "csv",
+          "type": "string"
+        },
+        "url": {
+          "description": "Specify the URL address of the data file.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object"
+    },
     "DataDeep": {
       "anyOf": [
         {
-          "$ref": "#/definitions/JSONData"
+          "$ref": "#/definitions/JsonData"
         },
         {
-          "$ref": "#/definitions/CSVData"
+          "$ref": "#/definitions/CsvData"
         },
         {
-          "$ref": "#/definitions/BIGWIGData"
+          "$ref": "#/definitions/BigWigData"
         },
         {
           "$ref": "#/definitions/MultivecData"
         },
         {
-          "$ref": "#/definitions/BEDDBData"
+          "$ref": "#/definitions/BeddbData"
         },
         {
           "$ref": "#/definitions/VectorData"
@@ -528,10 +528,10 @@
           "$ref": "#/definitions/MatrixData"
         },
         {
-          "$ref": "#/definitions/BAMData"
+          "$ref": "#/definitions/BamData"
         },
         {
-          "$ref": "#/definitions/VCFData"
+          "$ref": "#/definitions/VcfData"
         }
       ]
     },
@@ -3370,7 +3370,41 @@
       ],
       "type": "object"
     },
-    "JSONData": {
+    "JSONParseTransform": {
+      "additionalProperties": false,
+      "description": "Parse JSON Object Array and append vertically",
+      "properties": {
+        "baseGenomicField": {
+          "description": "Base genomic position when parsing relative position.",
+          "type": "string"
+        },
+        "field": {
+          "description": "The field that contains the JSON object array.",
+          "type": "string"
+        },
+        "genomicField": {
+          "description": "Relative genomic position to parse.",
+          "type": "string"
+        },
+        "genomicLengthField": {
+          "description": "Length of genomic interval.",
+          "type": "string"
+        },
+        "type": {
+          "const": "subjson",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "field",
+        "baseGenomicField",
+        "genomicField",
+        "genomicLengthField"
+      ],
+      "type": "object"
+    },
+    "JsonData": {
       "additionalProperties": false,
       "description": "The JSON data format allows users to include data directly in the Gosling's JSON specification.",
       "properties": {
@@ -3428,40 +3462,6 @@
       "required": [
         "type",
         "values"
-      ],
-      "type": "object"
-    },
-    "JSONParseTransform": {
-      "additionalProperties": false,
-      "description": "Parse JSON Object Array and append vertically",
-      "properties": {
-        "baseGenomicField": {
-          "description": "Base genomic position when parsing relative position.",
-          "type": "string"
-        },
-        "field": {
-          "description": "The field that contains the JSON object array.",
-          "type": "string"
-        },
-        "genomicField": {
-          "description": "Relative genomic position to parse.",
-          "type": "string"
-        },
-        "genomicLengthField": {
-          "description": "Length of genomic interval.",
-          "type": "string"
-        },
-        "type": {
-          "const": "subjson",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type",
-        "field",
-        "baseGenomicField",
-        "genomicField",
-        "genomicLengthField"
       ],
       "type": "object"
     },
@@ -8754,7 +8754,23 @@
         }
       ]
     },
-    "VCFData": {
+    "ValueExtent": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "VcfData": {
       "additionalProperties": false,
       "description": "The Variant Call Format (VCF).",
       "properties": {
@@ -8781,22 +8797,6 @@
         "indexUrl"
       ],
       "type": "object"
-    },
-    "ValueExtent": {
-      "anyOf": [
-        {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        {
-          "items": {
-            "type": "number"
-          },
-          "type": "array"
-        }
-      ]
     },
     "VectorData": {
       "additionalProperties": false,

--- a/schema/higlass.schema.json
+++ b/schema/higlass.schema.json
@@ -27,8 +27,7 @@
         "height": {
           "type": "number"
         },
-        "options": {
-        },
+        "options": {},
         "position": {
           "type": "string"
         },
@@ -56,8 +55,7 @@
           "$ref": "#/definitions/Assembly"
         },
         "children": {
-          "items": {
-          },
+          "items": {},
           "type": "array"
         },
         "filter": {
@@ -66,10 +64,8 @@
           },
           "type": "array"
         },
-        "tiles": {
-        },
-        "tilesetInfo": {
-        },
+        "tiles": {},
+        "tilesetInfo": {},
         "type": {
           "type": "string"
         },
@@ -97,8 +93,7 @@
         "height": {
           "type": "number"
         },
-        "options": {
-        },
+        "options": {},
         "server": {
           "type": "string"
         },
@@ -211,8 +206,7 @@
         "locksByViewUid": {
           "$ref": "#/definitions/LocksByViewUid"
         },
-        "locksDict": {
-        }
+        "locksDict": {}
       },
       "required": [
         "locksByViewUid",
@@ -254,8 +248,7 @@
         "height": {
           "type": "number"
         },
-        "options": {
-        },
+        "options": {},
         "position": {
           "type": "string"
         },
@@ -367,8 +360,7 @@
         "fromViewUid": {
           "type": "null"
         },
-        "options": {
-        },
+        "options": {},
         "projectionXDomain": {
           "items": {
             "type": "number"
@@ -382,8 +374,7 @@
           "type": "array"
         },
         "transforms": {
-          "items": {
-          },
+          "items": {},
           "type": "array"
         },
         "type": {
@@ -489,8 +480,7 @@
           "type": "string"
         },
         "includes": {
-          "items": {
-          },
+          "items": {},
           "type": "array"
         },
         "options": {
@@ -509,8 +499,7 @@
       "additionalProperties": false,
       "properties": {
         "extent": {
-          "items": {
-          },
+          "items": {},
           "type": "array"
         },
         "fill": {
@@ -531,8 +520,7 @@
         "outlinePos": {
           "anyOf": [
             {
-              "items": {
-              },
+              "items": {},
               "type": "array"
             },
             {
@@ -552,8 +540,7 @@
         "strokePos": {
           "anyOf": [
             {
-              "items": {
-              },
+              "items": {},
               "type": "array"
             },
             {
@@ -676,8 +663,7 @@
         "locksByViewUid": {
           "$ref": "#/definitions/LocksByViewUid"
         },
-        "locksDict": {
-        }
+        "locksDict": {}
       },
       "required": [
         "locksByViewUid"
@@ -733,20 +719,12 @@
           "type": "boolean"
         },
         "zoomLimits": {
-          "items": [
-            {
-              "type": [
-                "number",
-                "null"
-              ]
-            },
-            {
-              "type": [
-                "number",
-                "null"
-              ]
-            }
-          ],
+          "items": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -2,6 +2,16 @@
   "$ref": "#/definitions/TemplateTrackDef",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "Aggregate": {
+      "enum": [
+        "max",
+        "min",
+        "mean",
+        "bin",
+        "count"
+      ],
+      "type": "string"
+    },
     "Assembly": {
       "enum": [
         "hg38",
@@ -28,8 +38,385 @@
     "ChannelWithBase": {
       "anyOf": [
         {
+          "additionalProperties": false,
+          "properties": {
+            "aggregate": {
+              "$ref": "#/definitions/Aggregate",
+              "description": "Specify how to aggregate data. __Default__: `undefined`"
+            },
+            "axis": {
+              "$ref": "#/definitions/AxisPosition",
+              "description": "Specify where should the axis be put"
+            },
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/GenomicDomain",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field.",
+              "type": "string"
+            },
+            "grid": {
+              "description": "Whether to display grid. __Default__: `false`",
+              "type": "boolean"
+            },
+            "legend": {
+              "description": "Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "linkingId": {
+              "description": "Users need to assign a unique linkingId for [linking views](/docs/user-interaction#linking-views) and [Brushing and Linking](/docs/user-interaction#brushing-and-linking)",
+              "type": "string"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the visual channel."
+            },
+            "type": {
+              "const": "genomic",
+              "description": "Specify the data type.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "aggregate": {
+              "$ref": "#/definitions/Aggregate",
+              "description": "Specify how to aggregate data. __Default__: `undefined`"
+            },
+            "axis": {
+              "$ref": "#/definitions/AxisPosition",
+              "description": "Specify where should the axis be put"
+            },
+            "base": {
+              "type": "string"
+            },
+            "baseline": {
+              "description": "Custom baseline of the y-axis. __Default__: `0`",
+              "type": [
+                "string",
+                "number"
+              ]
+            },
+            "domain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ValueExtent"
+                },
+                {
+                  "$ref": "#/definitions/GenomicDomain"
+                }
+              ],
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field.",
+              "type": "string"
+            },
+            "flip": {
+              "description": "Whether to flip the y-axis. This is done by inverting the `range` property. __Default__: `false`",
+              "type": "boolean"
+            },
+            "grid": {
+              "description": "Whether to display grid. __Default__: `false`",
+              "type": "boolean"
+            },
+            "legend": {
+              "description": "Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "linkingId": {
+              "description": "Users need to assign a unique linkingId for [linking views](/docs/user-interaction#linking-views) and [Brushing and Linking](/docs/user-interaction#brushing-and-linking)",
+              "type": "string"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the visual channel."
+            },
+            "type": {
+              "description": "Specify the data type.",
+              "enum": [
+                "quantitative",
+                "nominal",
+                "genomic"
+              ],
+              "type": "string"
+            },
+            "zeroBaseline": {
+              "description": "Specify whether to use zero baseline. __Default__: `true`",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
           "properties": {
             "base": {
+              "type": "string"
+            },
+            "clip": {
+              "description": "Clip row when the actual y value exceeds the max value of the y scale. Used only for bar marks at the moment. __Default__: `true`",
+              "type": "boolean"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "grid": {
+              "description": "Whether to display grid. __Default__: `false`",
+              "type": "boolean"
+            },
+            "legend": {
+              "description": "Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "padding": {
+              "description": "Determines the size of inner white spaces on the top and bottom of individiual rows. __Default__: `0`",
+              "type": "number"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Determine the start and end position of rendering area of this track along vertical axis. __Default__: `[0, height]`"
+            },
+            "type": {
+              "const": "nominal",
+              "description": "Specify the data type",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "legend": {
+              "description": "Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "range": {
+              "$ref": "#/definitions/Range",
+              "description": "Determine the colors that should be bound to data value. Default properties are determined considering the field type."
+            },
+            "scale": {
+              "enum": [
+                "linear",
+                "log"
+              ],
+              "type": "string"
+            },
+            "scaleOffset": {
+              "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            "title": {
+              "description": "Title of the legend. __Default__: `undefined`",
+              "type": "string"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "legend": {
+              "description": "not supported: Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Ranges of visual channel values"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "legend": {
+              "description": "Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "range": {
+              "$ref": "#/definitions/Range",
+              "description": "Ranges of visual channel values"
+            },
+            "scaleOffset": {
+              "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            "title": {
+              "description": "Title of the legend. __Default__: `undefined`",
+              "type": "string"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Ranges of visual channel values"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Ranges of visual channel values"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "description": "Values of the data",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "range": {
+              "description": "Ranges of visual channel values",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
               "type": "string"
             }
           },
@@ -425,14 +812,9 @@
           "description": "If specified, only showing a certain interval in a chromosome."
         },
         "interval": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -444,19 +826,38 @@
       ],
       "type": "object"
     },
+    "DomainGene": {
+      "additionalProperties": false,
+      "properties": {
+        "gene": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            }
+          ]
+        }
+      },
+      "required": [
+        "gene"
+      ],
+      "type": "object"
+    },
     "DomainInterval": {
       "additionalProperties": false,
       "properties": {
         "interval": {
           "description": "Show a certain interval within entire chromosome",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -508,6 +909,22 @@
         "quantitative"
       ],
       "type": "string"
+    },
+    "GenomicDomain": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DomainInterval"
+        },
+        {
+          "$ref": "#/definitions/DomainChrInterval"
+        },
+        {
+          "$ref": "#/definitions/DomainChr"
+        },
+        {
+          "$ref": "#/definitions/DomainGene"
+        }
+      ]
     },
     "LogBase": {
       "anyOf": [
@@ -562,6 +979,30 @@
         "vertical"
       ],
       "type": "string"
+    },
+    "PredefinedColors": {
+      "enum": [
+        "viridis",
+        "grey",
+        "spectral",
+        "warm",
+        "cividis",
+        "bupu",
+        "rdbu",
+        "hot",
+        "pink"
+      ],
+      "type": "string"
+    },
+    "Range": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ValueExtent"
+        },
+        {
+          "$ref": "#/definitions/PredefinedColors"
+        }
+      ]
     },
     "SizeVisibilityCondition": {
       "additionalProperties": false,
@@ -670,14 +1111,9 @@
         },
         "dashed": {
           "description": "Specify the pattern of dashes and gaps for `rule` marks.",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -1055,6 +1491,22 @@
       ],
       "type": "object"
     },
+    "ValueExtent": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        }
+      ]
+    },
     "VisibilityCondition": {
       "anyOf": [
         {
@@ -1107,20 +1559,12 @@
       "type": "object"
     },
     "ZoomLimits": {
-      "items": [
-        {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        {
-          "type": [
-            "number",
-            "null"
-          ]
-        }
-      ],
+      "items": {
+        "type": [
+          "number",
+          "null"
+        ]
+      },
       "maxItems": 2,
       "minItems": 2,
       "type": "array"

--- a/schema/theme.schema.json
+++ b/schema/theme.schema.json
@@ -12,14 +12,9 @@
           "type": "string"
         },
         "gridStrokeDash": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -115,14 +110,9 @@
           "type": "number"
         },
         "quantitativeSizeRange": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -278,14 +268,9 @@
               "type": "number"
             },
             "quantitativeSizeRange": {
-              "items": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                }
-              ],
+              "items": {
+                "type": "number"
+              },
               "maxItems": 2,
               "minItems": 2,
               "type": "array"

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -19,17 +19,17 @@ import type {
     OneOfFilter,
     RangeFilter,
     IncludeFilter,
-    BEDDBData,
+    BeddbData,
     MultivecData,
     MatrixData,
     VectorData,
     DataTrack,
-    BIGWIGData,
+    BigWigData,
     SingleView,
     FlatTracks,
     OverlaidTracks,
     StackedTracks,
-    BAMData,
+    BamData,
     Range,
     TemplateTrack,
     MouseEventsDeep
@@ -164,7 +164,7 @@ export function IsChannelValue(channel: ChannelDeep | ChannelValue | undefined |
 
 export function IsDataDeepTileset(
     _: DataDeep | undefined
-): _ is BEDDBData | VectorData | MultivecData | BIGWIGData | BAMData | MatrixData {
+): _ is BeddbData | VectorData | MultivecData | BigWigData | BamData | MatrixData {
     return (
         _ !== undefined &&
         (_.type === 'vector' ||

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -1072,7 +1072,7 @@ export type DataTransform =
     | GenomicLengthTransform
     | SvTypeTransform
     | CoverageTransform
-    | JSONParseTransform;
+    | JsonParseTransform;
 
 export type FilterTransform = OneOfFilter | RangeFilter | IncludeFilter;
 
@@ -1216,7 +1216,7 @@ export interface CoverageTransform {
 /**
  * Parse JSON Object Array and append vertically
  */
-export interface JSONParseTransform {
+export interface JsonParseTransform {
     type: 'subjson';
     /** The field that contains the JSON object array. */
     field: string;

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -751,15 +751,15 @@ export type BinAggregate = 'mean' | 'sum';
 
 /* ----------------------------- DATA ----------------------------- */
 export type DataDeep =
-    | JSONData
-    | CSVData
-    | BIGWIGData
+    | JsonData
+    | CsvData
+    | BigWigData
     | MultivecData
-    | BEDDBData
+    | BeddbData
     | VectorData
     | MatrixData
-    | BAMData
-    | VCFData;
+    | BamData
+    | VcfData;
 
 /** Values in the form of JSON. */
 export interface Datum {
@@ -769,7 +769,7 @@ export interface Datum {
 /**
  * The JSON data format allows users to include data directly in the Gosling's JSON specification.
  */
-export interface JSONData {
+export interface JsonData {
     /**
      * Define data type.
      */
@@ -801,7 +801,7 @@ export interface JSONData {
  * Any small enough tabular data files, such as tsv, csv, BED, BEDPE, and GFF, can be loaded using "csv" data specification.
  */
 
-export interface CSVData {
+export interface CsvData {
     type: 'csv';
 
     /**
@@ -909,7 +909,7 @@ export interface MultivecData {
     aggregation?: BinAggregate;
 }
 
-export interface BIGWIGData {
+export interface BigWigData {
     type: 'bigwig';
 
     /**
@@ -981,7 +981,7 @@ export interface VectorData {
  * Regular BED or similar files can be pre-aggregated for the scalable data exploration.
  * Find our more about this format at [HiGlass Docs](https://docs.higlass.io/data_preparation.html#bed-files).
  */
-export interface BEDDBData {
+export interface BeddbData {
     type: 'beddb';
 
     /** Specify the URL address of the data file. */
@@ -1003,7 +1003,7 @@ export interface BEDDBData {
  * Binary Alignment Map (BAM) is the comprehensive raw data of genome sequencing;
  * it consists of the lossless, compressed binary representation of the Sequence Alignment Map-files.
  */
-export interface BAMData {
+export interface BamData {
     type: 'bam';
 
     /** URL link to the BAM data file */
@@ -1028,7 +1028,7 @@ export interface BAMData {
 /**
  * The Variant Call Format (VCF).
  */
-export interface VCFData {
+export interface VcfData {
     type: 'vcf';
 
     /** URL link to the VCF file */

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -12,7 +12,7 @@ import type {
     SvTypeTransform,
     CoverageTransform,
     DisplaceTransform,
-    JSONParseTransform
+    JsonParseTransform
 } from '../gosling.schema';
 import {
     getChannelKeysByAggregateFnc,
@@ -406,7 +406,7 @@ export function splitExon(split: ExonSplitTransform, data: Datum[], assembly: As
 }
 
 // TODO: Get this data from the fetcher as a default with a flag variable.
-export function parseSubJSON(_: JSONParseTransform, data: Datum[]): Datum[] {
+export function parseSubJSON(_: JsonParseTransform, data: Datum[]): Datum[] {
     const { field, genomicField, baseGenomicField, genomicLengthField } = _;
     let output: Datum[] = Array.from(data);
     output = output

--- a/src/data-fetchers/bigwig/bigwig-data-fetcher.ts
+++ b/src/data-fetchers/bigwig/bigwig-data-fetcher.ts
@@ -3,14 +3,14 @@
  * https://github.com/higlass/higlass-bigwig-datafetcher/blob/main/src/BigwigDataFetcher.js
  */
 import { BigWig } from '@gmod/bbi';
-import type { Assembly, BIGWIGData } from '@gosling.schema';
+import type { Assembly, BigWigData } from '@gosling.schema';
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 import { CommonDataConfig, RemoteFile } from '../utils';
 
 import type { Feature } from '@gmod/bbi';
 import type { ChromInfo, TilesetInfo } from '@higlass/types';
 
-type BigWigDataConfig = BIGWIGData & CommonDataConfig;
+type BigWigDataConfig = BigWigData & CommonDataConfig;
 
 type Tile = {
     tilePos: [number];

--- a/src/data-fetchers/csv/csv-data-fetcher.ts
+++ b/src/data-fetchers/csv/csv-data-fetcher.ts
@@ -67,11 +67,11 @@ function CsvDataFetcher(HGC: any, ...args: any): any {
                 // we have raw data that we can use right away
                 this.values = dataConfig.data;
             } else {
-                this.dataPromise = this.fetchCSV();
+                this.dataPromise = this.fetchCsv();
             }
         }
 
-        fetchCSV() {
+        fetchCsv() {
             const {
                 url,
                 chromosomeField,

--- a/src/data-fetchers/csv/csv-data-fetcher.ts
+++ b/src/data-fetchers/csv/csv-data-fetcher.ts
@@ -1,11 +1,11 @@
 import { dsvFormat as d3dsvFormat } from 'd3-dsv';
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 import { sampleSize } from 'lodash-es';
-import type { Assembly, CSVData, FilterTransform } from '@gosling.schema';
+import type { Assembly, CsvData, FilterTransform } from '@gosling.schema';
 import { filterData } from '../../core/utils/data-transform';
 import { CommonDataConfig, filterUsingGenoPos } from '../utils';
 
-type CsvDataConfig = CSVData & CommonDataConfig & { filter: FilterTransform[] };
+type CsvDataConfig = CsvData & CommonDataConfig & { filter: FilterTransform[] };
 
 /**
  * HiGlass data fetcher specific for Gosling which ultimately will accept any types of data other than CSV files.

--- a/src/data-fetchers/json/json-data-fetcher.ts
+++ b/src/data-fetchers/json/json-data-fetcher.ts
@@ -1,9 +1,9 @@
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 import { sampleSize } from 'lodash-es';
-import type { JSONData } from '@gosling.schema';
+import type { JsonData } from '@gosling.schema';
 import { CommonDataConfig, filterUsingGenoPos } from '../utils';
 
-type CsvDataConfig = JSONData & CommonDataConfig;
+type CsvDataConfig = JsonData & CommonDataConfig;
 
 /**
  * HiGlass data fetcher specific for Gosling which ultimately will accept any types of data other than JSON values.

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -8,13 +8,13 @@ import Worker from './vcf-worker.ts?worker&inline';
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 
 import type { ModuleThread } from 'threads';
-import type { Assembly, VCFData } from '../../core/gosling.schema';
+import type { Assembly, VcfData } from '../../core/gosling.schema';
 import type { WorkerApi, TilesetInfo, Tile } from './vcf-worker';
 import type { CommonDataConfig } from '../utils';
 
 const DEBOUNCE_TIME = 200;
 
-type VcfDataConfig = VCFData & CommonDataConfig;
+type VcfDataConfig = VcfData & CommonDataConfig;
 
 class VcfDataFetcher {
     uid: string;


### PR DESCRIPTION
Changes from

`JSONData, CSVData, BIGWIGData, VCFData, BAMData, BEDDBData`

to

`JsonData, CsvData, BigWigData, VcfData, BamData, BeddbData`,

consistent with data fetcher class names (e.g., `BigWigDataFetcher`)