### PR TITLE
chore: correctly render bar when y is zero and ye is provided

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -643,7 +643,7 @@
           "type": "object"
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {
@@ -1380,7 +1380,7 @@
                         ]
                       },
                       "spacing": {
-                        "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
                         "type": "number"
                       },
                       "startAngle": {
@@ -1630,7 +1630,7 @@
               ]
             },
             "spacing": {
-              "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
               "type": "number"
             },
             "startAngle": {
@@ -2136,7 +2136,7 @@
                         ]
                       },
                       "spacing": {
-                        "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
                         "type": "number"
                       },
                       "startAngle": {
@@ -2386,7 +2386,7 @@
               ]
             },
             "spacing": {
-              "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
               "type": "number"
             },
             "startAngle": {
@@ -2799,7 +2799,7 @@
                         ]
                       },
                       "spacing": {
-                        "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
                         "type": "number"
                       },
                       "startAngle": {
@@ -3029,7 +3029,7 @@
               "type": "array"
             },
             "spacing": {
-              "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
               "type": "number"
             },
             "static": {
@@ -3199,7 +3199,7 @@
                         "description": "Specify the orientation."
                       },
                       "spacing": {
-                        "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
                         "type": "number"
                       },
                       "static": {
@@ -3280,7 +3280,7 @@
               "type": "array"
             },
             "spacing": {
-              "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
               "type": "number"
             },
             "static": {
@@ -3665,7 +3665,7 @@
           "description": "Specify the orientation."
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "static": {
@@ -4120,7 +4120,7 @@
                 ]
               },
               "spacing": {
-                "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+                "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
                 "type": "number"
               },
               "startAngle": {
@@ -4340,7 +4340,7 @@
           ]
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {
@@ -4690,7 +4690,7 @@
           ]
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {
@@ -5156,7 +5156,7 @@
                 ]
               },
               "spacing": {
-                "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+                "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
                 "type": "number"
               },
               "startAngle": {
@@ -5376,7 +5376,7 @@
           ]
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {
@@ -5868,7 +5868,7 @@
           ]
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {
@@ -6363,7 +6363,7 @@
                         ]
                       },
                       "spacing": {
-                        "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
                         "type": "number"
                       },
                       "startAngle": {
@@ -6613,7 +6613,7 @@
               ]
             },
             "spacing": {
-              "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
               "type": "number"
             },
             "startAngle": {
@@ -7112,7 +7112,7 @@
                         ]
                       },
                       "spacing": {
-                        "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
                         "type": "number"
                       },
                       "startAngle": {
@@ -7362,7 +7362,7 @@
               ]
             },
             "spacing": {
-              "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
               "type": "number"
             },
             "startAngle": {
@@ -7768,7 +7768,7 @@
                         ]
                       },
                       "spacing": {
-                        "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
                         "type": "number"
                       },
                       "startAngle": {
@@ -7998,7 +7998,7 @@
               "type": "array"
             },
             "spacing": {
-              "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
               "type": "number"
             },
             "static": {
@@ -8604,7 +8604,7 @@
           "type": "object"
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -1396,7 +1396,7 @@
           "$ref": "#/definitions/ChannelWithBase"
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -100,7 +100,7 @@ export interface CommonViewDef {
      * The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks.
      * The effect of this property depends on where on the spec you specify the `spacing`.
      *
-     * In a linear layout, this value is used in pixels, 
+     * In a linear layout, this value is used in pixels,
      * while in a circular layout, this value is used relative to the height of the tracks or views.
      */
     spacing?: number;

--- a/src/core/mark/bar.test.ts
+++ b/src/core/mark/bar.test.ts
@@ -1,0 +1,32 @@
+import * as PIXI from 'pixi.js';
+import type { SingleTrack } from '@gosling.schema';
+import { GoslingTrackModel } from '../gosling-track-model';
+import { getTheme } from '../utils/theme';
+import { drawBar } from './bar';
+
+describe('mark:= bar', () => {
+    it('x:=G, y:=V, ye:=V', () => {
+        const t: SingleTrack = {
+            data: { type: 'csv', url: '' },
+            mark: 'bar',
+            x: { field: 'g', type: 'genomic' },
+            y: { value: 0 },
+            ye: { value: 100 },
+            width: 100,
+            height: 100
+        };
+        const d = [{ g: 1 }];
+        const model = new GoslingTrackModel(t, d, getTheme());
+        const trackMock = {
+            dimensions: [100, 100],
+            tilesetInfo: {},
+            getTilePosAndDimensions: () => {
+                return { tileX: null, tileWidth: null };
+            }
+        };
+        const tileMock = { graphics: new PIXI.Graphics(), gos: {} };
+        drawBar(trackMock, tileMock, model);
+        // Should render all data (https://github.com/gosling-lang/gosling.js/pull/791)
+        expect(model.getMouseEventModel().size()).toEqual(d.length);
+    });
+});

--- a/src/core/mark/bar.ts
+++ b/src/core/mark/bar.ts
@@ -173,7 +173,7 @@ export function drawBar(trackInfo: any, tile: any, model: GoslingTrackModel) {
                 const alphaTransition = model.markVisibility(d, { width: barWidth, zoomLevel });
                 const actualOpacity = Math.min(alphaTransition, opacity);
 
-                if (actualOpacity === 0 || barWidth === 0 || y === 0) {
+                if (actualOpacity === 0 || barWidth === 0 || ye - ys === 0) {
                     // do not draw invisible marks
                     return;
                 }


### PR DESCRIPTION
A spec that was not working:

```js
{
  "style": {"dashed": [3, 3]},
  "views": [
    {
      "alignment": "overlay",
      "tracks": [
        {
          "data": {
            "type": "json",
            "values": [
              {"c": "chr2", "p": 100000, "v": 0.0001},
              {"c": "chr5", "p": 100000, "v": 0.0004},
              {"c": "chr10", "p": 100000, "v": 0.0009}
            ],
            "chromosomeField": "c",
            "genomicFields": ["p"]
          },
          "mark": "bar",
          "x": {"field": "p", "type": "genomic"},
          "y": {"value": 0},
          "ye": {"value": 200},
          "size": {"value": 10},
          "color": {"value": "red"}
        }
      ],
      "width": 500,
      "height": 200
    }
  ]
}
```

![gosling-visualization](https://user-images.githubusercontent.com/9922882/183210761-ecda0155-13d1-4d26-87f8-9a5da4c3e4f0.png)