### PR TITLE
refactor: simplify workers

### DIFF
--- a/src/data-fetchers/bam/bam-data-fetcher.ts
+++ b/src/data-fetchers/bam/bam-data-fetcher.ts
@@ -12,11 +12,8 @@ import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 
 const DEBOUNCE_TIME = 200;
 
-// TODO: why both url/bamUrl & baiUrl/indexUrl
 interface DataConfig {
     url: string;
-    bamUrl?: string;
-    baiUrl?: string;
     indexUrl?: string;
     assembly: Assembly;
 }
@@ -40,16 +37,9 @@ class BamDataFetcher {
         this.uid = HGC.libraries.slugid.nice();
         this.toFetch = new Set();
 
-        const chromSizes = Object.entries(GET_CHROM_SIZES(dataConfig.assembly).size);
-
         this.worker = spawn<WorkerApi>(new Worker()).then(async worker => {
-            const bamUrl = dataConfig.bamUrl ?? dataConfig.url;
-            await worker.init(this.uid, {
-                ...dataConfig,
-                bamUrl,
-                baiUrl: dataConfig.baiUrl ?? dataConfig.indexUrl ?? `${bamUrl}.bai`,
-                chromSizes
-            });
+            const chromSizes = Object.entries(GET_CHROM_SIZES(dataConfig.assembly).size);
+            await worker.init(this.uid, dataConfig, chromSizes);
             return worker;
         });
     }

--- a/src/data-fetchers/bam/bam-worker.ts
+++ b/src/data-fetchers/bam/bam-worker.ts
@@ -1,4 +1,4 @@
-// This worker is heavily based on https://github.com/higlass/higlass-pileup/blob/master/src/bam-fetcher-worker.js
+// Adopted from https://github.com/higlass/higlass-pileup/blob/master/src/bam-fetcher-worker.js
 import { expose, Transfer } from 'threads/worker';
 import { BamFile as _BamFile } from '@gmod/bam';
 import QuickLRU from 'quick-lru';

--- a/src/data-fetchers/bam/bam-worker.ts
+++ b/src/data-fetchers/bam/bam-worker.ts
@@ -1,12 +1,13 @@
 // This worker is heavily based on https://github.com/higlass/higlass-pileup/blob/master/src/bam-fetcher-worker.js
 import { expose, Transfer } from 'threads/worker';
-import { BamFile } from '@gmod/bam';
+import { BamFile as _BamFile } from '@gmod/bam';
 import QuickLRU from 'quick-lru';
 
 import type { TilesetInfo } from '@higlass/types';
 import type { BamRecord } from '@gmod/bam';
 
-import { ExtendedChromInfo, RemoteFile, sizesToChromInfo } from '../utils';
+import { DataSource, RemoteFile } from '../utils';
+import type { ChromSizes } from '@gosling.schema';
 
 function parseMD(mdString: string, useCounts: true): { type: string; length: number }[];
 function parseMD(mdString: string, useCounts: false): { pos: number; base: string; length: 1; bamSeqShift: number }[];
