### PR TITLE
feat: make `width` and `height` of track optional

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -714,9 +714,7 @@
         }
       },
       "required": [
-        "data",
-        "height",
-        "width"
+        "data"
       ],
       "type": "object"
     },
@@ -1835,9 +1833,7 @@
           },
           "required": [
             "alignment",
-            "height",
-            "tracks",
-            "width"
+            "tracks"
           ],
           "type": "object"
         },
@@ -4540,9 +4536,7 @@
         }
       },
       "required": [
-        "height",
-        "overlay",
-        "width"
+        "overlay"
       ],
       "type": "object"
     },
@@ -4899,9 +4893,7 @@
       },
       "required": [
         "alignment",
-        "tracks",
-        "width",
-        "height"
+        "tracks"
       ],
       "type": "object"
     },
@@ -6073,9 +6065,7 @@
       },
       "required": [
         "data",
-        "height",
-        "mark",
-        "width"
+        "mark"
       ],
       "type": "object"
     },
@@ -6826,9 +6816,7 @@
           },
           "required": [
             "alignment",
-            "height",
-            "tracks",
-            "width"
+            "tracks"
           ],
           "type": "object"
         },
@@ -8690,10 +8678,8 @@
         }
       },
       "required": [
-        "data",
-        "height",
         "template",
-        "width"
+        "data"
       ],
       "type": "object"
     },

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -7,10 +7,9 @@ export const DEFAULT_SUBTITLE_HEIGHT = 20; // deprecated
 export const DEWFAULT_TITLE_PADDING_ON_TOP_AND_BOTTOM = 6;
 
 // default track size
