### PR TITLE
feat(api): get track information; correctly use assembly in zoom APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "@types/bezier-js": "^4.1.0",
         "@types/d3": "^7.0.0",
         "@types/lodash": "^4.14.151",
-        "@types/node": "^12.0.0",
+        "@types/node": "^18.6.2",
         "@types/rbush": "^3.0.0",
         "@types/uuid": "^8.3.1",
         "bezier-js": "4.0.3",

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -102,7 +102,8 @@ export function createApi(
 
             const assembly = getTrack(viewId)?.spec.assembly;
             const chr = position.split(':')[0];
-            const chrStart = GET_CHROM_SIZES(assembly).interval?.[chr]?.[0];
+            const info = GET_CHROM_SIZES(assembly);
+            const chrStart = info.interval?.[chr]?.[0];
 
             if (!chr || typeof chrStart === undefined) {
                 console.warn('Chromosome name is not valid', chr);

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,4 +1,3 @@
-import type React from 'react';
 import * as PIXI from 'pixi.js';
 import type { TrackMouseEventData } from '@gosling.schema';
 import type { HiGlassApi } from './higlass-component-wrapper';
@@ -42,14 +41,14 @@ export interface GoslingApi {
 export function createApi(
     hg: HiGlassApi,
     hgSpec: HiGlassSpec | undefined,
-    trackInfos: React.MutableRefObject<TrackMouseEventData[]>,
+    trackInfos: TrackMouseEventData[],
     theme: Required<CompleteThemeDeep>
 ): GoslingApi {
     const getTracks = () => {
-        return trackInfos.current;
+        return trackInfos;
     };
     const getTrack = (trackId: string) => {
-        const trackInfoFound = trackInfos.current.find(d => d.id === trackId);
+        const trackInfoFound = trackInfos.find(d => d.id === trackId);
         if (!trackInfoFound) {
             console.warn(`[getTrack()] Unable to find a track using the ID (${trackId})`);
         }

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -27,7 +27,8 @@ export interface GoslingApi {
     zoomToGene(viewId: string, gene: string, padding?: number, duration?: number): void;
     suggestGene(viewId: string, keyword: string, callback: (suggestions: GeneSuggestion[]) => void): void;
     getViewIds(): string[];
-    getTrackInfo(trackId: string): TrackMouseEventData | undefined;
+    getTracks(): TrackMouseEventData[];
+    getTrack(trackId: string): TrackMouseEventData | undefined;
     exportPng(transparentBackground?: boolean): void;
     exportPdf(transparentBackground?: boolean): void;
     getCanvas(options?: { resolution?: number; transparentBackground?: boolean }): {
@@ -44,10 +45,13 @@ export function createApi(
     trackInfos: React.MutableRefObject<TrackMouseEventData[]>,
     theme: Required<CompleteThemeDeep>
 ): GoslingApi {
-    const getTrackInfo = (trackId: string) => {
+    const getTracks = () => {
+        return trackInfos.current;
+    };
+    const getTrack = (trackId: string) => {
         const trackInfoFound = trackInfos.current.find(d => d.id === trackId);
         if (!trackInfoFound) {
-            console.warn(`[getTrackInfo()] Unable to find a track using the ID (${trackId})`);
+            console.warn(`[getTrack()] Unable to find a track using the ID (${trackId})`);
         }
         return trackInfoFound;
     };
@@ -96,7 +100,7 @@ export function createApi(
                 return;
             }
 
-            const assembly = getTrackInfo(viewId)?.spec.assembly;
+            const assembly = getTrack(viewId)?.spec.assembly;
             const chr = position.split(':')[0];
             const chrStart = GET_CHROM_SIZES(assembly).interval?.[chr]?.[0];
 
@@ -112,7 +116,7 @@ export function createApi(
             hg.api.zoomTo(viewId, start, end, start, end, duration);
         },
         zoomToExtent: (viewId, duration = 1000) => {
-            const assembly = getTrackInfo(viewId)?.spec.assembly;
+            const assembly = getTrack(viewId)?.spec.assembly;
             const [start, end] = [0, GET_CHROM_SIZES(assembly).total];
             hg.api.zoomTo(viewId, start, end, start, end, duration);
         },
@@ -130,7 +134,8 @@ export function createApi(
             });
             return ids;
         },
-        getTrackInfo,
+        getTracks,
+        getTrack,
         getCanvas,
         exportPng: transparentBackground => {
             const { canvas } = getCanvas({ resolution: 4, transparentBackground });

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,6 +1,6 @@
-import type { TrackMouseEventData } from '@gosling.schema';
-import * as PIXI from 'pixi.js';
 import type React from 'react';
+import * as PIXI from 'pixi.js';
+import type { TrackMouseEventData } from '@gosling.schema';
 import type { HiGlassApi } from './higlass-component-wrapper';
 import type { HiGlassSpec } from './higlass.schema';
 import { subscribe, unsubscribe } from './pubsub';

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -60,5 +60,5 @@ export function compile(
     }
 
     // Make HiGlass models for individual tracks
-    createHiGlassModels(JSON.parse(JSON.stringify(specCopy)), trackInfos, callback, theme);
+    createHiGlassModels(structuredClone(specCopy), trackInfos, callback, theme);
 }

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -20,7 +20,7 @@ export function compile(
     }
 ) {
     // Make sure to keep the original spec as-is
-    const specCopy = structuredClone(spec);
+    const specCopy = JSON.parse(JSON.stringify(spec));
 
     // Override default visual encoding (i.e., `DataTrack` => `BasicSingleTrack`)
     overrideDataTemplates(specCopy);

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -11,7 +11,7 @@ export type CompileCallback = (hg: HiGlassSpec, size: Size, gs: GoslingSpec, tra
 
 export function compile(
     spec: GoslingSpec,
-    callback: compileCallback,
+    callback: CompileCallback,
     templates: TemplateTrackDef[],
     theme: Required<CompleteThemeDeep>,
     containerStatus: {
@@ -20,7 +20,7 @@ export function compile(
     }
 ) {
     // Make sure to keep the original spec as-is
-    const specCopy = JSON.parse(JSON.stringify(spec));
+    const specCopy = structuredClone(spec);
 
     // Override default visual encoding (i.e., `DataTrack` => `BasicSingleTrack`)
     overrideDataTemplates(specCopy);
@@ -60,5 +60,5 @@ export function compile(
     }
 
     // Make HiGlass models for individual tracks
-    createHiGlassModels(structuredClone(specCopy), trackInfos, callback, theme);
+    createHiGlassModels(specCopy, trackInfos, callback, theme);
 }

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -7,7 +7,7 @@ import type { CompleteThemeDeep } from './utils/theme';
 import { renderHiGlass as createHiGlassModels } from './create-higlass-models';
 import { manageResponsiveSpecs } from './responsive';
 
-export type compileCallback = (hg: HiGlassSpec, size: Size, gs: GoslingSpec, trackInfos: TrackMouseEventData[]) => void;
+export type CompileCallback = (hg: HiGlassSpec, size: Size, gs: GoslingSpec, trackInfos: TrackMouseEventData[]) => void;
 
 export function compile(
     spec: GoslingSpec,

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -1,4 +1,4 @@
-import type { GoslingSpec, TemplateTrackDef } from './gosling.schema';
+import type { GoslingSpec, TemplateTrackDef, TrackMouseEventData } from './gosling.schema';
 import type { HiGlassSpec } from './higlass.schema';
 import { traverseToFixSpecDownstream, overrideDataTemplates } from './utils/spec-preprocess';
 import { replaceTrackTemplates } from './utils/template';
@@ -7,9 +7,11 @@ import type { CompleteThemeDeep } from './utils/theme';
 import { renderHiGlass as createHiGlassModels } from './create-higlass-models';
 import { manageResponsiveSpecs } from './responsive';
 
+export type compileCallback = (hg: HiGlassSpec, size: Size, gs: GoslingSpec, trackInfos: TrackMouseEventData[]) => void;
+
 export function compile(
     spec: GoslingSpec,
-    setHg: (hg: HiGlassSpec, size: Size, gs: GoslingSpec) => void,
+    callback: compileCallback,
     templates: TemplateTrackDef[],
     theme: Required<CompleteThemeDeep>,
     containerStatus: {
@@ -58,5 +60,5 @@ export function compile(
     }
 
     // Make HiGlass models for individual tracks
-    createHiGlassModels(JSON.parse(JSON.stringify(specCopy)), trackInfos, setHg, theme);
+    createHiGlassModels(JSON.parse(JSON.stringify(specCopy)), trackInfos, callback, theme);
 }

--- a/src/core/create-higlass-models.ts
+++ b/src/core/create-higlass-models.ts
@@ -4,12 +4,12 @@ import { HiGlassModel } from './higlass-model';
 import { getLinkingInfo } from './utils/linking';
 import type { GoslingSpec, OverlaidTrack, SingleTrack, TrackMouseEventData } from './gosling.schema';
 import type { CompleteThemeDeep } from './utils/theme';
-import type { compileCallback } from './compile';
+import type { CompileCallback } from './compile';
 
 export function renderHiGlass(
     spec: GoslingSpec,
     trackInfos: TrackInfo[],
-    callback: compileCallback,
+    callback: CompileCallback,
     theme: CompleteThemeDeep
 ) {
     if (trackInfos.length === 0) {

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -10,7 +10,7 @@ import { omitDeep } from './utils/omit-deep';
 import { isEqual } from 'lodash';
 import * as uuid from 'uuid';
 
-import type { TemplateTrackDef } from './gosling.schema';
+import type { TemplateTrackDef, TrackMouseEventData } from './gosling.schema';
 
 // Before rerendering, wait for a few time so that HiGlass container is resized already.
 // If HiGlass is rendered and then the container resizes, the viewport position changes, unmatching `xDomain` specified by users.
@@ -42,6 +42,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
     const wrapperSize = useRef<undefined | { width: number; height: number }>();
     const wrapperParentSize = useRef<undefined | { width: number; height: number }>();
     const prevSpec = useRef<undefined | gosling.GoslingSpec>();
+    const trackInfos = useRef<TrackMouseEventData[]>([]);
 
     // HiGlass API
     // https://dev.to/wojciechmatuszewski/mutable-and-immutable-useref-semantics-with-react-typescript-30c9
@@ -54,7 +55,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
     useEffect(() => {
         if (!ref || !hgRef?.current) return;
         const hgApi = hgRef.current;
-        const api = createApi(hgApi, viewConfig, theme);
+        const api = createApi(hgApi, viewConfig, trackInfos, theme);
         if (typeof ref == 'function') {
             ref({ api, hgApi });
         } else {
@@ -74,7 +75,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
 
             gosling.compile(
                 props.spec,
-                (newHs, newSize, newGs) => {
+                (newHs, newSize, newGs, newTrackInfos) => {
                     // TODO: `linkingId` should be updated
                     // We may not want to re-render this
                     if (
@@ -103,6 +104,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
                     }
 
                     prevSpec.current = newGs;
+                    trackInfos.current = newTrackInfos;
                 },
                 [...GoslingTemplates], // TODO: allow user definitions
                 theme,

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -55,7 +55,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
     useEffect(() => {
         if (!ref || !hgRef?.current) return;
         const hgApi = hgRef.current;
-        const api = createApi(hgApi, viewConfig, trackInfos, theme);
+        const api = createApi(hgApi, viewConfig, trackInfos.current, theme);
         if (typeof ref == 'function') {
             ref({ api, hgApi });
         } else {

--- a/src/core/gosling-embed.ts
+++ b/src/core/gosling-embed.ts
@@ -81,9 +81,9 @@ export function embed(element: HTMLElement, spec: GoslingSpec, opts: GoslingEmbe
 
         compile(
             spec,
-            async (hsSpec, size) => {
+            async (hsSpec, size, _, trackInfos) => {
                 const hg = await launchHiglass(element, hsSpec, size, options);
-                const api = createApi(hg, hsSpec, theme);
+                const api = createApi(hg, hsSpec, { current: trackInfos }, theme);
                 resolve(api);
             },
             [...GoslingTemplates],

--- a/src/core/gosling-embed.ts
+++ b/src/core/gosling-embed.ts
@@ -83,7 +83,7 @@ export function embed(element: HTMLElement, spec: GoslingSpec, opts: GoslingEmbe
             spec,
             async (hsSpec, size, _, trackInfos) => {
                 const hg = await launchHiglass(element, hsSpec, size, options);
-                const api = createApi(hg, hsSpec, { current: trackInfos }, theme);
+                const api = createApi(hg, hsSpec, trackInfos, theme);
                 resolve(api);
             },
             [...GoslingTemplates],

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -269,7 +269,7 @@ interface LinearTrackShape {
 }
 
 /** The visual parameters that determine the shape of a circular track */
-export interface CircularTrackShape {
+interface CircularTrackShape {
     cx: number;
     cy: number;
     innerRadius: number;

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -269,7 +269,7 @@ interface LinearTrackShape {
 }
 
 /** The visual parameters that determine the shape of a circular track */
-interface CircularTrackShape {
+export interface CircularTrackShape {
     cx: number;
     cy: number;
     innerRadius: number;
@@ -281,7 +281,7 @@ interface CircularTrackShape {
 }
 
 /** The information for a track mouse event */
-type TrackMouseEventData = {
+export type TrackMouseEventData = {
     /** ID of a source track, i.e., `track.id` */
     id: string;
 

--- a/src/core/utils/assembly.ts
+++ b/src/core/utils/assembly.ts
@@ -138,3 +138,9 @@ export function getChromInterval(chromSize: { [k: string]: number }) {
 export function getChromTotalSize(chromSize: { [k: string]: number }) {
     return Object.values(chromSize).reduce((sum, current) => sum + current, 0);
 }
+
+export function parseGenomicPosition(position: string): { chromosome: string; start?: number; end?: number } {
+    const [chromosome, intervalString] = position.split(':');
+    const [start, end] = intervalString.split('-').map(s => +s.replaceAll(',', ''));
+    return { chromosome, start, end };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1130,10 +1130,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.6.tgz#040a64d7faf9e5d9e940357125f0963012e66f04"
   integrity sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ==
 
-"@types/node@^12.0.0":
-  version "12.20.26"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.26.tgz#a6db0d0577e40844f0b28c2a9289c09e5b44b541"
-  integrity sha512-gIt+h4u2uTho2bsH1K250fUv5fHU71ET1yWT7bM4523zV/XrFb9jlWBOV4DO8FpscY+Sz/WEr1EEjIP2H4yumQ==
+"@types/node@^18.6.2":
+  version "18.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.2.tgz#ffc5f0f099d27887c8d9067b54e55090fcd54126"
+  integrity sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
Fix #544

## Change List

- Added an API function `gosRef.current.api.getTrack('traci-1')` to get track information, such as its expanded spec after compiling and shape:

```ts
const info = gosRef.current.api.getTrack('traci-1');

console.log(info);

// { id: 'track-1', spec: { mark: 'rect', ...}, shape: { x: 0, y: 130, width: 400, height: 100 }
// or `undefined` if not found
```

- Added an API function `getTracks` that return information of all tracks.

- Use the `getTrackInfo` function internally for `zoomToExtent` and `zoomTo` functions to correctly use the assembly


Open to any suggestions.

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