@@ -228,78 +229,65 @@ const bamRecordToJson = (bamRecord: BamRecord, chrName: string, chrOffset: numbe
 
 type JsonBamRecord = ReturnType<typeof bamRecordToJson>;
 
-// promises indexed by urls
-const bamFiles: Record<string, BamFile> = {};
-const bamHeaders: Record<string, ReturnType<BamFile['getHeader']>> = {};
+class BamFile extends _BamFile {
+    headerPromise: ReturnType<BamFile['getHeader']>;
+    constructor(...args: ConstructorParameters<typeof _BamFile>) {
+        super(...args);
+        this.headerPromise = this.getHeader();
+    }
+    static fromUrl(url: string, indexUrl: string) {
+        return new BamFile({
+            bamFilehandle: new RemoteFile(url),
+            baiFilehandle: new RemoteFile(indexUrl)
+            // fetchSizeLimit: 500000000,
+            // chunkSizeLimit: 100000000,
+            // yieldThreadTime: 1000,
+        });
+    }
+}
 
+interface BamFileOptions {
+    loadMates: boolean;
+    maxInsertSize: number;
+    extractJunction: boolean;
+    junctionMinCoverage: number;
+}
+
+// indexed by dataset uuid
+const dataSources: Map<string, DataSource<BamFile, BamFileOptions>> = new Map();
+// indexed by bam url
+const bamFileCache: Map<string, BamFile> = new Map();
 const MAX_TILES = 20;
-
 const tileValues = new QuickLRU<string, JsonBamRecord[] | { error: string }>({ maxSize: MAX_TILES });
-
-export type DataConfig = {
-    bamUrl: string;
-    baiUrl: string;
-    chromSizes: [string, number][];
-    loadMates?: boolean;
-    maxInsertSize?: number;
-    extractJunction?: boolean;
-    junctionMinCoverage?: number;
-};
-
-type HiGlassDataConfig = Omit<DataConfig, 'baiUrl' | 'chromSizes'> & {
-    chromInfo: ExtendedChromInfo;
-};
-
-// indexed by uuid
-const dataConfs: Record<string, HiGlassDataConfig> = {};
 
 const init = (
     uid: string,
-    {
-        bamUrl,
-        baiUrl,
-        chromSizes,
-        loadMates = false,
-        maxInsertSize = 5000,
-        extractJunction = false,
-        junctionMinCoverage = 1
-    }: DataConfig
+    bam: { url: string; indexUrl?: string },
+    chromSizes: ChromSizes,
+	options: Partial<BamFileOptions> = {}
 ) => {
-    if (!bamFiles[bamUrl]) {
-        // we do not yet have this file cached
-        bamFiles[bamUrl] = new BamFile({
-            bamFilehandle: new RemoteFile(bamUrl),
-            baiFilehandle: new RemoteFile(baiUrl)
-            // fetchSizeLimit: 500000000,
-            // chunkSizeLimit: 100000000 ,
-            // yieldThreadTime: 1000
-        });
-
-        // we have to fetch the header before we can fetch data
-        bamHeaders[bamUrl] = bamFiles[bamUrl].getHeader();
+    if (!bamFileCache.has(bam.url)) {
+        const bamFile = BamFile.fromUrl(bam.url, bam.indexUrl ?? `${bam.url}.bai`);
+        bamFileCache.set(bam.url, bamFile);
     }
-    const chromInfo = sizesToChromInfo(chromSizes);
-
-    dataConfs[uid] = { bamUrl, chromInfo, loadMates, maxInsertSize, extractJunction, junctionMinCoverage };
+    const bamFile = bamFileCache.get(bam.url)!;
+    const dataSource = new DataSource(uid, bamFile, chromSizes, {
+        loadMates: false,
+        maxInsertSize: 5000,
+        extractJunction: false,
+        junctionMinCoverage: 1,
+        ...options
+    })
+    dataSources.set(uid, dataSource);
 };
 
 const tilesetInfo = (uid: string) => {
-    const TILE_SIZE = 1024;
-    const { chromInfo } = dataConfs[uid];
-    return {
-        tile_size: TILE_SIZE,
-        bins_per_dimension: TILE_SIZE,
-        max_zoom: Math.ceil(Math.log(chromInfo.totalLength / TILE_SIZE) / Math.log(2)),
-        max_width: chromInfo.totalLength,
-        min_pos: [0],
-        max_pos: [chromInfo.totalLength]
-    };
+    return dataSources.get(uid)!.tilesetInfo;
 };
 
 const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]> => {
     const MAX_TILE_WIDTH = 200000;
-    const { bamUrl, loadMates, chromInfo } = dataConfs[uid];
-    const bamFile = bamFiles[bamUrl];
+    const bam = dataSources.get(uid)!;
 
     const info = tilesetInfo(uid);
 
@@ -320,10 +308,10 @@ const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]>
     let minX = info.min_pos[0] + x * tileWidth;
     const maxX = info.min_pos[0] + (x + 1) * tileWidth;
 
-    const { chromLengths, cumPositions } = chromInfo;
+    const { chromLengths, cumPositions } = bam.chromInfo;
 
     const opt = {
-        viewAsPairs: loadMates
+        viewAsPairs: bam.options.loadMates
         // TODO: Turning this on results in "too many requests error"
         // https://github.com/gosling-lang/gosling.js/pull/556
         // pairAcrossChr: typeof loadMates === 'undefined' ? false : loadMates,
@@ -343,7 +331,7 @@ const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]>
                 // the visible region extends beyond the end of this chromosome
                 // fetch from the start until the end of the chromosome
                 recordPromises.push(
-                    bamFile
+                    bam.file
                         .getRecordsForRange(chromName, minX - chromStart, chromEnd - chromStart, opt)
                         .then(records => {
                             const mappedRecords = records.map(rec =>
@@ -365,7 +353,7 @@ const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]>
                 const endPos = Math.ceil(maxX - chromStart);
                 // the end of the region is within this chromosome
                 recordPromises.push(
-                    bamFile.getRecordsForRange(chromName, startPos, endPos, opt).then(records => {
+                    bam.file.getRecordsForRange(chromName, startPos, endPos, opt).then(records => {
                         const mappedRecords = records.map(rec => bamRecordToJson(rec, chromName, cumPositions[i].pos));
                         tileValues.set(
                             `${uid}.${z}.${x}`,
@@ -415,7 +403,7 @@ const fetchTilesDebounced = async (uid: string, tileIds: string[]) => {
 };
 
 const getTabularData = (uid: string, tileIds: string[]) => {
-    const config = dataConfs[uid];
+    const { options } = dataSources.get(uid)!;
     const allSegments: Record<string, Segment & { substitutions: string }> = {};
 
     for (const tileId of tileIds) {
@@ -440,15 +428,15 @@ const getTabularData = (uid: string, tileIds: string[]) => {
     const segments = Object.values(allSegments);
 
     // find and set mate info when the `data.loadMates` flag is on.
-    if (config.loadMates) {
+    if (options.loadMates) {
         // TODO: avoid mutation?
-        findMates(segments, config.maxInsertSize);
+        findMates(segments, options.maxInsertSize);
     }
 
     let output: Junction[] | SegmentWithMate[] | Segment[];
-    if (config.extractJunction) {
+    if (options.extractJunction) {
         // Reference(ggsashimi): https://github.com/guigolab/ggsashimi/blob/d686d59b4e342b8f9dcd484f0af4831cc092e5de/ggsashimi.py#L136
-        output = findJunctions(segments, config.junctionMinCoverage);
+        output = findJunctions(segments, options.junctionMinCoverage);
     } else {
         output = segments;
     }

--- a/src/data-fetchers/bam/bam-worker.ts
+++ b/src/data-fetchers/bam/bam-worker.ts
@@ -264,20 +264,20 @@ const init = (
     uid: string,
     bam: { url: string; indexUrl?: string },
     chromSizes: ChromSizes,
-	options: Partial<BamFileOptions> = {}
+    options: Partial<BamFileOptions> = {}
 ) => {
     if (!bamFileCache.has(bam.url)) {
         const bamFile = BamFile.fromUrl(bam.url, bam.indexUrl ?? `${bam.url}.bai`);
         bamFileCache.set(bam.url, bamFile);
     }
     const bamFile = bamFileCache.get(bam.url)!;
-    const dataSource = new DataSource(uid, bamFile, chromSizes, {
+    const dataSource = new DataSource(bamFile, chromSizes, {
         loadMates: false,
         maxInsertSize: 5000,
         extractJunction: false,
         junctionMinCoverage: 1,
         ...options
-    })
+    });
     dataSources.set(uid, dataSource);
 };
 

--- a/src/data-fetchers/utils.ts
+++ b/src/data-fetchers/utils.ts
@@ -2,7 +2,7 @@ import { bisector } from 'd3-array';
 import { RemoteFile as _RemoteFile } from 'generic-filehandle';
 
 import type * as HiGlass from '@higlass/types';
-import type { Assembly, Datum } from '@gosling.schema';
+import type { Assembly, ChromSizes, Datum } from '@gosling.schema';
 
 export type CommonDataConfig = {
     assembly: Assembly;
@@ -11,6 +11,16 @@ export type CommonDataConfig = {
     x1?: string;
     x1e?: string;
 };
+
+export class DataSource<File, Options> {
+    chromInfo: ExtendedChromInfo;
+    tilesetInfo: ReturnType<typeof tilesetInfoFromChromInfo>;
+
+    constructor(public uid: string, public file: File, chromSizes: ChromSizes, public options: Options) {
+        this.chromInfo = sizesToChromInfo(chromSizes);
+        this.tilesetInfo = tilesetInfoFromChromInfo(this.chromInfo);
+    }
+}
 
 /**
  * Filter data before sending to a track considering the visible genomic area in the track.
@@ -104,6 +114,17 @@ export type ExtendedChromInfo = HiGlass.ChromInfo & {
     absToChr(absPos: number): ReturnType<typeof absToChr> | null;
     chrToAbs(chr: [name: string, pos: number]): number | null;
 };
+
+export function tilesetInfoFromChromInfo(chromInfo: ExtendedChromInfo, tileSize = 1024) {
+    return {
+        tile_size: tileSize,
+        bins_per_dimension: tileSize,
+        max_zoom: Math.ceil(Math.log(chromInfo.totalLength / tileSize) / Math.log(2)),
+        max_width: chromInfo.totalLength,
+        min_pos: [0],
+        max_pos: [chromInfo.totalLength]
+    };
+}
 
 export function sizesToChromInfo(sizes: [string, number][]): ExtendedChromInfo {
     const info: HiGlass.ChromInfo = {

--- a/src/data-fetchers/utils.ts
+++ b/src/data-fetchers/utils.ts
@@ -16,7 +16,7 @@ export class DataSource<File, Options> {
     chromInfo: ExtendedChromInfo;
     tilesetInfo: ReturnType<typeof tilesetInfoFromChromInfo>;
 
-    constructor(public uid: string, public file: File, chromSizes: ChromSizes, public options: Options) {
+    constructor(public file: File, chromSizes: ChromSizes, public options: Options) {
         this.chromInfo = sizesToChromInfo(chromSizes);
         this.tilesetInfo = tilesetInfoFromChromInfo(this.chromInfo);
     }

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -30,12 +30,8 @@ class VcfDataFetcher {
         this.prevRequestTime = 0;
         this.toFetch = new Set();
         this.worker = spawn<WorkerApi>(new Worker()).then(async worker => {
-            await worker.init(this.uid, {
-                vcfUrl: dataConfig.url,
-                tbiUrl: dataConfig.indexUrl,
-                chromSizes: Object.entries(GET_CHROM_SIZES(dataConfig.assembly).size),
-                sampleLength: dataConfig.sampleLength ?? 1000
-            });
+            const chromSizes = Object.entries(GET_CHROM_SIZES(dataConfig.assembly).size);
+            await worker.init(this.uid, dataConfig, chromSizes, dataConfig);
             return worker;
         });
     }

--- a/src/data-fetchers/vcf/vcf-worker.ts
+++ b/src/data-fetchers/vcf/vcf-worker.ts
@@ -7,15 +7,39 @@ import { TabixIndexedFile } from '@gmod/tabix';
 import { expose, Transfer } from 'threads/worker';
 import { sampleSize } from 'lodash-es';
 
-import { sizesToChromInfo, RemoteFile } from '../utils';
+import { DataSource, RemoteFile } from '../utils';
 
 import type { TilesetInfo } from '@higlass/types';
-import type { ExtendedChromInfo } from '../utils';
+import type { ChromSizes } from '@gosling.schema';
 
 // promises indexed by urls
-const vcfFiles: Record<string, TabixIndexedFile> = {};
-const vcfHeaders: Record<string, Promise<string>> = {};
-const tbiVCFParsers: Record<string, VCF> = {};
+const vcfFiles: Map<string, VcfFile> = new Map();
+
+type VcfFileOptions = {
+    sampleLength: number;
+};
+
+class VcfFile {
+    private parser?: VCF;
+
+    constructor(public tbi: TabixIndexedFile) {}
+
+    async getParser() {
+        if (!this.parser) {
+            const header = await this.tbi.getHeader();
+            this.parser = new VCF({ header });
+        }
+        return this.parser;
+    }
+
+    static fromUrl(url: string, indexUrl: string) {
+        const tbi = new TabixIndexedFile({
+            filehandle: new RemoteFile(url),
+            tbiFilehandle: new RemoteFile(indexUrl)
+        });
+        return new VcfFile(tbi);
+    }
+}
 
 // const MAX_TILES = 20;
 // https://github.com/GMOD/vcf-js/blob/c4a9cbad3ba5a3f0d1c817d685213f111bf9de9b/src/parse.ts#L284-L291
@@ -46,52 +70,27 @@ export type Tile = Omit<VcfRecord, 'ALT' | 'INFO'> & {
 const tileValues: Record<string, Tile[]> = {}; // new LRU({ max: MAX_TILES });
 
 // const vcfData = [];
-
-// indexed by uuid
-type DataConfig = {
-    vcfUrl: string;
-    chromInfo: ExtendedChromInfo;
-    sampleLength: number;
-};
-
-const dataConfs: Record<string, DataConfig> = {};
+const dataSources: Map<string, DataSource<VcfFile, VcfFileOptions>> = new Map();
 
 function init(
     uid: string,
-    config: { vcfUrl: string; tbiUrl: string; chromSizes: [string, number][]; sampleLength: number }
+    vcf: { url: string; indexUrl: string },
+    chromSizes: ChromSizes,
+    options: Partial<VcfFileOptions> = {}
 ) {
-    if (!vcfFiles[config.vcfUrl]) {
-        vcfFiles[config.vcfUrl] = new TabixIndexedFile({
-            filehandle: new RemoteFile(config.vcfUrl),
-            tbiFilehandle: new RemoteFile(config.tbiUrl)
-        });
-
-        vcfHeaders[config.vcfUrl] = vcfFiles[config.vcfUrl].getHeader();
+    let vcfFile = vcfFiles.get(vcf.url);
+    if (!vcfFile) {
+        vcfFile = VcfFile.fromUrl(vcf.url, vcf.indexUrl);
     }
-    dataConfs[uid] = {
-        vcfUrl: config.vcfUrl,
-        chromInfo: sizesToChromInfo(config.chromSizes),
-        sampleLength: config.sampleLength
-    };
+    const dataSource = new DataSource(uid, vcfFile, chromSizes, {
+        sampleLength: 1000,
+        ...options
+    });
+    dataSources.set(uid, dataSource);
 }
 
-const tilesetInfo = async (uid: string) => {
-    const { chromInfo, vcfUrl } = dataConfs[uid];
-    const header = await vcfHeaders[vcfUrl];
-
-    if (!tbiVCFParsers[vcfUrl]) {
-        tbiVCFParsers[vcfUrl] = new VCF({ header });
-    }
-
-    const TILE_SIZE = 1024;
-
-    return {
-        tile_size: TILE_SIZE,
-        max_zoom: Math.ceil(Math.log(chromInfo.totalLength / TILE_SIZE) / Math.log(2)),
-        max_width: chromInfo.totalLength,
-        min_pos: [0],
-        max_pos: [chromInfo.totalLength]
-    };
+const tilesetInfo = (uid: string) => {
+    return dataSources.get(uid)!.tilesetInfo;
 };
 
 const getMutationType = (ref: string, alt?: string) => {
@@ -129,9 +128,8 @@ const getSubstitutionType = (ref: string, alt?: string) => {
 
 // We return an empty tile. We get the data from SvTrack
 const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
-    const { chromInfo, vcfUrl } = dataConfs[uid];
-
-    if (!vcfHeaders[vcfUrl]) return [];
+    const source = dataSources.get(uid)!;
+    const parser = await source.file.getParser();
 
     const CACHE_KEY = `${uid}.${z}.${x}`;
 
@@ -140,19 +138,16 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
     tileValues[CACHE_KEY] = [];
     // }
 
-    const tsInfo = await tilesetInfo(uid);
     const recordPromises: Promise<void>[] = [];
-
-    const tileWidth = +tsInfo.max_width / 2 ** +z;
+    const tileWidth = +source.tilesetInfo.max_width / 2 ** +z;
 
     // get bounds of this tile
-    const minX = tsInfo.min_pos[0] + x * tileWidth;
-    const maxX = tsInfo.min_pos[0] + (x + 1) * tileWidth;
+    const minX = source.tilesetInfo.min_pos[0] + x * tileWidth;
+    const maxX = source.tilesetInfo.min_pos[0] + (x + 1) * tileWidth;
 
     let curMinX = minX;
 
-    const { chromLengths, cumPositions } = chromInfo;
-    const tbiVCFParser = tbiVCFParsers[vcfUrl];
+    const { chromLengths, cumPositions } = source.chromInfo;
 
     cumPositions.forEach(cumPos => {
         const chromName = cumPos.chr;
@@ -160,7 +155,7 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
         const chromEnd = cumPos.pos + chromLengths[chromName];
 
         const parseLineStoreData = (line: string, prevPos?: number) => {
-            const vcfRecord: VcfRecord = tbiVCFParser.parseLine(line);
+            const vcfRecord: VcfRecord = parser.parseLine(line);
             const POS = cumPos.pos + vcfRecord.POS + 1;
 
             let ALT: string | undefined;
@@ -213,7 +208,7 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
                 startPos = curMinX - chromStart;
                 endPos = chromEnd - chromStart;
                 recordPromises.push(
-                    vcfFiles[vcfUrl]
+                    source.file.tbi
                         .getLines(chromName, startPos, endPos, line => {
                             prevPOS = parseLineStoreData(line, prevPOS);
                         })
@@ -223,7 +218,7 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
                 startPos = Math.floor(curMinX - chromStart);
                 endPos = Math.ceil(maxX - chromStart);
                 recordPromises.push(
-                    vcfFiles[vcfUrl]
+                    source.file.tbi
                         .getLines(chromName, startPos, endPos, line => {
                             prevPOS = parseLineStoreData(line, prevPOS);
                         })
@@ -287,7 +282,7 @@ const getTabularData = (uid: string, tileIds: string[]) => {
 
     let output = Object.values(data).flat();
 
-    const sampleLength = dataConfs[uid].sampleLength;
+    const sampleLength = dataSources.get(uid)!.options.sampleLength;
     if (output.length >= sampleLength) {
         // TODO: we can make this more generic
         // priotize that mutations with closer each other are selected when sampling.

--- a/src/data-fetchers/vcf/vcf-worker.ts
+++ b/src/data-fetchers/vcf/vcf-worker.ts
@@ -82,7 +82,7 @@ function init(
     if (!vcfFile) {
         vcfFile = VcfFile.fromUrl(vcf.url, vcf.indexUrl);
     }
-    const dataSource = new DataSource(uid, vcfFile, chromSizes, {
+    const dataSource = new DataSource(vcfFile, chromSizes, {
         sampleLength: 1000,
         ...options
     });


### PR DESCRIPTION
There is a log of redundant caching of separate objects in both bam-worker.ts and vcf-worker.ts. This PR replaces uses of plain objects `{}` with ES6 `Map` and then creates a generic data source container (`DataSource<File, Options>`) for caching datasets. The data source takes care of translating chromsizes -> chrominfo and generating tilesetinfo for HiGlass.