### PR TITLE
chore: fix an issue that did not render BAM track initially

### DIFF
--- a/src/data-fetchers/bam/bam-worker.ts
+++ b/src/data-fetchers/bam/bam-worker.ts
@@ -260,7 +260,7 @@ const bamFileCache: Map<string, BamFile> = new Map();
 const MAX_TILES = 20;
 const tileValues = new QuickLRU<string, JsonBamRecord[] | { error: string }>({ maxSize: MAX_TILES });
 
-const init = (
+const init = async (
     uid: string,
     bam: { url: string; indexUrl: string },
     chromSizes: ChromSizes,
@@ -268,6 +268,7 @@ const init = (
 ) => {
     if (!bamFileCache.has(bam.url)) {
         const bamFile = BamFile.fromUrl(bam.url, bam.indexUrl);
+        await bamFile.getHeader(); // reads bam/bai headers
         bamFileCache.set(bam.url, bamFile);
     }
     const bamFile = bamFileCache.get(bam.url)!;


### PR DESCRIPTION
Fix #787

Calling [`bam.getHeader()`](https://github.com/GMOD/bam-js/blob/73b6d1c3012ae2f144f3b3954112fb3286ae867e/src/bamFile.ts#L144) has been recently removed from the codes which I think was the reason why BAM tracks do not render any graphics. It looks like the function should be called once before requesting range data (`.getRecordsForRange()`) to parse index data.

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
