### PR TITLE
chore: use preset autocompleteIds

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -415,14 +415,9 @@
         },
         "scaleOffset": {
           "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -868,14 +863,9 @@
           "description": "If specified, only showing a certain interval in a chromosome."
         },
         "interval": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -896,14 +886,9 @@
               "type": "string"
             },
             {
-              "items": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "string"
-                }
-              ],
+              "items": {
+                "type": "string"
+              },
               "maxItems": 2,
               "minItems": 2,
               "type": "array"
@@ -921,14 +906,9 @@
       "properties": {
         "interval": {
           "description": "Show a certain interval within entire chromosome",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -8270,14 +8250,9 @@
         },
         "scaleOffset": {
           "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -8378,14 +8353,9 @@
         },
         "dashed": {
           "description": "Specify the pattern of dashes and gaps for `rule` marks.",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -9052,20 +9022,12 @@
       "type": "object"
     },
     "ZoomLimits": {
-      "items": [
-        {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        {
-          "type": [
-            "number",
-            "null"
-          ]
-        }
-      ],
+      "items": {
+        "type": [
+          "number",
+          "null"
+        ]
+      },
       "maxItems": 2,
       "minItems": 2,
       "type": "array"

--- a/schema/higlass.schema.json
+++ b/schema/higlass.schema.json
@@ -70,8 +70,7 @@
         "height": {
           "type": "number"
         },
-        "options": {
-        },
+        "options": {},
         "position": {
           "type": "string"
         },
@@ -99,8 +98,7 @@
           "$ref": "#/definitions/Assembly"
         },
         "children": {
-          "items": {
-          },
+          "items": {},
           "type": "array"
         },
         "filter": {
@@ -109,10 +107,8 @@
           },
           "type": "array"
         },
-        "tiles": {
-        },
-        "tilesetInfo": {
-        },
+        "tiles": {},
+        "tilesetInfo": {},
         "type": {
           "type": "string"
         },
@@ -140,8 +136,7 @@
         "height": {
           "type": "number"
         },
-        "options": {
-        },
+        "options": {},
         "server": {
           "type": "string"
         },
@@ -254,8 +249,7 @@
         "locksByViewUid": {
           "$ref": "#/definitions/LocksByViewUid"
         },
-        "locksDict": {
-        }
+        "locksDict": {}
       },
       "required": [
         "locksByViewUid",
@@ -297,8 +291,7 @@
         "height": {
           "type": "number"
         },
-        "options": {
-        },
+        "options": {},
         "position": {
           "type": "string"
         },
@@ -410,8 +403,7 @@
         "fromViewUid": {
           "type": "null"
         },
-        "options": {
-        },
+        "options": {},
         "projectionXDomain": {
           "items": {
             "type": "number"
@@ -425,8 +417,7 @@
           "type": "array"
         },
         "transforms": {
-          "items": {
-          },
+          "items": {},
           "type": "array"
         },
         "type": {
@@ -532,8 +523,7 @@
           "type": "string"
         },
         "includes": {
-          "items": {
-          },
+          "items": {},
           "type": "array"
         },
         "options": {
@@ -552,8 +542,7 @@
       "additionalProperties": false,
       "properties": {
         "extent": {
-          "items": {
-          },
+          "items": {},
           "type": "array"
         },
         "fill": {
@@ -574,8 +563,7 @@
         "outlinePos": {
           "anyOf": [
             {
-              "items": {
-              },
+              "items": {},
               "type": "array"
             },
             {
@@ -595,8 +583,7 @@
         "strokePos": {
           "anyOf": [
             {
-              "items": {
-              },
+              "items": {},
               "type": "array"
             },
             {
@@ -719,8 +706,7 @@
         "locksByViewUid": {
           "$ref": "#/definitions/LocksByViewUid"
         },
-        "locksDict": {
-        }
+        "locksDict": {}
       },
       "required": [
         "locksByViewUid"
@@ -776,20 +762,12 @@
           "type": "boolean"
         },
         "zoomLimits": {
-          "items": [
-            {
-              "type": [
-                "number",
-                "null"
-              ]
-            },
-            {
-              "type": [
-                "number",
-                "null"
-              ]
-            }
-          ],
+          "items": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -2,6 +2,16 @@
   "$ref": "#/definitions/TemplateTrackDef",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "Aggregate": {
+      "enum": [
+        "max",
+        "min",
+        "mean",
+        "bin",
+        "count"
+      ],
+      "type": "string"
+    },
     "Assembly": {
       "anyOf": [
         {
@@ -54,8 +64,385 @@
     "ChannelWithBase": {
       "anyOf": [
         {
+          "additionalProperties": false,
+          "properties": {
+            "aggregate": {
+              "$ref": "#/definitions/Aggregate",
+              "description": "Specify how to aggregate data. __Default__: `undefined`"
+            },
+            "axis": {
+              "$ref": "#/definitions/AxisPosition",
+              "description": "Specify where should the axis be put"
+            },
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/GenomicDomain",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field.",
+              "type": "string"
+            },
+            "grid": {
+              "description": "Whether to display grid. __Default__: `false`",
+              "type": "boolean"
+            },
+            "legend": {
+              "description": "Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "linkingId": {
+              "description": "Users need to assign a unique linkingId for [linking views](/docs/user-interaction#linking-views) and [Brushing and Linking](/docs/user-interaction#brushing-and-linking)",
+              "type": "string"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the visual channel."
+            },
+            "type": {
+              "const": "genomic",
+              "description": "Specify the data type.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "aggregate": {
+              "$ref": "#/definitions/Aggregate",
+              "description": "Specify how to aggregate data. __Default__: `undefined`"
+            },
+            "axis": {
+              "$ref": "#/definitions/AxisPosition",
+              "description": "Specify where should the axis be put"
+            },
+            "base": {
+              "type": "string"
+            },
+            "baseline": {
+              "description": "Custom baseline of the y-axis. __Default__: `0`",
+              "type": [
+                "string",
+                "number"
+              ]
+            },
+            "domain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ValueExtent"
+                },
+                {
+                  "$ref": "#/definitions/GenomicDomain"
+                }
+              ],
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field.",
+              "type": "string"
+            },
+            "flip": {
+              "description": "Whether to flip the y-axis. This is done by inverting the `range` property. __Default__: `false`",
+              "type": "boolean"
+            },
+            "grid": {
+              "description": "Whether to display grid. __Default__: `false`",
+              "type": "boolean"
+            },
+            "legend": {
+              "description": "Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "linkingId": {
+              "description": "Users need to assign a unique linkingId for [linking views](/docs/user-interaction#linking-views) and [Brushing and Linking](/docs/user-interaction#brushing-and-linking)",
+              "type": "string"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the visual channel."
+            },
+            "type": {
+              "description": "Specify the data type.",
+              "enum": [
+                "quantitative",
+                "nominal",
+                "genomic"
+              ],
+              "type": "string"
+            },
+            "zeroBaseline": {
+              "description": "Specify whether to use zero baseline. __Default__: `true`",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
           "properties": {
             "base": {
+              "type": "string"
+            },
+            "clip": {
+              "description": "Clip row when the actual y value exceeds the max value of the y scale. Used only for bar marks at the moment. __Default__: `true`",
+              "type": "boolean"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "grid": {
+              "description": "Whether to display grid. __Default__: `false`",
+              "type": "boolean"
+            },
+            "legend": {
+              "description": "Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "padding": {
+              "description": "Determines the size of inner white spaces on the top and bottom of individiual rows. __Default__: `0`",
+              "type": "number"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Determine the start and end position of rendering area of this track along vertical axis. __Default__: `[0, height]`"
+            },
+            "type": {
+              "const": "nominal",
+              "description": "Specify the data type",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "legend": {
+              "description": "Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "range": {
+              "$ref": "#/definitions/Range",
+              "description": "Determine the colors that should be bound to data value. Default properties are determined considering the field type."
+            },
+            "scale": {
+              "enum": [
+                "linear",
+                "log"
+              ],
+              "type": "string"
+            },
+            "scaleOffset": {
+              "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            "title": {
+              "description": "Title of the legend. __Default__: `undefined`",
+              "type": "string"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "legend": {
+              "description": "not supported: Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Ranges of visual channel values"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "legend": {
+              "description": "Whether to display legend. __Default__: `false`",
+              "type": "boolean"
+            },
+            "range": {
+              "$ref": "#/definitions/Range",
+              "description": "Ranges of visual channel values"
+            },
+            "scaleOffset": {
+              "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            "title": {
+              "description": "Title of the legend. __Default__: `undefined`",
+              "type": "string"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Ranges of visual channel values"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Values of the data"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "range": {
+              "$ref": "#/definitions/ValueExtent",
+              "description": "Ranges of visual channel values"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "base": {
+              "type": "string"
+            },
+            "domain": {
+              "description": "Values of the data",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "field": {
+              "description": "Name of the data field",
+              "type": "string"
+            },
+            "range": {
+              "description": "Ranges of visual channel values",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "description": "Specify the data type",
+              "enum": [
+                "quantitative",
+                "nominal"
+              ],
               "type": "string"
             }
           },
@@ -468,14 +855,9 @@
           "description": "If specified, only showing a certain interval in a chromosome."
         },
         "interval": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -487,19 +869,38 @@
       ],
       "type": "object"
     },
+    "DomainGene": {
+      "additionalProperties": false,
+      "properties": {
+        "gene": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            }
+          ]
+        }
+      },
+      "required": [
+        "gene"
+      ],
+      "type": "object"
+    },
     "DomainInterval": {
       "additionalProperties": false,
       "properties": {
         "interval": {
           "description": "Show a certain interval within entire chromosome",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -551,6 +952,22 @@
         "quantitative"
       ],
       "type": "string"
+    },
+    "GenomicDomain": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DomainInterval"
+        },
+        {
+          "$ref": "#/definitions/DomainChrInterval"
+        },
+        {
+          "$ref": "#/definitions/DomainChr"
+        },
+        {
+          "$ref": "#/definitions/DomainGene"
+        }
+      ]
     },
     "LogBase": {
       "anyOf": [
@@ -605,6 +1022,30 @@
         "vertical"
       ],
       "type": "string"
+    },
+    "PredefinedColors": {
+      "enum": [
+        "viridis",
+        "grey",
+        "spectral",
+        "warm",
+        "cividis",
+        "bupu",
+        "rdbu",
+        "hot",
+        "pink"
+      ],
+      "type": "string"
+    },
+    "Range": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ValueExtent"
+        },
+        {
+          "$ref": "#/definitions/PredefinedColors"
+        }
+      ]
     },
     "SizeVisibilityCondition": {
       "additionalProperties": false,
@@ -713,14 +1154,9 @@
         },
         "dashed": {
           "description": "Specify the pattern of dashes and gaps for `rule` marks.",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -1098,6 +1534,22 @@
       ],
       "type": "object"
     },
+    "ValueExtent": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        }
+      ]
+    },
     "VisibilityCondition": {
       "anyOf": [
         {
@@ -1150,20 +1602,12 @@
       "type": "object"
     },
     "ZoomLimits": {
-      "items": [
-        {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        {
-          "type": [
-            "number",
-            "null"
-          ]
-        }
-      ],
+      "items": {
+        "type": [
+          "number",
+          "null"
+        ]
+      },
       "maxItems": 2,
       "minItems": 2,
       "type": "array"

--- a/schema/theme.schema.json
+++ b/schema/theme.schema.json
@@ -12,14 +12,9 @@
           "type": "string"
         },
         "gridStrokeDash": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -115,14 +110,9 @@
           "type": "number"
         },
         "quantitativeSizeRange": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -278,14 +268,9 @@
               "type": "number"
             },
             "quantitativeSizeRange": {
-              "items": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                }
-              ],
+              "items": {
+                "type": "number"
+              },
               "maxItems": 2,
               "minItems": 2,
               "type": "array"

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -5,7 +5,7 @@ import type { Assembly, AxisPosition, Domain, Orientation, ZoomLimits } from './
 import { getNumericDomain } from './utils/scales';
 import type { RelativePosition } from './utils/bounding-box';
 import { validateSpec } from './utils/validate';
-import { GET_CHROM_SIZES } from './utils/assembly';
+import { getAutoCompleteId, GET_CHROM_SIZES } from './utils/assembly';
 import type { CompleteThemeDeep } from './utils/theme';
 import exampleHg from './example/hg-view-config-1';
 import { insertItemToArray } from './utils/array';
@@ -17,7 +17,7 @@ const getViewTemplate = (assembly?: Assembly) => {
         genomePositionSearchBoxVisible: false,
         genomePositionSearchBox: {
             autocompleteServer: 'https://higlass.io/api/v1',
-            autocompleteId: 'P0PLbQMwTYGy-5uPIQid7A',
+            autocompleteId: getAutoCompleteId(assembly),
             chromInfoServer: 'https://higlass.io/api/v1',
             chromInfoId: assembly ?? 'hg38'
         },

--- a/src/core/utils/assembly.ts
+++ b/src/core/utils/assembly.ts
@@ -119,6 +119,23 @@ const CRHOM_SIZES: { [assembly: string]: ChromSize } = Object.freeze({
 });
 
 /**
+ * Some presets of auto-complete IDs (`autocompleteId`) to search for genes using the HiGlass server.
+ */
+export function getAutoCompleteId(assembly?: Assembly) {
+    switch (assembly) {
+        case 'hg19':
+            return 'OHJakQICQD6gTD7skx4EWA';
+        case 'mm10':
+            return 'QDutvmyiSrec5nX4pA5WGQ';
+        case 'mm9':
+            return 'GUm5aBiLRCyz2PsBea7Yzg';
+        case 'hg38':
+        default:
+            return 'P0PLbQMwTYGy-5uPIQid7A';
+    }
+}
+
+/**
  * Calculate cumulative interval of each chromosome.
  */
 export function getChromInterval(chromSize: { [k: string]: number }) {


### PR DESCRIPTION
A quick workaround to use presets of `autocompleteId` for several assemblies. This affects `zoomToGene()` API function. We need to figure out a generic/consistent way to support navigating genes in different assemblies.