-export const DEFAULT_TRACK_HEIGHT_LINEAR = 180;
-export const DEFAULT_TRACK_WIDTH_LINEAR = 360;
-export const DEFAULT_TRACK_HEIGHT_CIRCULAR = 400;
-export const DEFAULT_TRACK_WIDTH_CIRCULAR = 400;
+export const DEFAULT_TRACK_HEIGHT_LINEAR = 130;
+export const DEFAULT_TRACK_WIDTH_LINEAR = 600;
+export const DEFAULT_TRACK_SIZE_2D = 600;
 
 // gab between views
 export const DEFAULT_VIEW_SPACING = 10;

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -60,8 +60,6 @@ export interface StackedTracks extends CommonViewDef, Partial<SingleTrack> {
 export interface OverlaidTracks extends CommonViewDef, Partial<SingleTrack> {
     alignment: 'overlay';
     tracks: PartialTrack[];
-    width: number;
-    height: number;
 }
 
 export interface MultipleViews extends CommonViewDef {
@@ -156,14 +154,7 @@ export interface CommonViewDef {
 /* ----------------------------- TRACK ----------------------------- */
 export type Track = SingleTrack | OverlaidTrack | DataTrack | TemplateTrack;
 
-export interface CommonRequiredTrackDef {
-    /** Specify the track width in pixels. */
-    width: number;
-    /** Specify the track height in pixels. */
-    height: number;
-}
-
-export interface CommonTrackDef extends CommonViewDef, CommonRequiredTrackDef {
+export interface CommonTrackDef extends CommonViewDef {
     // !! TODO: we can check if the same id is used multiple times.
     // !! TODO: this should be track-specific and not defined in views.
     id?: string; // Assigned to `uid` in a HiGlass view config, used for API and caching.
@@ -171,6 +162,11 @@ export interface CommonTrackDef extends CommonViewDef, CommonRequiredTrackDef {
     /** If defined, will show the textual label on the left-top corner of a track. */
     title?: string;
     subtitle?: string; // Being used only for a title track (i.e., 'text-track')
+
+    /** Specify the track width in pixels. */
+    width?: number;
+    /** Specify the track height in pixels. */
+    height?: number;
 
     // Arrangement
     overlayOnPreviousTrack?: boolean;
@@ -405,11 +401,10 @@ export type DisplacementType = 'pile' | 'spread';
 /**
  * Superposing multiple tracks.
  */
-export type OverlaidTrack = Partial<SingleTrack> &
-    CommonRequiredTrackDef & {
-        // This is a property internally used when compiling
-        overlay: Partial<Omit<SingleTrack, 'height' | 'width' | 'layout' | 'title' | 'subtitle'>>[];
-    };
+export type OverlaidTrack = Partial<SingleTrack> & {
+    // This is a property internally used when compiling
+    overlay: Partial<Omit<SingleTrack, 'height' | 'width' | 'layout' | 'title' | 'subtitle'>>[];
+};
 
 /**
  * The styles defined here will be applied to the target marks of mouse events, such as a point mark after the user clicks on it.
@@ -1280,7 +1275,7 @@ export interface JsonParseTransform {
 /**
  * Template specification that will be internally converted into `SingleTrack` for rendering.
  */
-export interface TemplateTrack extends CommonRequiredTrackDef, CommonTrackDef {
+export interface TemplateTrack extends CommonTrackDef {
     // Template name (e.g., 'gene')
     template: string;
 
@@ -1323,7 +1318,7 @@ export type DataTransformWithBase = Partial<DataTransform> & { base?: string };
  * and remove of certain properties (e.g., `data`)
  */
 export type TemplateTrackMappingDef = Omit<
-    CommonRequiredTrackDef & CommonTrackDef,
+    CommonTrackDef,
     'data' | 'height' | 'width' | 'layout' | 'title' | 'subtitle'
 > & {
     // Data transformation

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -185,14 +185,15 @@ function traverseAndCollectTrackInfo(
     const numTracksBeforeInsert = output.length;
 
     if ('tracks' in spec) {
-        const tracks = spec.tracks as Track[];
+        // following `traverseToFixSpecDownstream`, the width and height of each track are gaurenteed to be defined
+        const tracks = spec.tracks as (Track & { width: number; height: number })[];
 
         if (spec.orientation === 'vertical') {
             // This is a vertical view, so use the largest `height` of the tracks for this view.
-            cumHeight = Math.max(...tracks.map(d => d.height!));
+            cumHeight = Math.max(...tracks.map(d => d.height));
             tracks.forEach((track, i, array) => {
                 if (getNumOfXAxes([track]) === 1) {
-                    track.width! += HIGLASS_AXIS_SIZE;
+                    track.width += HIGLASS_AXIS_SIZE;
                 }
 
                 track.height = cumHeight;
@@ -202,7 +203,7 @@ function traverseAndCollectTrackInfo(
                     boundingBox: {
                         x: dx + cumWidth,
                         y: dy,
-                        width: track.width!,
+                        width: track.width,
                         height: cumHeight
                     },
                     layout: { x: 0, y: 0, w: 0, h: 0 } // Just put a dummy info here, this should be added after entire bounding box has been determined
@@ -211,7 +212,7 @@ function traverseAndCollectTrackInfo(
                 if (array[i + 1] && array[i + 1].overlayOnPreviousTrack) {
                     // do not add a height
                 } else {
-                    cumWidth += track.width!;
+                    cumWidth += track.width;
                     if (i !== array.length - 1) {
                         cumWidth += spec.spacing !== undefined ? spec.spacing : 0;
                     }
@@ -219,12 +220,12 @@ function traverseAndCollectTrackInfo(
             });
         } else {
             // This is a horizontal view, so use the largest `width` for this view.
-            cumWidth = Math.max(...tracks.map(d => d.width!)); //forceWidth ? forceWidth : spec.tracks[0]?.width;
+            cumWidth = Math.max(...tracks.map(d => d.width)); //forceWidth ? forceWidth : spec.tracks[0]?.width;
             tracks.forEach((track, i, array) => {
                 // let scaledHeight = track.height;
 
                 if (getNumOfXAxes([track]) === 1) {
-                    track.height! += HIGLASS_AXIS_SIZE;
+                    track.height += HIGLASS_AXIS_SIZE;
                 }
 
                 if (Is2DTrack(resolveSuperposedTracks(track)[0]) && getNumOfYAxes([track]) === 1) {
@@ -240,7 +241,7 @@ function traverseAndCollectTrackInfo(
                         x: dx,
                         y: dy + cumHeight,
                         width: cumWidth,
-                        height: track.height!
+                        height: track.height
                     },
                     layout: { x: 0, y: 0, w: 0, h: 0 } // Just put a dummy info here, this should be added after entire bounding box has been determined
                 });
@@ -248,7 +249,7 @@ function traverseAndCollectTrackInfo(
                 if (array[i + 1] && array[i + 1].overlayOnPreviousTrack) {
                     // do not add a height
                 } else {
-                    cumHeight += track.height!;
+                    cumHeight += track.height;
                     if (i !== array.length - 1) {
                         cumHeight += spec.spacing !== undefined ? spec.spacing : 0;
                     }

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -189,10 +189,10 @@ function traverseAndCollectTrackInfo(
 
         if (spec.orientation === 'vertical') {
             // This is a vertical view, so use the largest `height` of the tracks for this view.
-            cumHeight = Math.max(...tracks.map(d => d.height));
+            cumHeight = Math.max(...tracks.map(d => d.height!));
             tracks.forEach((track, i, array) => {
                 if (getNumOfXAxes([track]) === 1) {
-                    track.width += HIGLASS_AXIS_SIZE;
+                    track.width! += HIGLASS_AXIS_SIZE;
                 }
 
                 track.height = cumHeight;
@@ -202,7 +202,7 @@ function traverseAndCollectTrackInfo(
                     boundingBox: {
                         x: dx + cumWidth,
                         y: dy,
-                        width: track.width,
+                        width: track.width!,
                         height: cumHeight
                     },
                     layout: { x: 0, y: 0, w: 0, h: 0 } // Just put a dummy info here, this should be added after entire bounding box has been determined
@@ -211,7 +211,7 @@ function traverseAndCollectTrackInfo(
                 if (array[i + 1] && array[i + 1].overlayOnPreviousTrack) {
                     // do not add a height
                 } else {
-                    cumWidth += track.width;
+                    cumWidth += track.width!;
                     if (i !== array.length - 1) {
                         cumWidth += spec.spacing !== undefined ? spec.spacing : 0;
                     }
@@ -219,12 +219,12 @@ function traverseAndCollectTrackInfo(
             });
         } else {
             // This is a horizontal view, so use the largest `width` for this view.
-            cumWidth = Math.max(...tracks.map(d => d.width)); //forceWidth ? forceWidth : spec.tracks[0]?.width;
+            cumWidth = Math.max(...tracks.map(d => d.width!)); //forceWidth ? forceWidth : spec.tracks[0]?.width;
             tracks.forEach((track, i, array) => {
                 // let scaledHeight = track.height;
 
                 if (getNumOfXAxes([track]) === 1) {
-                    track.height += HIGLASS_AXIS_SIZE;
+                    track.height! += HIGLASS_AXIS_SIZE;
                 }
 
                 if (Is2DTrack(resolveSuperposedTracks(track)[0]) && getNumOfYAxes([track]) === 1) {
@@ -240,7 +240,7 @@ function traverseAndCollectTrackInfo(
                         x: dx,
                         y: dy + cumHeight,
                         width: cumWidth,
-                        height: track.height
+                        height: track.height!
                     },
                     layout: { x: 0, y: 0, w: 0, h: 0 } // Just put a dummy info here, this should be added after entire bounding box has been determined
                 });
@@ -248,7 +248,7 @@ function traverseAndCollectTrackInfo(
                 if (array[i + 1] && array[i + 1].overlayOnPreviousTrack) {
                     // do not add a height
                 } else {
-                    cumHeight += track.height;
+                    cumHeight += track.height!;
                     if (i !== array.length - 1) {
                         cumHeight += spec.spacing !== undefined ? spec.spacing : 0;
                     }

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -24,6 +24,7 @@ import {
 import {
     DEFAULT_INNER_RADIUS_PROP,
     DEFAULT_TRACK_HEIGHT_LINEAR,
+    DEFAULT_TRACK_SIZE_2D,
     DEFAULT_TRACK_WIDTH_LINEAR,
     DEFAULT_VIEW_SPACING
 } from '../defaults';
@@ -187,8 +188,12 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
         const linkID = uuid.v4();
         tracks.forEach((track, i, array) => {
             // If size not defined, set default ones
-            if (!track.width) track.width = DEFAULT_TRACK_WIDTH_LINEAR;
-            if (!track.height) track.height = DEFAULT_TRACK_HEIGHT_LINEAR;
+            if (!track.width) {
+                track.width = Is2DTrack(track) ? DEFAULT_TRACK_SIZE_2D : DEFAULT_TRACK_WIDTH_LINEAR;
+            }
+            if (!track.height) {
+                track.height = Is2DTrack(track) ? DEFAULT_TRACK_SIZE_2D : DEFAULT_TRACK_HEIGHT_LINEAR;
+            }
 
             /**
              * Process a stack option.

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -969,7 +969,7 @@ function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
                 // Replace width and height information with the actual values for responsive encoding
                 const axisSize = IsXAxis(resolved) ? HIGLASS_AXIS_SIZE : 0; // Why the axis size must be added here?
                 const [w, h] = [trackWidth, trackHeight + axisSize];
-                const circularFactor = Math.min(w, h) / Math.min(resolved.width, resolved.height);
+                const circularFactor = Math.min(w, h) / Math.min(resolved.width!, resolved.height!);
                 if (resolved.innerRadius) {
                     resolved.innerRadius = resolved.innerRadius * circularFactor;
                 }


### PR DESCRIPTION
Fix #778

## Change List
 - Make width and height optional and set default values when missing:

   - 1D tracks → `width: 600, height: 130`
   - 2D tracks → `width: 600, height: 600`

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
