### PR TITLE
refactor: use simple event emitter to listen for brush events

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "jspdf": "^2.3.1",
         "lodash-es": "^4.17.21",
         "mixwith": "^0.1.1",
+        "nanoevents": "^7.0.1",
         "pubsub-js": "^1.9.3",
         "quick-lru": "^6.1.1",
         "rbush": "^3.0.1",

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -153,12 +153,8 @@ function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
             this.isRangeBrushActivated = false;
             this.pMask.interactive = true;
             this.gBrush = HGC.libraries.d3Selection.select(this.context.svgElement).append('g');
-            this.mRangeBrush = new LinearBrushModel(
-                this.gBrush,
-                HGC.libraries,
-                this.onRangeBrush.bind(this),
-                this.options.spec.style?.brush
-            );
+            this.mRangeBrush = new LinearBrushModel(this.gBrush, HGC.libraries, this.options.spec.style?.brush);
+            this.mRangeBrush.on('brush', this.onRangeBrush.bind(this));
             this.pMask.mousedown = (e: InteractionEvent) =>
                 this.onMouseDown(
                     e.data.getLocalPosition(this.pMain).x,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6102,6 +6102,11 @@ nanocolors@^0.1.0, nanocolors@^0.1.5:
   resolved "https://registry.yarnpkg.com/nanocolors/-/nanocolors-0.1.12.tgz#8577482c58cbd7b5bb1681db4cf48f11a87fd5f6"
   integrity sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==
 
+nanoevents@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/nanoevents/-/nanoevents-7.0.1.tgz#181580b47787688d8cac775b977b1cf24e26e570"
+  integrity sha512-o6lpKiCxLeijK4hgsqfR6CNToPyRU3keKyyI6uwuHRvpRTbZ0wXw51WRgyldVugZqoJfkGFrjrIenYH3bfEO3Q==
+
 nanoid@^3.0.0, nanoid@^3.1.25:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"


### PR DESCRIPTION
This PR implements an idea for better composition of the different models in Gosling. Much of the node.js API is built around `Events` and objects extend from [`EventEmitter`](https://nodejs.org/api/events.html#class-eventemitter), where other objects can subscribe to various custom events emitted from objects:

```javascript

class Timer extends EventEmitter {
  constructor() {
    super();
    setInterval(() => {
      this.emit('tick')
    }, 100)
  }
}

let timer = new Timer();
timer.on('tick', () => console.log('tick!');
``` 

This is similar to the d3 API (except the `.on` methods are for various DOM events). Browsers don't have a native `EventEmitter`, so several libraries have made their own implementations:

- https://github.com/primus/eventemitter3
- https://github.com/EventEmitter2/EventEmitter2
- https://github.com/ai/nanoevents

This PR demonstrates the use of `nanoevents`, the most minimal and modern choice to show how to create custom emitters and add listeners. The library is tiny, and I think generally would encourage the ability to break apart large objects into smaller "emitting" components. 
