### PR TITLE
fix: allow custom chromnames in zoomTo api

### DIFF
--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -94,10 +94,6 @@ export function createApi(
         unsubscribe,
         zoomTo: (viewId, position, padding = 0, duration = 1000) => {
             // Accepted input: 'chr1' or 'chr1:1-1000'
-            if (!position.includes('chr')) {
-                console.warn('Genomic interval you entered is not in a correct form.');
-                return;
-            }
             const assembly = getTrack(viewId)?.spec.assembly;
             const chromInfo = GET_CHROM_SIZES(assembly);
             const parsed = parseGenomicPosition(position);

--- a/src/core/utils/assembly.ts
+++ b/src/core/utils/assembly.ts
@@ -158,6 +158,12 @@ export function getChromTotalSize(chromSize: { [k: string]: number }) {
 
 export function parseGenomicPosition(position: string): { chromosome: string; start?: number; end?: number } {
     const [chromosome, intervalString] = position.split(':');
-    const [start, end] = intervalString.split('-').map(s => +s.replaceAll(',', ''));
-    return { chromosome, start, end };
+    if (intervalString) {
+        const [start, end] = intervalString.split('-').map(s => +s.replaceAll(',', ''));
+        // only return if both are valid
+        if (!Number.isNaN(start) && !Number.isNaN(end)) {
+            return { chromosome, start, end };
+        }
+    }
+    return { chromosome };
 }


### PR DESCRIPTION
Currently the `zoomTo` API requires that the `position` string include a `chr` in the identifier. This prevents the API from being used with custom assemblies.

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [x] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
