### PR TITLE
refactor: use literal chromsizes in worker

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -415,9 +415,14 @@
         },
         "scaleOffset": {
           "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
-          "items": {
-            "type": "number"
-          },
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -863,9 +868,14 @@
           "description": "If specified, only showing a certain interval in a chromosome."
         },
         "interval": {
-          "items": {
-            "type": "number"
-          },
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -886,9 +896,14 @@
               "type": "string"
             },
             {
-              "items": {
-                "type": "string"
-              },
+              "items": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "maxItems": 2,
               "minItems": 2,
               "type": "array"
@@ -906,9 +921,14 @@
       "properties": {
         "interval": {
           "description": "Show a certain interval within entire chromosome",
-          "items": {
-            "type": "number"
-          },
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -8250,9 +8270,14 @@
         },
         "scaleOffset": {
           "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
-          "items": {
-            "type": "number"
-          },
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -8353,9 +8378,14 @@
         },
         "dashed": {
           "description": "Specify the pattern of dashes and gaps for `rule` marks.",
-          "items": {
-            "type": "number"
-          },
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -9022,12 +9052,20 @@
       "type": "object"
     },
     "ZoomLimits": {
-      "items": {
-        "type": [
-          "number",
-          "null"
-        ]
-      },
+      "items": [
+        {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        {
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      ],
       "maxItems": 2,
       "minItems": 2,
       "type": "array"

--- a/schema/higlass.schema.json
+++ b/schema/higlass.schema.json
@@ -70,7 +70,8 @@
         "height": {
           "type": "number"
         },
-        "options": {},
+        "options": {
+        },
         "position": {
           "type": "string"
         },
@@ -98,7 +99,8 @@
           "$ref": "#/definitions/Assembly"
         },
         "children": {
-          "items": {},
+          "items": {
+          },
           "type": "array"
         },
         "filter": {
@@ -107,8 +109,10 @@
           },
           "type": "array"
         },
-        "tiles": {},
-        "tilesetInfo": {},
+        "tiles": {
+        },
+        "tilesetInfo": {
+        },
         "type": {
           "type": "string"
         },
@@ -136,7 +140,8 @@
         "height": {
           "type": "number"
         },
-        "options": {},
+        "options": {
+        },
         "server": {
           "type": "string"
         },
@@ -249,7 +254,8 @@
         "locksByViewUid": {
           "$ref": "#/definitions/LocksByViewUid"
         },
-        "locksDict": {}
+        "locksDict": {
+        }
       },
       "required": [
         "locksByViewUid",
@@ -291,7 +297,8 @@
         "height": {
           "type": "number"
         },
-        "options": {},
+        "options": {
+        },
         "position": {
           "type": "string"
         },
@@ -403,7 +410,8 @@
         "fromViewUid": {
           "type": "null"
         },
-        "options": {},
+        "options": {
+        },
         "projectionXDomain": {
           "items": {
             "type": "number"
@@ -417,7 +425,8 @@
           "type": "array"
         },
         "transforms": {
-          "items": {},
+          "items": {
+          },
           "type": "array"
         },
         "type": {
@@ -523,7 +532,8 @@
           "type": "string"
         },
         "includes": {
-          "items": {},
+          "items": {
+          },
           "type": "array"
         },
         "options": {
@@ -542,7 +552,8 @@
       "additionalProperties": false,
       "properties": {
         "extent": {
-          "items": {},
+          "items": {
+          },
           "type": "array"
         },
         "fill": {
@@ -563,7 +574,8 @@
         "outlinePos": {
           "anyOf": [
             {
-              "items": {},
+              "items": {
+              },
               "type": "array"
             },
             {
@@ -583,7 +595,8 @@
         "strokePos": {
           "anyOf": [
             {
-              "items": {},
+              "items": {
+              },
               "type": "array"
             },
             {
@@ -706,7 +719,8 @@
         "locksByViewUid": {
           "$ref": "#/definitions/LocksByViewUid"
         },
-        "locksDict": {}
+        "locksDict": {
+        }
       },
       "required": [
         "locksByViewUid"
@@ -762,12 +776,20 @@
           "type": "boolean"
         },
         "zoomLimits": {
-          "items": {
-            "type": [
-              "number",
-              "null"
-            ]
-          },
+          "items": [
+            {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          ],
           "maxItems": 2,
           "minItems": 2,
           "type": "array"

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -2,16 +2,6 @@
   "$ref": "#/definitions/TemplateTrackDef",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "Aggregate": {
-      "enum": [
-        "max",
-        "min",
-        "mean",
-        "bin",
-        "count"
-      ],
-      "type": "string"
-    },
     "Assembly": {
       "anyOf": [
         {
@@ -64,385 +54,8 @@
     "ChannelWithBase": {
       "anyOf": [
         {
-          "additionalProperties": false,
-          "properties": {
-            "aggregate": {
-              "$ref": "#/definitions/Aggregate",
-              "description": "Specify how to aggregate data. __Default__: `undefined`"
-            },
-            "axis": {
-              "$ref": "#/definitions/AxisPosition",
-              "description": "Specify where should the axis be put"
-            },
-            "base": {
-              "type": "string"
-            },
-            "domain": {
-              "$ref": "#/definitions/GenomicDomain",
-              "description": "Values of the data"
-            },
-            "field": {
-              "description": "Name of the data field.",
-              "type": "string"
-            },
-            "grid": {
-              "description": "Whether to display grid. __Default__: `false`",
-              "type": "boolean"
-            },
-            "legend": {
-              "description": "Whether to display legend. __Default__: `false`",
-              "type": "boolean"
-            },
-            "linkingId": {
-              "description": "Users need to assign a unique linkingId for [linking views](/docs/user-interaction#linking-views) and [Brushing and Linking](/docs/user-interaction#brushing-and-linking)",
-              "type": "string"
-            },
-            "range": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Values of the visual channel."
-            },
-            "type": {
-              "const": "genomic",
-              "description": "Specify the data type.",
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "aggregate": {
-              "$ref": "#/definitions/Aggregate",
-              "description": "Specify how to aggregate data. __Default__: `undefined`"
-            },
-            "axis": {
-              "$ref": "#/definitions/AxisPosition",
-              "description": "Specify where should the axis be put"
-            },
-            "base": {
-              "type": "string"
-            },
-            "baseline": {
-              "description": "Custom baseline of the y-axis. __Default__: `0`",
-              "type": [
-                "string",
-                "number"
-              ]
-            },
-            "domain": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ValueExtent"
-                },
-                {
-                  "$ref": "#/definitions/GenomicDomain"
-                }
-              ],
-              "description": "Values of the data"
-            },
-            "field": {
-              "description": "Name of the data field.",
-              "type": "string"
-            },
-            "flip": {
-              "description": "Whether to flip the y-axis. This is done by inverting the `range` property. __Default__: `false`",
-              "type": "boolean"
-            },
-            "grid": {
-              "description": "Whether to display grid. __Default__: `false`",
-              "type": "boolean"
-            },
-            "legend": {
-              "description": "Whether to display legend. __Default__: `false`",
-              "type": "boolean"
-            },
-            "linkingId": {
-              "description": "Users need to assign a unique linkingId for [linking views](/docs/user-interaction#linking-views) and [Brushing and Linking](/docs/user-interaction#brushing-and-linking)",
-              "type": "string"
-            },
-            "range": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Values of the visual channel."
-            },
-            "type": {
-              "description": "Specify the data type.",
-              "enum": [
-                "quantitative",
-                "nominal",
-                "genomic"
-              ],
-              "type": "string"
-            },
-            "zeroBaseline": {
-              "description": "Specify whether to use zero baseline. __Default__: `true`",
-              "type": "boolean"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
           "properties": {
             "base": {
-              "type": "string"
-            },
-            "clip": {
-              "description": "Clip row when the actual y value exceeds the max value of the y scale. Used only for bar marks at the moment. __Default__: `true`",
-              "type": "boolean"
-            },
-            "domain": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Values of the data"
-            },
-            "field": {
-              "description": "Name of the data field",
-              "type": "string"
-            },
-            "grid": {
-              "description": "Whether to display grid. __Default__: `false`",
-              "type": "boolean"
-            },
-            "legend": {
-              "description": "Whether to display legend. __Default__: `false`",
-              "type": "boolean"
-            },
-            "padding": {
-              "description": "Determines the size of inner white spaces on the top and bottom of individiual rows. __Default__: `0`",
-              "type": "number"
-            },
-            "range": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Determine the start and end position of rendering area of this track along vertical axis. __Default__: `[0, height]`"
-            },
-            "type": {
-              "const": "nominal",
-              "description": "Specify the data type",
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "base": {
-              "type": "string"
-            },
-            "domain": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Values of the data"
-            },
-            "field": {
-              "description": "Name of the data field",
-              "type": "string"
-            },
-            "legend": {
-              "description": "Whether to display legend. __Default__: `false`",
-              "type": "boolean"
-            },
-            "range": {
-              "$ref": "#/definitions/Range",
-              "description": "Determine the colors that should be bound to data value. Default properties are determined considering the field type."
-            },
-            "scale": {
-              "enum": [
-                "linear",
-                "log"
-              ],
-              "type": "string"
-            },
-            "scaleOffset": {
-              "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
-              "items": {
-                "type": "number"
-              },
-              "maxItems": 2,
-              "minItems": 2,
-              "type": "array"
-            },
-            "title": {
-              "description": "Title of the legend. __Default__: `undefined`",
-              "type": "string"
-            },
-            "type": {
-              "description": "Specify the data type",
-              "enum": [
-                "quantitative",
-                "nominal"
-              ],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "base": {
-              "type": "string"
-            },
-            "domain": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Values of the data"
-            },
-            "field": {
-              "description": "Name of the data field",
-              "type": "string"
-            },
-            "legend": {
-              "description": "not supported: Whether to display legend. __Default__: `false`",
-              "type": "boolean"
-            },
-            "range": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Ranges of visual channel values"
-            },
-            "type": {
-              "description": "Specify the data type",
-              "enum": [
-                "quantitative",
-                "nominal"
-              ],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "base": {
-              "type": "string"
-            },
-            "domain": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Values of the data"
-            },
-            "field": {
-              "description": "Name of the data field",
-              "type": "string"
-            },
-            "legend": {
-              "description": "Whether to display legend. __Default__: `false`",
-              "type": "boolean"
-            },
-            "range": {
-              "$ref": "#/definitions/Range",
-              "description": "Ranges of visual channel values"
-            },
-            "scaleOffset": {
-              "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
-              "items": {
-                "type": "number"
-              },
-              "maxItems": 2,
-              "minItems": 2,
-              "type": "array"
-            },
-            "title": {
-              "description": "Title of the legend. __Default__: `undefined`",
-              "type": "string"
-            },
-            "type": {
-              "description": "Specify the data type",
-              "enum": [
-                "quantitative",
-                "nominal"
-              ],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "base": {
-              "type": "string"
-            },
-            "domain": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Values of the data"
-            },
-            "field": {
-              "description": "Name of the data field",
-              "type": "string"
-            },
-            "range": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Ranges of visual channel values"
-            },
-            "type": {
-              "description": "Specify the data type",
-              "enum": [
-                "quantitative",
-                "nominal"
-              ],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "base": {
-              "type": "string"
-            },
-            "domain": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Values of the data"
-            },
-            "field": {
-              "description": "Name of the data field",
-              "type": "string"
-            },
-            "range": {
-              "$ref": "#/definitions/ValueExtent",
-              "description": "Ranges of visual channel values"
-            },
-            "type": {
-              "description": "Specify the data type",
-              "enum": [
-                "quantitative",
-                "nominal"
-              ],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "base": {
-              "type": "string"
-            },
-            "domain": {
-              "description": "Values of the data",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "field": {
-              "description": "Name of the data field",
-              "type": "string"
-            },
-            "range": {
-              "description": "Ranges of visual channel values",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "type": {
-              "description": "Specify the data type",
-              "enum": [
-                "quantitative",
-                "nominal"
-              ],
               "type": "string"
             }
           },
@@ -855,9 +468,14 @@
           "description": "If specified, only showing a certain interval in a chromosome."
         },
         "interval": {
-          "items": {
-            "type": "number"
-          },
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -869,38 +487,19 @@
       ],
       "type": "object"
     },
-    "DomainGene": {
-      "additionalProperties": false,
-      "properties": {
-        "gene": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "items": {
-                "type": "string"
-              },
-              "maxItems": 2,
-              "minItems": 2,
-              "type": "array"
-            }
-          ]
-        }
-      },
-      "required": [
-        "gene"
-      ],
-      "type": "object"
-    },
     "DomainInterval": {
       "additionalProperties": false,
       "properties": {
         "interval": {
           "description": "Show a certain interval within entire chromosome",
-          "items": {
-            "type": "number"
-          },
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -952,22 +551,6 @@
         "quantitative"
       ],
       "type": "string"
-    },
-    "GenomicDomain": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/DomainInterval"
-        },
-        {
-          "$ref": "#/definitions/DomainChrInterval"
-        },
-        {
-          "$ref": "#/definitions/DomainChr"
-        },
-        {
-          "$ref": "#/definitions/DomainGene"
-        }
-      ]
     },
     "LogBase": {
       "anyOf": [
@@ -1022,30 +605,6 @@
         "vertical"
       ],
       "type": "string"
-    },
-    "PredefinedColors": {
-      "enum": [
-        "viridis",
-        "grey",
-        "spectral",
-        "warm",
-        "cividis",
-        "bupu",
-        "rdbu",
-        "hot",
-        "pink"
-      ],
-      "type": "string"
-    },
-    "Range": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ValueExtent"
-        },
-        {
-          "$ref": "#/definitions/PredefinedColors"
-        }
-      ]
     },
     "SizeVisibilityCondition": {
       "additionalProperties": false,
@@ -1154,9 +713,14 @@
         },
         "dashed": {
           "description": "Specify the pattern of dashes and gaps for `rule` marks.",
-          "items": {
-            "type": "number"
-          },
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -1534,22 +1098,6 @@
       ],
       "type": "object"
     },
-    "ValueExtent": {
-      "anyOf": [
-        {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        {
-          "items": {
-            "type": "number"
-          },
-          "type": "array"
-        }
-      ]
-    },
     "VisibilityCondition": {
       "anyOf": [
         {
@@ -1602,12 +1150,20 @@
       "type": "object"
     },
     "ZoomLimits": {
-      "items": {
-        "type": [
-          "number",
-          "null"
-        ]
-      },
+      "items": [
+        {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        {
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      ],
       "maxItems": 2,
       "minItems": 2,
       "type": "array"

--- a/schema/theme.schema.json
+++ b/schema/theme.schema.json
@@ -12,9 +12,14 @@
           "type": "string"
         },
         "gridStrokeDash": {
-          "items": {
-            "type": "number"
-          },
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -110,9 +115,14 @@
           "type": "number"
         },
         "quantitativeSizeRange": {
-          "items": {
-            "type": "number"
-          },
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -268,9 +278,14 @@
               "type": "number"
             },
             "quantitativeSizeRange": {
-              "items": {
-                "type": "number"
-              },
+              "items": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ],
               "maxItems": 2,
               "minItems": 2,
               "type": "array"

--- a/src/data-fetchers/bam/bam-data-fetcher.ts
+++ b/src/data-fetchers/bam/bam-data-fetcher.ts
@@ -12,11 +12,8 @@ import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 
 const DEBOUNCE_TIME = 200;
 
-// TODO: why both url/bamUrl & baiUrl/indexUrl
 interface DataConfig {
     url: string;
-    bamUrl?: string;
-    baiUrl?: string;
     indexUrl?: string;
     assembly: Assembly;
 }
@@ -40,16 +37,9 @@ class BamDataFetcher {
         this.uid = HGC.libraries.slugid.nice();
         this.toFetch = new Set();
 
-        const chromSizes = Object.entries(GET_CHROM_SIZES(dataConfig.assembly).size);
-
         this.worker = spawn<WorkerApi>(new Worker()).then(async worker => {
-            const bamUrl = dataConfig.bamUrl ?? dataConfig.url;
-            await worker.init(this.uid, {
-                ...dataConfig,
-                bamUrl,
-                baiUrl: dataConfig.baiUrl ?? dataConfig.indexUrl ?? `${bamUrl}.bai`,
-                chromSizes
-            });
+            const chromSizes = Object.entries(GET_CHROM_SIZES(dataConfig.assembly).size);
+            await worker.init(this.uid, dataConfig, chromSizes);
             return worker;
         });
     }

--- a/src/data-fetchers/bam/bam-data-fetcher.ts
+++ b/src/data-fetchers/bam/bam-data-fetcher.ts
@@ -7,15 +7,7 @@ import Worker from './bam-worker.ts?worker&inline';
 
 import type { Assembly } from '../../core/gosling.schema';
 import type { ModuleThread } from 'threads';
-import type {
-    WorkerApi,
-    TilesetInfo,
-    Tiles,
-    DataConfig as WorkerDataConfig,
-    Segment,
-    SegmentWithMate,
-    Junction
-} from './bam-worker';
+import type { WorkerApi, TilesetInfo, Tiles, Segment, SegmentWithMate, Junction } from './bam-worker';
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 
 const DEBOUNCE_TIME = 200;
@@ -52,13 +44,12 @@ class BamDataFetcher {
 
         this.worker = spawn<WorkerApi>(new Worker()).then(async worker => {
             const bamUrl = dataConfig.bamUrl ?? dataConfig.url;
-            const workerDataConfig: WorkerDataConfig = {
+            await worker.init(this.uid, {
                 ...dataConfig,
                 bamUrl,
                 baiUrl: dataConfig.baiUrl ?? dataConfig.indexUrl ?? `${bamUrl}.bai`,
                 chromSizes
-            };
-            await worker.init(this.uid, workerDataConfig);
+            });
             return worker;
         });
     }

--- a/src/data-fetchers/bam/bam-data-fetcher.ts
+++ b/src/data-fetchers/bam/bam-data-fetcher.ts
@@ -5,7 +5,7 @@
 import { spawn } from 'threads';
 import Worker from './bam-worker.ts?worker&inline';
 
-import type { BamFile, Assembly } from '../../core/gosling.schema';
+import type { BamData, Assembly } from '@gosling.schema';
 import type { ModuleThread } from 'threads';
 import type { WorkerApi, TilesetInfo, Tiles, Segment, SegmentWithMate, Junction } from './bam-worker';
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
@@ -24,7 +24,7 @@ class BamDataFetcher {
         fetching: { delete(id: string): void };
     };
 
-    constructor(HGC: import('@higlass/types').HGC, config: BamFile & { assembly: Assembly }) {
+    constructor(HGC: import('@higlass/types').HGC, config: BamData & { assembly: Assembly }) {
         this.uid = HGC.libraries.slugid.nice();
         this.toFetch = new Set();
         const { url, indexUrl, assembly, ...options } = config;

--- a/src/data-fetchers/bam/bam-worker.ts
+++ b/src/data-fetchers/bam/bam-worker.ts
@@ -283,7 +283,7 @@ const init = (
     dataConfs[uid] = { bamUrl, chromInfo, loadMates, maxInsertSize, extractJunction, junctionMinCoverage };
 };
 
-const tilesetInfo = async (uid: string) => {
+const tilesetInfo = (uid: string) => {
     const TILE_SIZE = 1024;
     const { chromInfo } = dataConfs[uid];
     return {

--- a/src/data-fetchers/bam/bam-worker.ts
+++ b/src/data-fetchers/bam/bam-worker.ts
@@ -262,12 +262,12 @@ const tileValues = new QuickLRU<string, JsonBamRecord[] | { error: string }>({ m
 
 const init = (
     uid: string,
-    bam: { url: string; indexUrl?: string },
+    bam: { url: string; indexUrl: string },
     chromSizes: ChromSizes,
     options: Partial<BamFileOptions> = {}
 ) => {
     if (!bamFileCache.has(bam.url)) {
-        const bamFile = BamFile.fromUrl(bam.url, bam.indexUrl ?? `${bam.url}.bai`);
+        const bamFile = BamFile.fromUrl(bam.url, bam.indexUrl);
         bamFileCache.set(bam.url, bamFile);
     }
     const bamFile = bamFileCache.get(bam.url)!;

--- a/src/data-fetchers/bam/bam-worker.ts
+++ b/src/data-fetchers/bam/bam-worker.ts
@@ -301,7 +301,7 @@ const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]>
     const { bamUrl, loadMates, chromInfo } = dataConfs[uid];
     const bamFile = bamFiles[bamUrl];
 
-    const info = await tilesetInfo(uid);
+    const info = tilesetInfo(uid);
 
     if (!('max_width' in info)) {
         throw new Error('tilesetInfo does not include `max_width`, which is required for the Gosling BamDataFetcher.');

--- a/src/data-fetchers/bam/bam-worker.ts
+++ b/src/data-fetchers/bam/bam-worker.ts
@@ -1,12 +1,13 @@
-// This worker is heavily based on https://github.com/higlass/higlass-pileup/blob/master/src/bam-fetcher-worker.js
+// Adopted from https://github.com/higlass/higlass-pileup/blob/master/src/bam-fetcher-worker.js
 import { expose, Transfer } from 'threads/worker';
-import { BamFile } from '@gmod/bam';
+import { BamFile as _BamFile } from '@gmod/bam';
 import QuickLRU from 'quick-lru';
 
 import type { TilesetInfo } from '@higlass/types';
 import type { BamRecord } from '@gmod/bam';
 
-import { ExtendedChromInfo, RemoteFile, sizesToChromInfo } from '../utils';
+import { DataSource, RemoteFile } from '../utils';
+import type { ChromSizes } from '@gosling.schema';
 
 function parseMD(mdString: string, useCounts: true): { type: string; length: number }[];
 function parseMD(mdString: string, useCounts: false): { pos: number; base: string; length: 1; bamSeqShift: number }[];
@@ -228,78 +229,65 @@ const bamRecordToJson = (bamRecord: BamRecord, chrName: string, chrOffset: numbe
 
 type JsonBamRecord = ReturnType<typeof bamRecordToJson>;
 
-// promises indexed by urls
-const bamFiles: Record<string, BamFile> = {};
-const bamHeaders: Record<string, ReturnType<BamFile['getHeader']>> = {};
+class BamFile extends _BamFile {
+    headerPromise: ReturnType<BamFile['getHeader']>;
+    constructor(...args: ConstructorParameters<typeof _BamFile>) {
+        super(...args);
+        this.headerPromise = this.getHeader();
+    }
+    static fromUrl(url: string, indexUrl: string) {
+        return new BamFile({
+            bamFilehandle: new RemoteFile(url),
+            baiFilehandle: new RemoteFile(indexUrl)
+            // fetchSizeLimit: 500000000,
+            // chunkSizeLimit: 100000000,
+            // yieldThreadTime: 1000,
+        });
+    }
+}
 
+interface BamFileOptions {
+    loadMates: boolean;
+    maxInsertSize: number;
+    extractJunction: boolean;
+    junctionMinCoverage: number;
+}
+
+// indexed by dataset uuid
+const dataSources: Map<string, DataSource<BamFile, BamFileOptions>> = new Map();
+// indexed by bam url
+const bamFileCache: Map<string, BamFile> = new Map();
 const MAX_TILES = 20;
-
 const tileValues = new QuickLRU<string, JsonBamRecord[] | { error: string }>({ maxSize: MAX_TILES });
-
-export type DataConfig = {
-    bamUrl: string;
-    baiUrl: string;
-    chromSizes: [string, number][];
-    loadMates?: boolean;
-    maxInsertSize?: number;
-    extractJunction?: boolean;
-    junctionMinCoverage?: number;
-};
-
-type HiGlassDataConfig = Omit<DataConfig, 'baiUrl' | 'chromSizes'> & {
-    chromInfo: ExtendedChromInfo;
-};
-
-// indexed by uuid
-const dataConfs: Record<string, HiGlassDataConfig> = {};
 
 const init = (
     uid: string,
-    {
-        bamUrl,
-        baiUrl,
-        chromSizes,
-        loadMates = false,
-        maxInsertSize = 5000,
-        extractJunction = false,
-        junctionMinCoverage = 1
-    }: DataConfig
+    bam: { url: string; indexUrl?: string },
+    chromSizes: ChromSizes,
+    options: Partial<BamFileOptions> = {}
 ) => {
-    if (!bamFiles[bamUrl]) {
-        // we do not yet have this file cached
-        bamFiles[bamUrl] = new BamFile({
-            bamFilehandle: new RemoteFile(bamUrl),
-            baiFilehandle: new RemoteFile(baiUrl)
-            // fetchSizeLimit: 500000000,
-            // chunkSizeLimit: 100000000 ,
-            // yieldThreadTime: 1000
-        });
-
-        // we have to fetch the header before we can fetch data
-        bamHeaders[bamUrl] = bamFiles[bamUrl].getHeader();
+    if (!bamFileCache.has(bam.url)) {
+        const bamFile = BamFile.fromUrl(bam.url, bam.indexUrl ?? `${bam.url}.bai`);
+        bamFileCache.set(bam.url, bamFile);
     }
-    const chromInfo = sizesToChromInfo(chromSizes);
-
-    dataConfs[uid] = { bamUrl, chromInfo, loadMates, maxInsertSize, extractJunction, junctionMinCoverage };
+    const bamFile = bamFileCache.get(bam.url)!;
+    const dataSource = new DataSource(bamFile, chromSizes, {
+        loadMates: false,
+        maxInsertSize: 5000,
+        extractJunction: false,
+        junctionMinCoverage: 1,
+        ...options
+    });
+    dataSources.set(uid, dataSource);
 };
 
 const tilesetInfo = (uid: string) => {
-    const TILE_SIZE = 1024;
-    const { chromInfo } = dataConfs[uid];
-    return {
-        tile_size: TILE_SIZE,
-        bins_per_dimension: TILE_SIZE,
-        max_zoom: Math.ceil(Math.log(chromInfo.totalLength / TILE_SIZE) / Math.log(2)),
-        max_width: chromInfo.totalLength,
-        min_pos: [0],
-        max_pos: [chromInfo.totalLength]
-    };
+    return dataSources.get(uid)!.tilesetInfo;
 };
 
 const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]> => {
     const MAX_TILE_WIDTH = 200000;
-    const { bamUrl, loadMates, chromInfo } = dataConfs[uid];
-    const bamFile = bamFiles[bamUrl];
+    const bam = dataSources.get(uid)!;
 
     const info = tilesetInfo(uid);
 
@@ -320,10 +308,10 @@ const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]>
     let minX = info.min_pos[0] + x * tileWidth;
     const maxX = info.min_pos[0] + (x + 1) * tileWidth;
 
-    const { chromLengths, cumPositions } = chromInfo;
+    const { chromLengths, cumPositions } = bam.chromInfo;
 
     const opt = {
-        viewAsPairs: loadMates
+        viewAsPairs: bam.options.loadMates
         // TODO: Turning this on results in "too many requests error"
         // https://github.com/gosling-lang/gosling.js/pull/556
         // pairAcrossChr: typeof loadMates === 'undefined' ? false : loadMates,
@@ -343,7 +331,7 @@ const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]>
                 // the visible region extends beyond the end of this chromosome
                 // fetch from the start until the end of the chromosome
                 recordPromises.push(
-                    bamFile
+                    bam.file
                         .getRecordsForRange(chromName, minX - chromStart, chromEnd - chromStart, opt)
                         .then(records => {
                             const mappedRecords = records.map(rec =>
@@ -365,7 +353,7 @@ const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]>
                 const endPos = Math.ceil(maxX - chromStart);
                 // the end of the region is within this chromosome
                 recordPromises.push(
-                    bamFile.getRecordsForRange(chromName, startPos, endPos, opt).then(records => {
+                    bam.file.getRecordsForRange(chromName, startPos, endPos, opt).then(records => {
                         const mappedRecords = records.map(rec => bamRecordToJson(rec, chromName, cumPositions[i].pos));
                         tileValues.set(
                             `${uid}.${z}.${x}`,
@@ -415,7 +403,7 @@ const fetchTilesDebounced = async (uid: string, tileIds: string[]) => {
 };
 
 const getTabularData = (uid: string, tileIds: string[]) => {
-    const config = dataConfs[uid];
+    const { options } = dataSources.get(uid)!;
     const allSegments: Record<string, Segment & { substitutions: string }> = {};
 
     for (const tileId of tileIds) {
@@ -440,15 +428,15 @@ const getTabularData = (uid: string, tileIds: string[]) => {
     const segments = Object.values(allSegments);
 
     // find and set mate info when the `data.loadMates` flag is on.
-    if (config.loadMates) {
+    if (options.loadMates) {
         // TODO: avoid mutation?
-        findMates(segments, config.maxInsertSize);
+        findMates(segments, options.maxInsertSize);
     }
 
     let output: Junction[] | SegmentWithMate[] | Segment[];
-    if (config.extractJunction) {
+    if (options.extractJunction) {
         // Reference(ggsashimi): https://github.com/guigolab/ggsashimi/blob/d686d59b4e342b8f9dcd484f0af4831cc092e5de/ggsashimi.py#L136
-        output = findJunctions(segments, config.junctionMinCoverage);
+        output = findJunctions(segments, options.junctionMinCoverage);
     } else {
         output = segments;
     }

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -30,12 +30,8 @@ class VcfDataFetcher {
         this.prevRequestTime = 0;
         this.toFetch = new Set();
         this.worker = spawn<WorkerApi>(new Worker()).then(async worker => {
-            await worker.init(this.uid, {
-                vcfUrl: dataConfig.url,
-                tbiUrl: dataConfig.indexUrl,
-                chromSizes: Object.entries(GET_CHROM_SIZES(dataConfig.assembly).size),
-                sampleLength: dataConfig.sampleLength ?? 1000
-            });
+            const chromSizes = Object.entries(GET_CHROM_SIZES(dataConfig.assembly).size);
+            await worker.init(this.uid, dataConfig, chromSizes, dataConfig);
             return worker;
         });
     }

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -8,7 +8,7 @@ import Worker from './vcf-worker.ts?worker&inline';
 import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 
 import type { ModuleThread } from 'threads';
-import type { Assembly, VcfData } from '../../core/gosling.schema';
+import type { VcfData } from '../../core/gosling.schema';
 import type { WorkerApi, TilesetInfo, Tile } from './vcf-worker';
 import type { CommonDataConfig } from '../utils';
 
@@ -21,7 +21,6 @@ class VcfDataFetcher {
     prevRequestTime: number;
     track?: any;
 
-    private assembly: Assembly;
     private toFetch: Set<string>;
     private fetchTimeout?: ReturnType<typeof setTimeout>;
     private worker: Promise<ModuleThread<WorkerApi>>;
@@ -29,14 +28,13 @@ class VcfDataFetcher {
     constructor(HGC: import('@higlass/types').HGC, public dataConfig: VcfDataConfig) {
         this.uid = HGC.libraries.slugid.nice();
         this.prevRequestTime = 0;
-        this.assembly = dataConfig.assembly;
         this.toFetch = new Set();
         this.worker = spawn<WorkerApi>(new Worker()).then(async worker => {
             await worker.init(
                 this.uid,
                 dataConfig.url,
                 dataConfig.indexUrl,
-                GET_CHROM_SIZES(this.assembly).path,
+                Object.entries(GET_CHROM_SIZES(dataConfig.assembly).size),
                 dataConfig.sampleLength ?? 1000
             );
             return worker;

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -30,13 +30,12 @@ class VcfDataFetcher {
         this.prevRequestTime = 0;
         this.toFetch = new Set();
         this.worker = spawn<WorkerApi>(new Worker()).then(async worker => {
-            await worker.init(
-                this.uid,
-                dataConfig.url,
-                dataConfig.indexUrl,
-                Object.entries(GET_CHROM_SIZES(dataConfig.assembly).size),
-                dataConfig.sampleLength ?? 1000
-            );
+            await worker.init(this.uid, {
+                vcfUrl: dataConfig.url,
+                tbiUrl: dataConfig.indexUrl,
+                chromSizes: Object.entries(GET_CHROM_SIZES(dataConfig.assembly).size),
+                sampleLength: dataConfig.sampleLength ?? 1000
+            });
             return worker;
         });
     }

--- a/src/data-fetchers/vcf/vcf-worker.ts
+++ b/src/data-fetchers/vcf/vcf-worker.ts
@@ -7,15 +7,39 @@ import { TabixIndexedFile } from '@gmod/tabix';
 import { expose, Transfer } from 'threads/worker';
 import { sampleSize } from 'lodash-es';
 
-import { sizesToChromInfo, RemoteFile } from '../utils';
+import { DataSource, RemoteFile } from '../utils';
 
 import type { TilesetInfo } from '@higlass/types';
-import type { ExtendedChromInfo } from '../utils';
+import type { ChromSizes } from '@gosling.schema';
 
 // promises indexed by urls
-const vcfFiles: Record<string, TabixIndexedFile> = {};
-const vcfHeaders: Record<string, Promise<string>> = {};
-const tbiVCFParsers: Record<string, VCF> = {};
+const vcfFiles: Map<string, VcfFile> = new Map();
+
+type VcfFileOptions = {
+    sampleLength: number;
+};
+
+class VcfFile {
+    private parser?: VCF;
+
+    constructor(public tbi: TabixIndexedFile) {}
+
+    async getParser() {
+        if (!this.parser) {
+            const header = await this.tbi.getHeader();
+            this.parser = new VCF({ header });
+        }
+        return this.parser;
+    }
+
+    static fromUrl(url: string, indexUrl: string) {
+        const tbi = new TabixIndexedFile({
+            filehandle: new RemoteFile(url),
+            tbiFilehandle: new RemoteFile(indexUrl)
+        });
+        return new VcfFile(tbi);
+    }
+}
 
 // const MAX_TILES = 20;
 // https://github.com/GMOD/vcf-js/blob/c4a9cbad3ba5a3f0d1c817d685213f111bf9de9b/src/parse.ts#L284-L291
@@ -46,52 +70,27 @@ export type Tile = Omit<VcfRecord, 'ALT' | 'INFO'> & {
 const tileValues: Record<string, Tile[]> = {}; // new LRU({ max: MAX_TILES });
 
 // const vcfData = [];
-
-// indexed by uuid
-type DataConfig = {
-    vcfUrl: string;
-    chromInfo: ExtendedChromInfo;
-    sampleLength: number;
-};
-
-const dataConfs: Record<string, DataConfig> = {};
+const dataSources: Map<string, DataSource<VcfFile, VcfFileOptions>> = new Map();
 
 function init(
     uid: string,
-    config: { vcfUrl: string; tbiUrl: string; chromSizes: [string, number][]; sampleLength: number }
+    vcf: { url: string; indexUrl: string },
+    chromSizes: ChromSizes,
+    options: Partial<VcfFileOptions> = {}
 ) {
-    if (!vcfFiles[config.vcfUrl]) {
-        vcfFiles[config.vcfUrl] = new TabixIndexedFile({
-            filehandle: new RemoteFile(config.vcfUrl),
-            tbiFilehandle: new RemoteFile(config.tbiUrl)
-        });
-
-        vcfHeaders[config.vcfUrl] = vcfFiles[config.vcfUrl].getHeader();
+    let vcfFile = vcfFiles.get(vcf.url);
+    if (!vcfFile) {
+        vcfFile = VcfFile.fromUrl(vcf.url, vcf.indexUrl);
     }
-    dataConfs[uid] = {
-        vcfUrl: config.vcfUrl,
-        chromInfo: sizesToChromInfo(config.chromSizes),
-        sampleLength: config.sampleLength
-    };
+    const dataSource = new DataSource(vcfFile, chromSizes, {
+        sampleLength: 1000,
+        ...options
+    });
+    dataSources.set(uid, dataSource);
 }
 
-const tilesetInfo = async (uid: string) => {
-    const { chromInfo, vcfUrl } = dataConfs[uid];
-    const header = await vcfHeaders[vcfUrl];
-
-    if (!tbiVCFParsers[vcfUrl]) {
-        tbiVCFParsers[vcfUrl] = new VCF({ header });
-    }
-
-    const TILE_SIZE = 1024;
-
-    return {
-        tile_size: TILE_SIZE,
-        max_zoom: Math.ceil(Math.log(chromInfo.totalLength / TILE_SIZE) / Math.log(2)),
-        max_width: chromInfo.totalLength,
-        min_pos: [0],
-        max_pos: [chromInfo.totalLength]
-    };
+const tilesetInfo = (uid: string) => {
+    return dataSources.get(uid)!.tilesetInfo;
 };
 
 const getMutationType = (ref: string, alt?: string) => {
@@ -129,9 +128,8 @@ const getSubstitutionType = (ref: string, alt?: string) => {
 
 // We return an empty tile. We get the data from SvTrack
 const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
-    const { chromInfo, vcfUrl } = dataConfs[uid];
-
-    if (!vcfHeaders[vcfUrl]) return [];
+    const source = dataSources.get(uid)!;
+    const parser = await source.file.getParser();
 
     const CACHE_KEY = `${uid}.${z}.${x}`;
 
@@ -140,19 +138,16 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
     tileValues[CACHE_KEY] = [];
     // }
 
-    const tsInfo = await tilesetInfo(uid);
     const recordPromises: Promise<void>[] = [];
-
-    const tileWidth = +tsInfo.max_width / 2 ** +z;
+    const tileWidth = +source.tilesetInfo.max_width / 2 ** +z;
 
     // get bounds of this tile
-    const minX = tsInfo.min_pos[0] + x * tileWidth;
-    const maxX = tsInfo.min_pos[0] + (x + 1) * tileWidth;
+    const minX = source.tilesetInfo.min_pos[0] + x * tileWidth;
+    const maxX = source.tilesetInfo.min_pos[0] + (x + 1) * tileWidth;
 
     let curMinX = minX;
 
-    const { chromLengths, cumPositions } = chromInfo;
-    const tbiVCFParser = tbiVCFParsers[vcfUrl];
+    const { chromLengths, cumPositions } = source.chromInfo;
 
     cumPositions.forEach(cumPos => {
         const chromName = cumPos.chr;
@@ -160,7 +155,7 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
         const chromEnd = cumPos.pos + chromLengths[chromName];
 
         const parseLineStoreData = (line: string, prevPos?: number) => {
-            const vcfRecord: VcfRecord = tbiVCFParser.parseLine(line);
+            const vcfRecord: VcfRecord = parser.parseLine(line);
             const POS = cumPos.pos + vcfRecord.POS + 1;
 
             let ALT: string | undefined;
@@ -213,7 +208,7 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
                 startPos = curMinX - chromStart;
                 endPos = chromEnd - chromStart;
                 recordPromises.push(
-                    vcfFiles[vcfUrl]
+                    source.file.tbi
                         .getLines(chromName, startPos, endPos, line => {
                             prevPOS = parseLineStoreData(line, prevPOS);
                         })
@@ -223,7 +218,7 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
                 startPos = Math.floor(curMinX - chromStart);
                 endPos = Math.ceil(maxX - chromStart);
                 recordPromises.push(
-                    vcfFiles[vcfUrl]
+                    source.file.tbi
                         .getLines(chromName, startPos, endPos, line => {
                             prevPOS = parseLineStoreData(line, prevPOS);
                         })
@@ -287,7 +282,7 @@ const getTabularData = (uid: string, tileIds: string[]) => {
 
     let output = Object.values(data).flat();
 
-    const sampleLength = dataConfs[uid].sampleLength;
+    const sampleLength = dataSources.get(uid)!.options.sampleLength;
     if (output.length >= sampleLength) {
         // TODO: we can make this more generic
         // priotize that mutations with closer each other are selected when sampling.

--- a/src/data-fetchers/vcf/vcf-worker.ts
+++ b/src/data-fetchers/vcf/vcf-worker.ts
@@ -53,23 +53,27 @@ type DataConfig = {
     chromInfo: ExtendedChromInfo;
     sampleLength: number;
 };
+
 const dataConfs: Record<string, DataConfig> = {};
 
-const init = (uid: string, vcfUrl: string, tbiUrl: string, chromSizes: [string, number][], sampleLength: number) => {
-    if (!vcfFiles[vcfUrl]) {
-        vcfFiles[vcfUrl] = new TabixIndexedFile({
-            filehandle: new RemoteFile(vcfUrl),
-            tbiFilehandle: new RemoteFile(tbiUrl)
+function init(
+    uid: string,
+    config: { vcfUrl: string; tbiUrl: string; chromSizes: [string, number][]; sampleLength: number }
+) {
+    if (!vcfFiles[config.vcfUrl]) {
+        vcfFiles[config.vcfUrl] = new TabixIndexedFile({
+            filehandle: new RemoteFile(config.vcfUrl),
+            tbiFilehandle: new RemoteFile(config.tbiUrl)
         });
 
-        vcfHeaders[vcfUrl] = vcfFiles[vcfUrl].getHeader();
+        vcfHeaders[config.vcfUrl] = vcfFiles[config.vcfUrl].getHeader();
     }
     dataConfs[uid] = {
-        vcfUrl,
-        chromInfo: sizesToChromInfo(chromSizes),
-        sampleLength
+        vcfUrl: config.vcfUrl,
+        chromInfo: sizesToChromInfo(config.chromSizes),
+        sampleLength: config.sampleLength
     };
-};
+}
 
 const tilesetInfo = async (uid: string) => {
     const { chromInfo, vcfUrl } = dataConfs[uid];

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -4,7 +4,7 @@ import * as uuid from 'uuid';
 import { isEqual, sampleSize, uniqBy } from 'lodash-es';
 import type { ScaleLinear } from 'd3-scale';
 import type { SingleTrack, OverlaidTrack, Datum, EventStyle, GenomicPosition, Assembly } from '@gosling.schema';
-import type { CompleteThemeDeep } from 'src/core/utils/theme';
+import type { CompleteThemeDeep } from '../core/utils/theme';
 import { drawMark, drawPostEmbellishment, drawPreEmbellishment } from '../core/mark';
 import { GoslingTrackModel } from '../core/gosling-track-model';
 import { validateTrack } from '../core/utils/validate';


### PR DESCRIPTION
Removes use of chromsizes URLs in worker-based loaders. This feature is necessary to support custom assemblies in the VCF/BAM data fetchers. In Gosling, we know the custom assembly so we can just provide the literal chromsizes.

~TODO: It seems slower to transfer the chromsizes to the worker? Maybe it's just my internet connection at home. Otherwise we could serialize them somehow.~
