### PR TITLE
chore: add empty `dataConfig` for HiGlass

### DIFF
--- a/src/data-fetchers/bam/bam-data-fetcher.ts
+++ b/src/data-fetchers/bam/bam-data-fetcher.ts
@@ -13,6 +13,7 @@ import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 const DEBOUNCE_TIME = 200;
 
 class BamDataFetcher {
+    dataConfig = {}; // required for higlass
     uid: string;
     fetchTimeout?: ReturnType<typeof setTimeout>;
     toFetch: Set<string>;

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -14,6 +14,7 @@ import type { WorkerApi, TilesetInfo, Tile } from './vcf-worker';
 const DEBOUNCE_TIME = 200;
 
 class VcfDataFetcher {
+    dataConfig = {}; // required for higlass
     uid: string;
     prevRequestTime: number;
     track?: any;


### PR DESCRIPTION
Apparently HiGlass requires that every data-fetcher have a `dataConfig` object. These fields were present previously in our data-fetchers but were marked by the `private` keyword, and thus I thought it was safe to remove. (A TypeScript note: `private` isn't actually private. The `private` keyword is a TypeScript construct which is only enforced by the typechecker and any `private` field will remain accessible in the JavaScript runtime. If you want real `private` fields, use the new [private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) from JS). 

This PR adds an empty `dataConfig` (`{}`) for both the bam/vcf data-fetchers, just so we don't break HiGlass. It would probably be beneficial to understand exactly what interface is required for a HiGlass data-fetcher and add a type to this repo, i.e.:


```typescript
interface HiGlassDataFetcher {
	dataConfig: Record<string, any>;
	tilesetInfo(...);
	tiles(...);
	/* ... */
}
```

```typescript
class MyDataFetcher implements HiGlassDataFetcher {
	// must implement dataConfg/tilesetInfo/tiles
}
```


we could also make a helper to do this automatically (like `definePluginTrack`), but it would probably be more useful to first sketch out something like https://github.com/gosling-lang/gosling.js/pull/760#issuecomment-1179158968
