### PR TITLE
fix: support using custom chromosome names in genomic domains (`GenomicDomain`); fix `zoomTo()`

### DIFF
--- a/editor/example/doc-examples/brush.ts
+++ b/editor/example/doc-examples/brush.ts
@@ -14,7 +14,7 @@ export const BRUSH: GoslingSpec = {
                 field: 'position',
                 type: 'genomic',
                 domain: {
-                    chromosome: '1'
+                    chromosome: 'chr1'
                 },
                 axis: 'top'
             },
@@ -46,7 +46,7 @@ export const BRUSH: GoslingSpec = {
                 field: 'position',
                 type: 'genomic',
                 domain: {
-                    chromosome: '1',
+                    chromosome: 'chr1',
                     interval: [200000000, 220000000]
                 },
                 axis: 'top',

--- a/editor/example/doc-examples/link.ts
+++ b/editor/example/doc-examples/link.ts
@@ -19,14 +19,14 @@ export const LINK: GoslingSpec = {
             x: {
                 field: 's1',
                 type: 'genomic',
-                domain: { chromosome: '1' },
+                domain: { chromosome: 'chr1' },
                 axis: 'top'
             },
             xe: { field: 'e1', type: 'genomic' },
             x1: {
                 field: 's2',
                 type: 'genomic',
-                domain: { chromosome: '1' },
+                domain: { chromosome: 'chr1' },
                 axis: 'top'
             },
             x1e: { field: 'e2', type: 'genomic' },

--- a/editor/example/doc-examples/linking-tracks.ts
+++ b/editor/example/doc-examples/linking-tracks.ts
@@ -18,7 +18,7 @@ export const LINKING_TRACKS: GoslingSpec = {
             x: {
                 field: 'position',
                 type: 'genomic',
-                domain: { chromosome: '2' },
+                domain: { chromosome: 'chr2' },
                 axis: 'top',
                 linkingId: 'link1' // assign a linking id
             },
@@ -43,7 +43,7 @@ export const LINKING_TRACKS: GoslingSpec = {
             x: {
                 field: 'position',
                 type: 'genomic',
-                domain: { chromosome: '2' },
+                domain: { chromosome: 'chr2' },
                 axis: 'top',
                 linkingId: 'link1' // assign the same linking id as the first track
             },

--- a/editor/example/doc-examples/overlay-tracks-bar-point.ts
+++ b/editor/example/doc-examples/overlay-tracks-bar-point.ts
@@ -83,7 +83,7 @@ export const OVERLAY_TRACKS_BAR_POINT: GoslingSpec = {
                 field: 'start',
                 type: 'genomic',
                 domain: {
-                    chromosome: '3'
+                    chromosome: 'chr3'
                 },
                 axis: 'top'
             },

--- a/editor/example/doc-examples/overlay-tracks-line-point.ts
+++ b/editor/example/doc-examples/overlay-tracks-line-point.ts
@@ -28,7 +28,7 @@ export const OVERLAY_TRACKS_LINE_POINT: GoslingSpec = {
             x: {
                 field: 'position',
                 type: 'genomic',
-                domain: { chromosome: '1', interval: [1, 3000500] },
+                domain: { chromosome: 'chr1', interval: [1, 3000500] },
                 axis: 'top'
             },
             y: { field: 'peak', type: 'quantitative' },

--- a/editor/example/doc-examples/overlay-tracks-rect-text.ts
+++ b/editor/example/doc-examples/overlay-tracks-rect-text.ts
@@ -110,7 +110,7 @@ export const OVERLAY_TRACKS_RECT_TEXT: GoslingSpec = {
                 field: 'chromStart',
                 type: 'genomic',
                 domain: {
-                    chromosome: '1'
+                    chromosome: 'chr1'
                 },
                 axis: 'top'
             },

--- a/editor/example/doc-examples/rect.ts
+++ b/editor/example/doc-examples/rect.ts
@@ -32,7 +32,7 @@ export const RECT: GoslingSpec = {
                 field: 'chromStart',
                 type: 'genomic',
                 domain: {
-                    chromosome: '1'
+                    chromosome: 'chr1'
                 },
                 axis: 'top'
             },

--- a/editor/example/json-spec/cancer-variant.ts
+++ b/editor/example/json-spec/cancer-variant.ts
@@ -200,7 +200,7 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
                 },
                 {
                     linkingId: 'mid-scale',
-                    xDomain: { chromosome: '1' },
+                    xDomain: { chromosome: 'chr1' },
                     layout: 'linear',
                     tracks: [
                         {
@@ -559,10 +559,10 @@ export const EX_SPEC_CANCER_VARIANT_PROTOTYPE: GoslingSpec = {
             spacing: 100,
             views: [
                 {
-                    ...EX_SPEC_VIEW_PILEUP('bam-1', 450, 310, { chromosome: '1', interval: [205000, 207000] })
+                    ...EX_SPEC_VIEW_PILEUP('bam-1', 450, 310, { chromosome: 'chr1', interval: [205000, 207000] })
                 },
                 {
-                    ...EX_SPEC_VIEW_PILEUP('bam-2', 450, 310, { chromosome: '1', interval: [490000, 496000] })
+                    ...EX_SPEC_VIEW_PILEUP('bam-2', 450, 310, { chromosome: 'chr1', interval: [490000, 496000] })
                 }
             ]
         }

--- a/editor/example/json-spec/circular-overview-linear-detail-views.ts
+++ b/editor/example/json-spec/circular-overview-linear-detail-views.ts
@@ -147,7 +147,7 @@ export const EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL: GoslingSpec = {
                             x: {
                                 field: 'start',
                                 type: 'genomic',
-                                domain: { chromosome: '16' },
+                                domain: { chromosome: 'chr16' },
                                 linkingId: 'detail-2'
                             },
                             xe: { field: 'end', type: 'genomic' },

--- a/editor/example/json-spec/corces.ts
+++ b/editor/example/json-spec/corces.ts
@@ -13,7 +13,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
     views: [
         {
             layout: 'linear',
-            xDomain: { chromosome: '3' },
+            xDomain: { chromosome: 'chr3' },
             centerRadius: 0.8,
             tracks: [
                 {
@@ -75,7 +75,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
             ]
         },
         {
-            xDomain: { chromosome: '3', interval: [52168000, 52890000] },
+            xDomain: { chromosome: 'chr3', interval: [52168000, 52890000] },
             linkingId: 'detail',
             mark: 'bar',
             x: {
@@ -420,7 +420,7 @@ export const EX_SPEC_CORCES_ET_AL: GoslingSpec = {
                 //         field: 'start',
                 //         type: 'genomic',
                 //         linkingId: 'l-h',
-                //         domain: { chromosome: '3', interval: [52450000, 52465000] }
+                //         domain: { chromosome: 'chr3', interval: [52450000, 52465000] }
                 //     },
                 //     xe: { field: 'end', type: 'genomic' },
                 //     color: {

--- a/editor/example/json-spec/gene-annotation.ts
+++ b/editor/example/json-spec/gene-annotation.ts
@@ -19,7 +19,7 @@ const data = {
         { index: 13, name: 'end' }
     ]
 } as DataDeep;
-const domain = undefined; // { chromosome: '3', interval: [52168000, 52890000] };
+const domain = undefined; // { chromosome: 'chr3', interval: [52168000, 52890000] };
 
 export const HiGlass: OverlaidTracks = {
     alignment: 'overlay',
@@ -734,7 +734,7 @@ export const EX_TRACK_GENE_ANNOTATION = {
 
 export const EX_SPEC_GENE_ANNOTATION: GoslingSpec = {
     layout: 'linear',
-    xDomain: { chromosome: '3', interval: [52168000, 52890000] },
+    xDomain: { chromosome: 'chr3', interval: [52168000, 52890000] },
     arrangement: 'horizontal',
     views: [
         {

--- a/editor/example/json-spec/gene-transcript.ts
+++ b/editor/example/json-spec/gene-transcript.ts
@@ -3,7 +3,7 @@ import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 export const EX_SPEC_GENE_TRANSCRIPT: GoslingSpec = {
     alignment: 'overlay',
-    xDomain: { chromosome: '3', interval: [142500000, 143000000] },
+    xDomain: { chromosome: 'chr3', interval: [142500000, 143000000] },
     data: {
         url: GOSLING_PUBLIC_DATA.transcript,
         type: 'beddb',

--- a/editor/example/json-spec/give.ts
+++ b/editor/example/json-spec/give.ts
@@ -38,7 +38,7 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                             x: {
                                 field: 'end',
                                 type: 'genomic',
-                                domain: { chromosome: '17', interval: [200000, 800000] },
+                                domain: { chromosome: 'chr17', interval: [200000, 800000] },
                                 axis: 'top'
                             },
                             size: { value: 7 }
@@ -157,7 +157,7 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                     x: {
                         field: 'chromStart',
                         type: 'genomic',
-                        domain: { chromosome: '17', interval: [20000000, 50000000] }
+                        domain: { chromosome: 'chr17', interval: [20000000, 50000000] }
                     },
                     xe: { field: 'chromEnd', type: 'genomic' },
                     color: { value: 'white' },
@@ -400,7 +400,7 @@ export const EX_SPEC_GIVE: GoslingSpec = {
                             x: {
                                 field: 'end',
                                 type: 'genomic',
-                                domain: { chromosome: '1', interval: [109000000, 112000000] },
+                                domain: { chromosome: 'chr1', interval: [109000000, 112000000] },
                                 axis: 'bottom'
                             },
                             size: { value: 7 }

--- a/editor/example/json-spec/ideograms.ts
+++ b/editor/example/json-spec/ideograms.ts
@@ -86,35 +86,35 @@ export const EX_SPEC_CYTOBANDS: GoslingSpec = {
     arrangement: 'parallel',
     views: [
         {
-            xDomain: { chromosome: '1' },
+            xDomain: { chromosome: 'chr1' },
             tracks: [
                 { ...StackedPeaks, width: 1000 },
                 { ...CytoBands, width: 1000 }
             ]
         },
         {
-            xDomain: { chromosome: '2' },
+            xDomain: { chromosome: 'chr2' },
             tracks: [
                 { ...StackedPeaks, width: 970 },
                 { ...CytoBands, width: 970 }
             ]
         },
         {
-            xDomain: { chromosome: '3' },
+            xDomain: { chromosome: 'chr3' },
             tracks: [
                 { ...StackedPeaks, width: 800 },
                 { ...CytoBands, width: 800 }
             ]
         },
         {
-            xDomain: { chromosome: '4' },
+            xDomain: { chromosome: 'chr4' },
             tracks: [
                 { ...StackedPeaks, width: 770 },
                 { ...CytoBands, width: 770 }
             ]
         },
         {
-            xDomain: { chromosome: '5' },
+            xDomain: { chromosome: 'chr5' },
             tracks: [
                 { ...StackedPeaks, width: 740 },
                 { ...CytoBands, width: 740 }

--- a/editor/example/json-spec/mark-displacement.ts
+++ b/editor/example/json-spec/mark-displacement.ts
@@ -8,11 +8,11 @@ export const EX_SPEC_MARK_DISPLACEMENT: GoslingSpec = {
     // static: true,
     spacing: 1,
     centerRadius: 0.8,
-    xDomain: { chromosome: '17', interval: [43080000, 43120000] },
+    xDomain: { chromosome: 'chr17', interval: [43080000, 43120000] },
     views: [
         EX_SPEC_GENE_TRANSCRIPT,
         {
-            xDomain: { chromosome: '2', interval: [126800000, 127700000] },
+            xDomain: { chromosome: 'chr2', interval: [126800000, 127700000] },
             tracks: [
                 {
                     alignment: 'overlay',

--- a/editor/example/json-spec/matrix-hffc6.ts
+++ b/editor/example/json-spec/matrix-hffc6.ts
@@ -5,7 +5,7 @@ export const EX_SPEC_MATRIX_HFFC6: GoslingSpec = {
     title: 'Matrix Visualization',
     subtitle: 'Comparison of Micro-C and Hi-C for HFFc6 Cells',
     arrangement: 'horizontal',
-    xDomain: { chromosome: '7', interval: [77700000, 81000000] },
+    xDomain: { chromosome: 'chr7', interval: [77700000, 81000000] },
     spacing: 1,
     linkingId: '-',
     views: [

--- a/editor/example/json-spec/mouse-event.ts
+++ b/editor/example/json-spec/mouse-event.ts
@@ -36,7 +36,7 @@ export const BAR: SingleTrack = {
 export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
     title: 'Custom Mouse Events',
     subtitle: 'Customize mouse hovering and range selection events',
-    xDomain: { chromosome: '1' },
+    xDomain: { chromosome: 'chr1' },
     views: [
         {
             tracks: [
@@ -128,7 +128,7 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
             ]
         },
         {
-            xDomain: { chromosome: '3', interval: [52168000, 52890000] },
+            xDomain: { chromosome: 'chr3', interval: [52168000, 52890000] },
             tracks: [
                 {
                     title: 'Group Marks By Gene',

--- a/editor/example/json-spec/pathogenic.ts
+++ b/editor/example/json-spec/pathogenic.ts
@@ -13,7 +13,7 @@ export const allDomains = [
 ];
 
 export const EX_SPEC_PATHOGENIC: GoslingSpec = {
-    xDomain: { chromosome: '3', interval: [10140000, 10160000] },
+    xDomain: { chromosome: 'chr3', interval: [10140000, 10160000] },
     centerRadius: 0.1,
     layout: 'linear',
     spacing: 0,

--- a/editor/example/json-spec/pileup.ts
+++ b/editor/example/json-spec/pileup.ts
@@ -152,5 +152,5 @@ export function EX_SPEC_VIEW_PILEUP(
 export const EX_SPEC_PILEUP: GoslingSpec = {
     title: 'Pileup Track Using BAM Data',
     subtitle: '',
-    ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: '1', interval: [136750, 139450] })
+    ...EX_SPEC_VIEW_PILEUP('bam', 1250, 600, { chromosome: 'chr1', interval: [136750, 139450] })
 };

--- a/editor/example/json-spec/pileup.ts
+++ b/editor/example/json-spec/pileup.ts
@@ -1,10 +1,10 @@
-import type { Domain, DomainGene, GoslingSpec, View } from '@gosling.schema';
+import type { Domain, GoslingSpec, View } from '@gosling.schema';
 
 export function EX_SPEC_VIEW_PILEUP(
     id: string,
     width: number,
     height: number,
-    xDomain: Exclude<Domain, string[] | number[] | DomainGene>
+    xDomain: Exclude<Domain, string[] | number[]>
 ): View {
     const maxInsertSize = 300;
     return {

--- a/editor/example/json-spec/responsive-track-wise-comparison.ts
+++ b/editor/example/json-spec/responsive-track-wise-comparison.ts
@@ -249,7 +249,7 @@ const _gene: (type: 1 | 2, compact?: boolean) => OverlaidTracks = (type, compact
 };
 
 const xDomain: (type: 1 | 2) => DomainChrInterval = type => {
-    if (type === 1) return { chromosome: '12', interval: [10140000, 10210000] };
+    if (type === 1) return { chromosome: 'chr12', interval: [10140000, 10210000] };
     else return { chromosome: '8', interval: [127734000, 127744000] };
 };
 

--- a/editor/example/json-spec/responsive.ts
+++ b/editor/example/json-spec/responsive.ts
@@ -4,7 +4,7 @@ export const EX_SPEC_RESPONSIVE_SEGREGATED_AREA_CHART: GoslingSpec = {
     // title: 'Responsive Visualization',
     // subtitle: 'Resize your browser to see visualization changes...',
     responsiveSize: { width: false, height: true },
-    xDomain: { chromosome: '12', interval: [5000000, 15000000] },
+    xDomain: { chromosome: 'chr12', interval: [5000000, 15000000] },
     views: [
         {
             tracks: [
@@ -78,7 +78,7 @@ const TotalChartSizes = [400, 200]; // [192, 96, 48]; // from the paper below
 export const EX_SPEC_RESPONSIVE_MULTIVEC: GoslingSpec = {
     description: 'Reference: Javed et al. Graphical perception of Multiple Time Series. TVCG 2010.',
     responsiveSize: { width: false, height: true },
-    xDomain: { chromosome: '12', interval: [5000000, 15000000] },
+    xDomain: { chromosome: 'chr12', interval: [5000000, 15000000] },
     views: [
         {
             // layout: 'circular', // 'linear',
@@ -268,7 +268,7 @@ export const EX_SPEC_RESPONSIVE_MULTIVEC: GoslingSpec = {
 export const EX_SPEC_RESPONSIVE_MULTIVEC_CIRCULAR: GoslingSpec = {
     description: 'Reference: Javed et al. Graphical perception of Multiple Time Series. TVCG 2010.',
     responsiveSize: { width: false, height: true },
-    xDomain: { chromosome: '12', interval: [5000000, 15000000] },
+    xDomain: { chromosome: 'chr12', interval: [5000000, 15000000] },
     views: [
         {
             layout: 'circular',
@@ -849,7 +849,7 @@ export const EX_SPEC_RESPONSIVE_COMPARATIVE_VIEWS: GoslingSpec = {
     ],
     views: [
         {
-            xDomain: { chromosome: '12', interval: [5000000, 15000000] },
+            xDomain: { chromosome: 'chr12', interval: [5000000, 15000000] },
             tracks: [
                 {
                     id: 'left',
@@ -901,7 +901,7 @@ export const EX_SPEC_RESPONSIVE_COMPARATIVE_VIEWS: GoslingSpec = {
             ]
         },
         {
-            xDomain: { chromosome: '12', interval: [5000000, 15000000] },
+            xDomain: { chromosome: 'chr12', interval: [5000000, 15000000] },
             tracks: [
                 {
                     id: 'right',

--- a/editor/example/json-spec/sashimi.ts
+++ b/editor/example/json-spec/sashimi.ts
@@ -76,8 +76,8 @@ export const EX_SPEC_SASHIMI: GoslingSpec = {
             ]
         },
         {
-            // xDomain: { chromosome: '10', interval: [27035000, 27150000] },
-            xDomain: { chromosome: '10', interval: [27040527, 27048076] },
+            // xDomain: { chromosome: 'chr10', interval: [27035000, 27150000] },
+            xDomain: { chromosome: 'chr10', interval: [27040527, 27048076] },
             tracks: [
                 {
                     data: {

--- a/editor/example/json-spec/semantic-zoom.ts
+++ b/editor/example/json-spec/semantic-zoom.ts
@@ -212,7 +212,7 @@ export const EX_SPEC_SEMANTIC_ZOOM: GoslingSpec = {
     views: [
         {
             layout: 'linear',
-            xDomain: { chromosome: '1', interval: [3000000, 3000010] },
+            xDomain: { chromosome: 'chr1', interval: [3000000, 3000010] },
             ...EX_TRACK_SEMANTIC_ZOOM.sequence,
             width: 800,
             height: 100
@@ -225,15 +225,15 @@ export const EX_SPEC_SEMANTIC_ZOOM: GoslingSpec = {
         },
         {
             ...EX_SPEC_PATHOGENIC,
-            xDomain: { chromosome: '13', interval: [31500000, 33150000] }
+            xDomain: { chromosome: 'chr13', interval: [31500000, 33150000] }
         },
         {
             ...EX_SPEC_PATHOGENIC,
-            xDomain: { chromosome: '13', interval: [32000000, 32700000] }
+            xDomain: { chromosome: 'chr13', interval: [32000000, 32700000] }
         },
         {
             ...EX_SPEC_PATHOGENIC,
-            xDomain: { chromosome: '13', interval: [32314000, 32402500] }
+            xDomain: { chromosome: 'chr13', interval: [32314000, 32402500] }
         }
     ]
 };
@@ -243,7 +243,7 @@ export const EX_SPEC_SEQUENCE_TRACK: GoslingSpec = {
     views: [
         {
             layout: 'linear',
-            xDomain: { chromosome: '1', interval: [3000000, 3000010] },
+            xDomain: { chromosome: 'chr1', interval: [3000000, 3000010] },
             ...EX_TRACK_SEMANTIC_ZOOM.sequence,
             width: 800,
             height: 100
@@ -256,15 +256,15 @@ export const EX_SPEC_CLINVAR_LOLLIPOP: GoslingSpec = {
     views: [
         {
             ...EX_SPEC_PATHOGENIC,
-            xDomain: { chromosome: '13', interval: [31500000, 33150000] }
+            xDomain: { chromosome: 'chr13', interval: [31500000, 33150000] }
         },
         {
             ...EX_SPEC_PATHOGENIC,
-            xDomain: { chromosome: '13', interval: [32000000, 32700000] }
+            xDomain: { chromosome: 'chr13', interval: [32000000, 32700000] }
         },
         {
             ...EX_SPEC_PATHOGENIC,
-            xDomain: { chromosome: '13', interval: [32314000, 32402500] }
+            xDomain: { chromosome: 'chr13', interval: [32314000, 32402500] }
         }
     ]
 };

--- a/editor/example/json-spec/theme.ts
+++ b/editor/example/json-spec/theme.ts
@@ -29,7 +29,7 @@ export const EX_SPEC_CUSTOM_THEME: GoslingSpec = {
     views: [
         {
             layout: 'linear',
-            xDomain: { chromosome: '3' },
+            xDomain: { chromosome: 'chr3' },
             centerRadius: 0.8,
             tracks: [
                 {
@@ -109,7 +109,7 @@ export const EX_SPEC_CUSTOM_THEME: GoslingSpec = {
             ]
         },
         {
-            xDomain: { chromosome: '3', interval: [52168000, 52890000] },
+            xDomain: { chromosome: 'chr3', interval: [52168000, 52890000] },
             linkingId: 'detail',
             mark: 'bar',
             x: {

--- a/editor/example/json-spec/track-template.ts
+++ b/editor/example/json-spec/track-template.ts
@@ -11,7 +11,7 @@ export const EX_SPEC_TEMPLATE: GoslingSpec = {
     style: { enableSmoothPath: true },
     views: [
         {
-            xDomain: { chromosome: '3', interval: [52168000, 52890000] },
+            xDomain: { chromosome: 'chr3', interval: [52168000, 52890000] },
             tracks: [
                 // {
                 //     data: {
@@ -70,7 +70,7 @@ export const EX_SPEC_TEMPLATE: GoslingSpec = {
             ]
         },
         {
-            xDomain: { chromosome: '1', interval: [77925299, 77925320] },
+            xDomain: { chromosome: 'chr1', interval: [77925299, 77925320] },
             tracks: [
                 {
                     template: 'sequence',
@@ -98,7 +98,7 @@ export const EX_SPEC_TEMPLATE: GoslingSpec = {
             ]
         },
         {
-            xDomain: { chromosome: '1' },
+            xDomain: { chromosome: 'chr1' },
             tracks: [
                 {
                     template: 'ideogram',

--- a/editor/example/json-spec/vertical-band.ts
+++ b/editor/example/json-spec/vertical-band.ts
@@ -2,7 +2,7 @@ import type { GoslingSpec } from 'gosling.js';
 
 export const EX_SPEC_BAND: GoslingSpec = {
     layout: 'linear',
-    xDomain: { chromosome: '1', interval: [103900000, 104100000] },
+    xDomain: { chromosome: 'chr1', interval: [103900000, 104100000] },
     spacing: 0,
     tracks: [
         {

--- a/editor/example/json-spec/visual-encoding.ts
+++ b/editor/example/json-spec/visual-encoding.ts
@@ -7,7 +7,7 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
     layout: 'linear',
     arrangement: 'vertical',
     centerRadius: 0.8,
-    xDomain: { chromosome: '1', interval: [1, 3000500] },
+    xDomain: { chromosome: 'chr1', interval: [1, 3000500] },
     views: [
         {
             tracks: [
@@ -287,7 +287,7 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                     x: {
                         field: 's1',
                         type: 'genomic',
-                        domain: { chromosome: '1', interval: [103900000, 104100000] }
+                        domain: { chromosome: 'chr1', interval: [103900000, 104100000] }
                     },
                     xe: {
                         field: 'e1',
@@ -296,7 +296,7 @@ export const EX_SPEC_VISUAL_ENCODING: GoslingSpec = {
                     x1: {
                         field: 's2',
                         type: 'genomic',
-                        domain: { chromosome: '1' }
+                        domain: { chromosome: 'chr1' }
                     },
                     x1e: {
                         field: 'e2',
@@ -327,7 +327,7 @@ export const EX_SPEC_VISUAL_ENCODING_CIRCULAR: GoslingSpec = {
     arrangement: 'vertical',
     centerRadius: 0.5,
     static: true,
-    xDomain: { chromosome: '1', interval: [1, 3000500] },
+    xDomain: { chromosome: 'chr1', interval: [1, 3000500] },
     views: [
         {
             arrangement: 'horizontal',
@@ -551,7 +551,7 @@ export const EX_SPEC_VISUAL_ENCODING_CIRCULAR: GoslingSpec = {
                             x: {
                                 field: 's1',
                                 type: 'genomic',
-                                domain: { chromosome: '1', interval: [103900000, 104100000] }
+                                domain: { chromosome: 'chr1', interval: [103900000, 104100000] }
                             },
                             xe: {
                                 field: 'e1',
@@ -560,7 +560,7 @@ export const EX_SPEC_VISUAL_ENCODING_CIRCULAR: GoslingSpec = {
                             x1: {
                                 field: 's2',
                                 type: 'genomic',
-                                domain: { chromosome: '1' }
+                                domain: { chromosome: 'chr1' }
                             },
                             x1e: {
                                 field: 'e2',
@@ -636,7 +636,7 @@ export const EX_SPEC_DARK_THEME: GoslingSpec = {
     arrangement: 'vertical',
     centerRadius: 0,
     static: true,
-    xDomain: { chromosome: '1', interval: [1, 3000500] },
+    xDomain: { chromosome: 'chr1', interval: [1, 3000500] },
     views: [
         {
             arrangement: 'horizontal',

--- a/editor/example/json-spec/visual-linking.ts
+++ b/editor/example/json-spec/visual-linking.ts
@@ -15,7 +15,7 @@ export const EX_SPEC_LINKING: GoslingSpec = {
                     spacing: 5,
                     static: true,
                     layout: 'circular',
-                    xDomain: { chromosome: '1' },
+                    xDomain: { chromosome: 'chr1' },
                     alignment: 'overlay',
                     tracks: [
                         { mark: 'bar' },
@@ -42,7 +42,7 @@ export const EX_SPEC_LINKING: GoslingSpec = {
                 },
                 {
                     layout: 'linear',
-                    xDomain: { chromosome: '1' },
+                    xDomain: { chromosome: 'chr1' },
                     alignment: 'overlay',
                     tracks: [
                         { mark: 'bar' },
@@ -71,7 +71,7 @@ export const EX_SPEC_LINKING: GoslingSpec = {
         },
         {
             layout: 'linear',
-            xDomain: { chromosome: '1', interval: [160000000, 200000000] },
+            xDomain: { chromosome: 'chr1', interval: [160000000, 200000000] },
             linkingId: 'detail',
             tracks: [
                 {

--- a/editor/example/spec/corces.ts
+++ b/editor/example/spec/corces.ts
@@ -4,7 +4,7 @@ const width = 400;
 
 const ideogram: View = {
     layout: 'linear',
-    xDomain: { chromosome: '3' },
+    xDomain: { chromosome: 'chr3' },
     centerRadius: 0.8,
     tracks: [
         {
@@ -257,7 +257,7 @@ const spec: GoslingSpec = {
     views: [
         ideogram,
         {
-            xDomain: { chromosome: '3', interval: [52168000, 52890000] },
+            xDomain: { chromosome: 'chr3', interval: [52168000, 52890000] },
             linkingId: 'detail',
             x: {
                 field: 'position',

--- a/editor/example/spec/sashimi.ts
+++ b/editor/example/spec/sashimi.ts
@@ -74,8 +74,8 @@ const spec: GoslingSpec = {
             ]
         },
         {
-            // xDomain: { chromosome: '10', interval: [27035000, 27150000] },
-            xDomain: { chromosome: '10', interval: [27040527, 27048076] },
+            // xDomain: { chromosome: 'chr10', interval: [27035000, 27150000] },
+            xDomain: { chromosome: 'chr10', interval: [27040527, 27048076] },
             tracks: [
                 {
                     data: {

--- a/editor/example/spec/vertical-band.ts
+++ b/editor/example/spec/vertical-band.ts
@@ -49,7 +49,7 @@ const getBetweenLinkTrack = (x: string, xe: string, x1: string, x1e: string): Tr
 
 const spec: GoslingSpec = {
     layout: 'linear',
-    xDomain: { chromosome: '1', interval: [103900000, 104100000] },
+    xDomain: { chromosome: 'chr1', interval: [103900000, 104100000] },
     spacing: 0,
     tracks: [
         getRectTrack('s1', 'e1'),

--- a/editor/example/spec/visual-encoding-circular.ts
+++ b/editor/example/spec/visual-encoding-circular.ts
@@ -206,13 +206,13 @@ const bandView: View = {
             x: {
                 field: 's1',
                 type: 'genomic',
-                domain: { chromosome: '1', interval: [103900000, 104100000] }
+                domain: { chromosome: 'chr1', interval: [103900000, 104100000] }
             },
             xe: { field: 'e1', type: 'genomic' },
             x1: {
                 field: 's2',
                 type: 'genomic',
-                domain: { chromosome: '1' }
+                domain: { chromosome: 'chr1' }
             },
             x1e: { field: 'e2', type: 'genomic' },
             color: { field: 's1', type: 'nominal' },
@@ -254,7 +254,7 @@ const spec: GoslingSpec = {
     arrangement: 'vertical',
     centerRadius: 0.5,
     static: true,
-    xDomain: { chromosome: '1', interval: [1, 3000500] },
+    xDomain: { chromosome: 'chr1', interval: [1, 3000500] },
     views: [row1, row2, row3, row4, barView2]
 };
 

--- a/editor/example/spec/visual-encoding.ts
+++ b/editor/example/spec/visual-encoding.ts
@@ -206,13 +206,13 @@ const bandView: View = {
             x: {
                 field: 's1',
                 type: 'genomic',
-                domain: { chromosome: '1', interval: [103900000, 104100000] }
+                domain: { chromosome: 'chr1', interval: [103900000, 104100000] }
             },
             xe: { field: 'e1', type: 'genomic' },
             x1: {
                 field: 's2',
                 type: 'genomic',
-                domain: { chromosome: '1' }
+                domain: { chromosome: 'chr1' }
             },
             x1e: { field: 'e2', type: 'genomic' },
             color: { field: 's1', type: 'nominal' },
@@ -231,7 +231,7 @@ const spec: GoslingSpec = {
     layout: 'linear',
     arrangement: 'vertical',
     centerRadius: 0.8,
-    xDomain: { chromosome: '1', interval: [1, 3000500] },
+    xDomain: { chromosome: 'chr1', interval: [1, 3000500] },
     views: [heatmapView, barView, stackView, lineView, pointView, pointView2, areaView2, barView2, bandView]
 };
 

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -332,61 +332,6 @@
       },
       "type": "array"
     },
-    "Chromosome": {
-      "enum": [
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11",
-        "12",
-        "13",
-        "14",
-        "15",
-        "16",
-        "17",
-        "18",
-        "19",
-        "20",
-        "21",
-        "22",
-        "X",
-        "Y",
-        "M",
-        "chr1",
-        "chr2",
-        "chr3",
-        "chr4",
-        "chr5",
-        "chr6",
-        "chr7",
-        "chr8",
-        "chr9",
-        "chr10",
-        "chr11",
-        "chr12",
-        "chr13",
-        "chr14",
-        "chr15",
-        "chr16",
-        "chr17",
-        "chr18",
-        "chr19",
-        "chr20",
-        "chr21",
-        "chr22",
-        "chrX",
-        "chrY",
-        "chrM"
-      ],
-      "type": "string"
-    },
     "Color": {
       "additionalProperties": false,
       "properties": {
@@ -845,7 +790,7 @@
       "additionalProperties": false,
       "properties": {
         "chromosome": {
-          "$ref": "#/definitions/Chromosome"
+          "type": "string"
         }
       },
       "required": [
@@ -857,8 +802,8 @@
       "additionalProperties": false,
       "properties": {
         "chromosome": {
-          "$ref": "#/definitions/Chromosome",
-          "description": "If specified, only showing a certain interval in a chromosome."
+          "description": "If specified, only showing a certain interval in a chromosome.",
+          "type": "string"
         },
         "interval": {
           "items": {
@@ -872,30 +817,6 @@
       "required": [
         "chromosome",
         "interval"
-      ],
-      "type": "object"
-    },
-    "DomainGene": {
-      "additionalProperties": false,
-      "properties": {
-        "gene": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "items": {
-                "type": "string"
-              },
-              "maxItems": 2,
-              "minItems": 2,
-              "type": "array"
-            }
-          ]
-        }
-      },
-      "required": [
-        "gene"
       ],
       "type": "object"
     },
@@ -1047,9 +968,6 @@
         },
         {
           "$ref": "#/definitions/DomainChr"
-        },
-        {
-          "$ref": "#/definitions/DomainGene"
         }
       ]
     },

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -486,61 +486,6 @@
       },
       "type": "array"
     },
-    "Chromosome": {
-      "enum": [
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11",
-        "12",
-        "13",
-        "14",
-        "15",
-        "16",
-        "17",
-        "18",
-        "19",
-        "20",
-        "21",
-        "22",
-        "X",
-        "Y",
-        "M",
-        "chr1",
-        "chr2",
-        "chr3",
-        "chr4",
-        "chr5",
-        "chr6",
-        "chr7",
-        "chr8",
-        "chr9",
-        "chr10",
-        "chr11",
-        "chr12",
-        "chr13",
-        "chr14",
-        "chr15",
-        "chr16",
-        "chr17",
-        "chr18",
-        "chr19",
-        "chr20",
-        "chr21",
-        "chr22",
-        "chrX",
-        "chrY",
-        "chrM"
-      ],
-      "type": "string"
-    },
     "CustomChannelDef": {
       "additionalProperties": false,
       "description": "Definition of custom channels used in a track template.",
@@ -839,7 +784,7 @@
       "additionalProperties": false,
       "properties": {
         "chromosome": {
-          "$ref": "#/definitions/Chromosome"
+          "type": "string"
         }
       },
       "required": [
@@ -851,8 +796,8 @@
       "additionalProperties": false,
       "properties": {
         "chromosome": {
-          "$ref": "#/definitions/Chromosome",
-          "description": "If specified, only showing a certain interval in a chromosome."
+          "description": "If specified, only showing a certain interval in a chromosome.",
+          "type": "string"
         },
         "interval": {
           "items": {
@@ -866,30 +811,6 @@
       "required": [
         "chromosome",
         "interval"
-      ],
-      "type": "object"
-    },
-    "DomainGene": {
-      "additionalProperties": false,
-      "properties": {
-        "gene": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "items": {
-                "type": "string"
-              },
-              "maxItems": 2,
-              "minItems": 2,
-              "type": "array"
-            }
-          ]
-        }
-      },
-      "required": [
-        "gene"
       ],
       "type": "object"
     },
@@ -963,9 +884,6 @@
         },
         {
           "$ref": "#/definitions/DomainChr"
-        },
-        {
-          "$ref": "#/definitions/DomainGene"
         }
       ]
     },

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -3,7 +3,7 @@ import type { TrackMouseEventData } from '@gosling.schema';
 import type { HiGlassApi } from './higlass-component-wrapper';
 import type { HiGlassSpec } from './higlass.schema';
 import { subscribe, unsubscribe } from './pubsub';
-import { GET_CHROM_SIZES, parseGenomicPosition } from './utils/assembly';
+import { computeChromSizes, GenomicPositionHelper } from './utils/assembly';
 import type { CompleteThemeDeep } from './utils/theme';
 import { traverseViewsInViewConfig } from './utils/view-config';
 
@@ -95,25 +95,13 @@ export function createApi(
         zoomTo: (viewId, position, padding = 0, duration = 1000) => {
             // Accepted input: 'chr1' or 'chr1:1-1000'
             const assembly = getTrack(viewId)?.spec.assembly;
-            const chromInfo = GET_CHROM_SIZES(assembly);
-            const parsed = parseGenomicPosition(position);
-            const { chromosome: chr } = parsed;
-            let { start, end } = parsed;
-            if (!chr || !chromInfo.interval[chr]) {
-                console.warn('Chromosome name is not valid', chr);
-                return;
-            }
-            if (typeof start === 'undefined' || typeof end === 'undefined') {
-                // if only a chromosome name is specified, zoom to the extent of the chromosome
-                [start, end] = [0, chromInfo.size[chr]];
-            }
-            const chrOffset = chromInfo.interval[chr][0];
-            const relativeGenomicPositions = [start + chrOffset - padding, end + chrOffset + padding];
-            hg.api.zoomTo(viewId, ...relativeGenomicPositions, ...relativeGenomicPositions, duration);
+            const manager = GenomicPositionHelper.fromString(position);
+            const absCoordinates = manager.toAbsoluteCoordinates(assembly, padding);
+            hg.api.zoomTo(viewId, ...absCoordinates, ...absCoordinates, duration);
         },
         zoomToExtent: (viewId, duration = 1000) => {
             const assembly = getTrack(viewId)?.spec.assembly;
-            const [start, end] = [0, GET_CHROM_SIZES(assembly).total];
+            const [start, end] = [0, computeChromSizes(assembly).total];
             hg.api.zoomTo(viewId, start, end, start, end, duration);
         },
         zoomToGene: (viewId, gene, padding = 0, duration = 1000) => {

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -99,7 +99,7 @@ export function createApi(
             const parsed = parseGenomicPosition(position);
             const { chromosome: chr } = parsed;
             let { start, end } = parsed;
-            if (!chr || chromInfo.interval[chr]) {
+            if (!chr || !chromInfo.interval[chr]) {
                 console.warn('Chromosome name is not valid', chr);
                 return;
             }

--- a/src/core/gosling.schema.guards.test.ts
+++ b/src/core/gosling.schema.guards.test.ts
@@ -49,7 +49,7 @@ describe('Type Guard', () => {
                         stroke: { value: 'red' }
                     }
                 ],
-                x: { field: 'Basepair_start', type: 'genomic', domain: { chromosome: '3' }, axis: 'none' },
+                x: { field: 'Basepair_start', type: 'genomic', domain: { chromosome: 'chr3' }, axis: 'none' },
                 xe: { field: 'Basepair_stop', type: 'genomic' },
                 stroke: { value: 'black' },
                 strokeWidth: { value: 1 },

--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -6,7 +6,6 @@ import type {
     DomainChr,
     DomainInterval,
     DomainChrInterval,
-    DomainGene,
     Style,
     Track,
     SingleTrack,
@@ -106,10 +105,6 @@ export function IsDomainInterval(domain: Domain): domain is DomainInterval {
 
 export function IsDomainChrInterval(domain: Domain): domain is DomainChrInterval {
     return 'chromosome' in domain && 'interval' in domain;
-}
-
-export function IsDomainGene(domain: Domain): domain is DomainGene {
-    return 'gene' in domain;
 }
 
 export function IsTrackStyle(track: Style | undefined): track is Style {

--- a/src/core/gosling.schema.test.ts
+++ b/src/core/gosling.schema.test.ts
@@ -16,7 +16,7 @@ describe('gosling schema should be checked correctly', () => {
         expect(IsChannelValue({ value: 1 } as Channel)).toBe(true);
         expect(IsChannelValue({ field: 'x' } as Channel)).toBe(false);
         expect(IsDataDeepTileset({ type: 'multivec', url: '', column: 'c', row: 'r', value: 'v' })).toBe(true);
-        expect(IsDomainChrInterval({ chromosome: '1', interval: [1, 1000] })).toBe(true);
+        expect(IsDomainChrInterval({ chromosome: 'chr1', interval: [1, 1000] })).toBe(true);
     });
 
     it('Should properly retreive values from data with channel spec', () => {

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -1,5 +1,3 @@
-import type { Chromosome } from './utils/chrom-size';
-
 /* ----------------------------- ROOT SPEC ----------------------------- */
 export type GoslingSpec =
     | (RootSpecWithSingleView & ResponsiveSpecOfSingleView)
@@ -766,18 +764,18 @@ export interface ChannelValue {
 export type AxisPosition = 'none' | 'top' | 'bottom' | 'left' | 'right';
 export type FieldType = 'genomic' | 'nominal' | 'quantitative';
 export type ValueExtent = string[] | number[];
-export type GenomicDomain = DomainInterval | DomainChrInterval | DomainChr | DomainGene;
+export type GenomicDomain = DomainInterval | DomainChrInterval | DomainChr;
 export type Domain = ValueExtent | GenomicDomain;
 export type Range = ValueExtent | PredefinedColors;
 export type PredefinedColors = 'viridis' | 'grey' | 'spectral' | 'warm' | 'cividis' | 'bupu' | 'rdbu' | 'hot' | 'pink';
 
 export interface DomainChr {
     // For showing a certain chromosome
-    chromosome: Chromosome;
+    chromosome: string;
 }
 export interface DomainChrInterval {
     /** If specified, only showing a certain interval in a chromosome. */
-    chromosome: Chromosome;
+    chromosome: string;
     interval: [number, number];
 }
 export interface DomainInterval {

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -782,11 +782,6 @@ export interface DomainInterval {
     /** Show a certain interval within entire chromosome */
     interval: [number, number]; // This is consistent to HiGlass's initXDomain and initYDomain.
 }
-export interface DomainGene {
-    // For showing genes
-    // TODO: Not supported yet
-    gene: string | [string, string];
-}
 
 export type Aggregate = 'max' | 'min' | 'mean' | 'bin' | 'count';
 export type BinAggregate = 'mean' | 'sum';

--- a/src/core/higlass-model.test.ts
+++ b/src/core/higlass-model.test.ts
@@ -12,7 +12,7 @@ describe('Should produce higlass model correctly', () => {
     it('Should set domain correctly', () => {
         const higlass = new HiGlassModel();
         higlass.addDefaultView(uuid.v1());
-        higlass.setDomain({ chromosome: '2' }, { chromosome: '2', interval: [100, 200] });
+        higlass.setDomain({ chromosome: 'chr2' }, { chromosome: 'chr2', interval: [100, 200] });
         expect(higlass.spec().views?.[0].initialXDomain).toEqual([
             GET_CHROM_SIZES().interval['chr2'][0] + 1,
             GET_CHROM_SIZES().interval['chr2'][1]

--- a/src/core/higlass-model.test.ts
+++ b/src/core/higlass-model.test.ts
@@ -1,6 +1,6 @@
 import * as uuid from 'uuid';
 import { HiGlassModel } from './higlass-model';
-import { GET_CHROM_SIZES } from './utils/assembly';
+import { computeChromSizes } from './utils/assembly';
 import { getTheme } from './utils/theme';
 
 describe('Should produce higlass model correctly', () => {
@@ -14,11 +14,11 @@ describe('Should produce higlass model correctly', () => {
         higlass.addDefaultView(uuid.v1());
         higlass.setDomain({ chromosome: 'chr2' }, { chromosome: 'chr2', interval: [100, 200] });
         expect(higlass.spec().views?.[0].initialXDomain).toEqual([
-            GET_CHROM_SIZES().interval['chr2'][0] + 1,
-            GET_CHROM_SIZES().interval['chr2'][1]
+            computeChromSizes().interval['chr2'][0] + 1,
+            computeChromSizes().interval['chr2'][1]
         ]);
-        expect(higlass.spec().views?.[0].initialYDomain?.[0]).toEqual(GET_CHROM_SIZES().interval['chr2'][0] + 100);
-        expect(higlass.spec().views?.[0].initialYDomain?.[1]).toEqual(GET_CHROM_SIZES().interval['chr2'][0] + 200);
+        expect(higlass.spec().views?.[0].initialYDomain?.[0]).toEqual(computeChromSizes().interval['chr2'][0] + 100);
+        expect(higlass.spec().views?.[0].initialYDomain?.[1]).toEqual(computeChromSizes().interval['chr2'][0] + 200);
     });
 
     it('Should add brush correctly', () => {

--- a/src/core/higlass-model.ts
+++ b/src/core/higlass-model.ts
@@ -5,7 +5,7 @@ import type { Assembly, AxisPosition, Domain, Orientation, ZoomLimits } from './
 import { getNumericDomain } from './utils/scales';
 import type { RelativePosition } from './utils/bounding-box';
 import { validateSpec } from './utils/validate';
-import { getAutoCompleteId, GET_CHROM_SIZES } from './utils/assembly';
+import { getAutoCompleteId, computeChromSizes } from './utils/assembly';
 import type { CompleteThemeDeep } from './utils/theme';
 import exampleHg from './example/hg-view-config-1';
 import { insertItemToArray } from './utils/array';
@@ -31,8 +31,8 @@ const getViewTemplate = (assembly?: Assembly) => {
             gallery: [],
             whole: []
         },
-        initialXDomain: [0, GET_CHROM_SIZES(assembly).total],
-        initialYDomain: [0, GET_CHROM_SIZES(assembly).total],
+        initialXDomain: [0, computeChromSizes(assembly).total],
+        initialYDomain: [0, computeChromSizes(assembly).total],
         zoomFixed: false
     };
 };
@@ -81,7 +81,7 @@ export class HiGlassModel {
 
     public setAssembly(assembly?: Assembly) {
         this.assembly = assembly;
-        this.setChromInfoPath(GET_CHROM_SIZES(this.assembly).path);
+        this.setChromInfoPath(computeChromSizes(this.assembly).path);
         return this;
     }
 

--- a/src/core/utils/assembly.test.ts
+++ b/src/core/utils/assembly.test.ts
@@ -1,22 +1,29 @@
-import { getChromInterval, getChromTotalSize, getRelativeGenomicPosition, GET_CHROM_SIZES } from './assembly';
+import type { Assembly } from '@gosling.schema';
+import {
+    getChromInterval,
+    getChromTotalSize,
+    getRelativeGenomicPosition,
+    computeChromSizes,
+    GenomicPositionHelper
+} from './assembly';
 import { CHROM_SIZE_HG38 } from './chrom-size';
 
 describe('Assembly', () => {
     it('Missing chromosome name', () => {
-        expect(GET_CHROM_SIZES().total).toBeDefined();
+        expect(computeChromSizes().total).toBeDefined();
     });
     it('hg38 ChromSizes', () => {
-        expect(GET_CHROM_SIZES('hg38').size).toEqual(CHROM_SIZE_HG38);
+        expect(computeChromSizes('hg38').size).toEqual(CHROM_SIZE_HG38);
     });
     it('Custom ChromSizes', () => {
         expect(
-            GET_CHROM_SIZES([
+            computeChromSizes([
                 ['foo', 100],
                 ['bar', 1000]
             ]).total
         ).toEqual(1100);
         // use default assembly instead when the size is zero
-        expect(GET_CHROM_SIZES([]).total).toEqual(GET_CHROM_SIZES().total);
+        expect(computeChromSizes([]).total).toEqual(computeChromSizes().total);
     });
     it('Chromosome total size calculation', () => {
         expect(getChromTotalSize({ 1: 1, 2: 999 })).toEqual(1000);
@@ -29,10 +36,33 @@ describe('Assembly', () => {
             chromosome: 'chr2',
             position: 1
         });
-        const outOfPos = GET_CHROM_SIZES('hg38').total + 1;
+        const outOfPos = computeChromSizes('hg38').total + 1;
         expect(getRelativeGenomicPosition(outOfPos, 'hg38')).toEqual({
             chromosome: 'unknown',
             position: outOfPos
         });
+    });
+    it('Parse string to genomic positions', () => {
+        const customChromSizes: Assembly = [
+            ['foo', 10],
+            ['bar', 20],
+            ['barz', 30]
+        ];
+        const padding = 10;
+
+        // edge cases
+        expect(() => GenomicPositionHelper.fromString('random-string').toAbsoluteCoordinates()).toThrow(); // not existing chromosome names
+        expect(GenomicPositionHelper.fromString('bar:12').toAbsoluteCoordinates(customChromSizes)).toEqual([11, 30]); // only start position
+        expect(GenomicPositionHelper.fromString('foo:100-200').toAbsoluteCoordinates(customChromSizes)).toEqual([
+            100, 200
+        ]); // out of range
+
+        // single chromosome
+        expect(GenomicPositionHelper.fromString('foo').toAbsoluteCoordinates(customChromSizes)).toEqual([1, 10]);
+        expect(GenomicPositionHelper.fromString('foo:1-2').toAbsoluteCoordinates(customChromSizes)).toEqual([1, 2]);
+        expect(GenomicPositionHelper.fromString('foo').toAbsoluteCoordinates(customChromSizes, padding)).toEqual([
+            1 - padding,
+            10 + padding
+        ]); // padding
     });
 });

--- a/src/core/utils/assembly.ts
+++ b/src/core/utils/assembly.ts
@@ -159,7 +159,7 @@ export function getChromTotalSize(chromSize: { [k: string]: number }) {
 export function parseGenomicPosition(position: string): { chromosome: string; start?: number; end?: number } {
     const [chromosome, intervalString] = position.split(':');
     if (intervalString) {
-        const [start, end] = intervalString.split('-').map(s => +s.replaceAll(',', ''));
+        const [start, end] = intervalString.split('-').map(s => +s.replace(/,/g, ''));
         // only return if both are valid
         if (!Number.isNaN(start) && !Number.isNaN(end)) {
             return { chromosome, start, end };

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -22,7 +22,7 @@ import {
     IsOneOfFilter,
     IsRangeFilter
 } from '../gosling.schema.guards';
-import { GET_CHROM_SIZES } from './assembly';
+import { computeChromSizes } from './assembly';
 // import Logging from './log';
 
 /**
@@ -386,7 +386,7 @@ export function splitExon(split: ExonSplitTransform, data: Datum[], assembly: As
                 splitted.forEach((s, i) => {
                     let newValue: string | number = s;
                     if (type === 'genomic') {
-                        newValue = GET_CHROM_SIZES(assembly).interval[d[chrField]][0] + +s;
+                        newValue = computeChromSizes(assembly).interval[d[chrField]][0] + +s;
                     }
                     if (!newRows[i]) {
                         // No row exist, so create one.

--- a/src/core/utils/scales.test.ts
+++ b/src/core/utils/scales.test.ts
@@ -2,11 +2,22 @@ import { getNumericDomain, shareScaleAcrossTracks } from './scales';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';
 import { getTheme } from './theme';
+import type { ChromSizes } from '@gosling.schema';
 
 describe('Genomic domain', () => {
     it('With Chromosome', () => {
-        expect(getNumericDomain({ chromosome: '1' })).toEqual(getNumericDomain({ chromosome: '1' }));
-        expect(getNumericDomain({ chromosome: '1' })).toEqual(getNumericDomain({ chromosome: 'chr1' }));
+        expect(getNumericDomain({ chromosome: '1' }, 'hg38')).toBeUndefined();
+        expect(getNumericDomain({ interval: [1, 100] })).toEqual([1, 100]);
+        expect(getNumericDomain({ chromosome: 'chr1', interval: [1, 100] })).toEqual([1, 100]);
+
+        const customAssembly: ChromSizes = [
+            ['foo', 10],
+            ['bar', 20],
+            ['barz', 30]
+        ];
+        expect(getNumericDomain({ chromosome: 'fool' }, customAssembly)).toBeUndefined();
+        expect(getNumericDomain({ chromosome: 'bar' }, customAssembly)).toEqual([11, 30]);
+        expect(getNumericDomain({ chromosome: 'barz', interval: [1, 2] }, customAssembly)).toEqual([31, 32]);
     });
 });
 

--- a/src/core/utils/scales.ts
+++ b/src/core/utils/scales.ts
@@ -2,29 +2,27 @@ import type { GoslingTrackModel } from '../gosling-track-model';
 import type { Assembly, Domain } from '../gosling.schema';
 import { SUPPORTED_CHANNELS } from '../mark';
 import { IsDomainChr, IsDomainInterval, IsDomainChrInterval, IsChannelDeep } from '../gosling.schema.guards';
-import { GET_CHROM_SIZES } from './assembly';
+import { computeChromSizes } from './assembly';
 
 /**
  * Get a numeric domain based on a domain specification.
  * For example, domain: { chromosome: 'chr1', interval: [1, 300,000] } => domain: [1, 300,000]
  */
 export function getNumericDomain(domain: Domain, assembly?: Assembly) {
+    const chromInterval = computeChromSizes(assembly).interval;
     if ('chromosome' in domain) {
-        const isThereChr = Object.keys(GET_CHROM_SIZES(assembly).interval).find(chr => chr === domain.chromosome);
+        const isThereChr = Object.keys(chromInterval).find(chr => chr === domain.chromosome);
         if (!isThereChr) {
             // Did not find the chromosome, so return early.
             return;
         }
     }
     if (IsDomainChr(domain)) {
-        return [
-            GET_CHROM_SIZES(assembly).interval[domain.chromosome][0] + 1,
-            GET_CHROM_SIZES(assembly).interval[domain.chromosome][1]
-        ];
+        return [chromInterval[domain.chromosome][0] + 1, chromInterval[domain.chromosome][1]];
     } else if (IsDomainInterval(domain)) {
         return domain.interval;
     } else if (IsDomainChrInterval(domain)) {
-        const chrStart = GET_CHROM_SIZES(assembly).interval[domain.chromosome][0];
+        const chrStart = chromInterval[domain.chromosome][0];
         const [start, end] = domain.interval;
         return [chrStart + start, chrStart + end];
     }

--- a/src/core/utils/scales.ts
+++ b/src/core/utils/scales.ts
@@ -1,43 +1,32 @@
 import type { GoslingTrackModel } from '../gosling-track-model';
 import type { Assembly, Domain } from '../gosling.schema';
 import { SUPPORTED_CHANNELS } from '../mark';
-import {
-    IsDomainChr,
-    IsDomainInterval,
-    IsDomainChrInterval,
-    IsDomainGene,
-    IsChannelDeep
-} from '../gosling.schema.guards';
+import { IsDomainChr, IsDomainInterval, IsDomainChrInterval, IsChannelDeep } from '../gosling.schema.guards';
 import { GET_CHROM_SIZES } from './assembly';
-import type { Chromosome } from './chrom-size';
 
 /**
  * Get a numeric domain based on a domain specification.
- * For example, domain: { chromosome: '1', interval: [1, 300,000] } => domain: [1, 300,000]
+ * For example, domain: { chromosome: 'chr1', interval: [1, 300,000] } => domain: [1, 300,000]
  */
 export function getNumericDomain(domain: Domain, assembly?: Assembly) {
     if ('chromosome' in domain) {
-        if (domain.chromosome.includes('chr')) {
-            domain.chromosome = domain.chromosome.replace('chr', '') as Chromosome;
-        }
-        if (!Object.keys(GET_CHROM_SIZES(assembly).interval).find(chr => chr === `chr${domain.chromosome}`)) {
-            // we did not find any, so use '1' by default
-            domain.chromosome = '1';
+        const isThereChr = Object.keys(GET_CHROM_SIZES(assembly).interval).find(chr => chr === domain.chromosome);
+        if (!isThereChr) {
+            // Did not find the chromosome, so return early.
+            return;
         }
     }
     if (IsDomainChr(domain)) {
         return [
-            GET_CHROM_SIZES(assembly).interval[`chr${domain.chromosome}`][0] + 1,
-            GET_CHROM_SIZES(assembly).interval[`chr${domain.chromosome}`][1]
+            GET_CHROM_SIZES(assembly).interval[domain.chromosome][0] + 1,
+            GET_CHROM_SIZES(assembly).interval[domain.chromosome][1]
         ];
     } else if (IsDomainInterval(domain)) {
         return domain.interval;
     } else if (IsDomainChrInterval(domain)) {
-        const chrStart = GET_CHROM_SIZES(assembly).interval[`chr${domain.chromosome}`][0];
+        const chrStart = GET_CHROM_SIZES(assembly).interval[domain.chromosome][0];
         const [start, end] = domain.interval;
         return [chrStart + start, chrStart + end];
-    } else if (IsDomainGene(domain)) {
-        // TODO: Not supported yet
     }
 }
 

--- a/src/data-fetchers/bam/bam-data-fetcher.ts
+++ b/src/data-fetchers/bam/bam-data-fetcher.ts
@@ -8,7 +8,7 @@ import Worker from './bam-worker.ts?worker&inline';
 import type { BamData, Assembly } from '@gosling.schema';
 import type { ModuleThread } from 'threads';
 import type { WorkerApi, TilesetInfo, Tiles, Segment, SegmentWithMate, Junction } from './bam-worker';
-import { GET_CHROM_SIZES } from '../../core/utils/assembly';
+import { computeChromSizes } from '../../core/utils/assembly';
 
 const DEBOUNCE_TIME = 200;
 
@@ -30,7 +30,7 @@ class BamDataFetcher {
         this.toFetch = new Set();
         const { url, indexUrl, assembly, ...options } = config;
         this.worker = spawn<WorkerApi>(new Worker()).then(async worker => {
-            const chromSizes = Object.entries(GET_CHROM_SIZES(assembly).size);
+            const chromSizes = Object.entries(computeChromSizes(assembly).size);
             await worker.init(this.uid, { url, indexUrl }, chromSizes, options);
             return worker;
         });

--- a/src/data-fetchers/bigwig/bigwig-data-fetcher.ts
+++ b/src/data-fetchers/bigwig/bigwig-data-fetcher.ts
@@ -4,7 +4,7 @@
  */
 import { BigWig } from '@gmod/bbi';
 import type { Assembly, BigWigData } from '@gosling.schema';
-import { GET_CHROM_SIZES } from '../../core/utils/assembly';
+import { computeChromSizes } from '../../core/utils/assembly';
 import { CommonDataConfig, RemoteFile } from '../utils';
 
 import type { Feature } from '@gmod/bbi';
@@ -57,13 +57,13 @@ function BigWigDataFetcher(HGC: import('@higlass/types').HGC, dataConfig: BigWig
             this.dataPromises = [];
 
             // Prepare chromosome interval information
-            const chromosomeSizes = GET_CHROM_SIZES(this.assembly).size;
+            const chromosomeSizes = computeChromSizes(this.assembly).size;
 
             const chromosomeCumPositions: ChromInfo['cumPositions'] = [];
             const chromosomePositions: Record<string, ChromInfo['cumPositions'][number]> = {};
             let prevEndPosition = 0;
 
-            Object.keys(GET_CHROM_SIZES(this.assembly).size).forEach((chrStr, i) => {
+            Object.keys(computeChromSizes(this.assembly).size).forEach((chrStr, i) => {
                 const positionInfo = {
                     id: i,
                     chr: chrStr,
@@ -73,7 +73,7 @@ function BigWigDataFetcher(HGC: import('@higlass/types').HGC, dataConfig: BigWig
                 chromosomeCumPositions.push(positionInfo);
                 chromosomePositions[chrStr] = positionInfo;
 
-                prevEndPosition += GET_CHROM_SIZES(this.assembly).size[chrStr];
+                prevEndPosition += computeChromSizes(this.assembly).size[chrStr];
             });
             this.chromSizes = {
                 chrToAbs: (chrom, chromPos) => this.chromSizes.chrPositions[chrom].pos + chromPos,

--- a/src/data-fetchers/csv/csv-data-fetcher.ts
+++ b/src/data-fetchers/csv/csv-data-fetcher.ts
@@ -1,5 +1,5 @@
 import { dsvFormat as d3dsvFormat } from 'd3-dsv';
-import { GET_CHROM_SIZES } from '../../core/utils/assembly';
+import { computeChromSizes } from '../../core/utils/assembly';
 import { sampleSize } from 'lodash-es';
 import type { Assembly, CsvData, FilterTransform } from '@gosling.schema';
 import { filterData } from '../../core/utils/data-transform';
@@ -38,12 +38,12 @@ function CsvDataFetcher(HGC: any, ...args: any): any {
             }
 
             // Prepare chromosome interval information
-            const chromosomeSizes: { [k: string]: number } = GET_CHROM_SIZES(this.assembly).size;
+            const chromosomeSizes: { [k: string]: number } = computeChromSizes(this.assembly).size;
             const chromosomeCumPositions: { id: number; chr: string; pos: number }[] = [];
             const chromosomePositions: { [k: string]: { id: number; chr: string; pos: number } } = {};
             let prevEndPosition = 0;
 
-            Object.keys(GET_CHROM_SIZES(this.assembly).size).forEach((chrStr, i) => {
+            Object.keys(computeChromSizes(this.assembly).size).forEach((chrStr, i) => {
                 const positionInfo = {
                     id: i,
                     chr: chrStr,
@@ -53,7 +53,7 @@ function CsvDataFetcher(HGC: any, ...args: any): any {
                 chromosomeCumPositions.push(positionInfo);
                 chromosomePositions[chrStr] = positionInfo;
 
-                prevEndPosition += GET_CHROM_SIZES(this.assembly).size[chrStr];
+                prevEndPosition += computeChromSizes(this.assembly).size[chrStr];
             });
             this.chromSizes = {
                 chrToAbs: (chrom: string, chromPos: number) => this.chromSizes.chrPositions[chrom].pos + chromPos,
@@ -107,7 +107,7 @@ function CsvDataFetcher(HGC: any, ...args: any): any {
                                                 this.assembly,
                                                 chromosomePrefix
                                             );
-                                            row[g] = GET_CHROM_SIZES(this.assembly).interval[chrName][0] + +row[g];
+                                            row[g] = computeChromSizes(this.assembly).interval[chrName][0] + +row[g];
                                         } else {
                                             // In this case, we use the genomic position as it is w/o adding the cumulative length of chr.
                                             // So, nothing to do additionally.
@@ -131,7 +131,7 @@ function CsvDataFetcher(HGC: any, ...args: any): any {
                                             this.assembly,
                                             chromosomePrefix
                                         );
-                                        row[g] = GET_CHROM_SIZES(this.assembly).interval[chrName][0] + +row[g];
+                                        row[g] = computeChromSizes(this.assembly).interval[chrName][0] + +row[g];
                                     } else {
                                         // In this case, we use the genomic position as it is w/o adding the cumulative length of chr.
                                         // So, nothing to do additionally.

--- a/src/data-fetchers/json/json-data-fetcher.ts
+++ b/src/data-fetchers/json/json-data-fetcher.ts
@@ -1,4 +1,4 @@
-import { GET_CHROM_SIZES } from '../../core/utils/assembly';
+import { computeChromSizes } from '../../core/utils/assembly';
 import { sampleSize } from 'lodash-es';
 import type { Assembly, JsonData } from '@gosling.schema';
 import { CommonDataConfig, filterUsingGenoPos, sanitizeChrName } from '../utils';
@@ -33,12 +33,12 @@ function JsonDataFetcher(HGC: any, ...args: any): any {
             }
 
             // Prepare chromosome interval information
-            const chromosomeSizes: { [k: string]: number } = GET_CHROM_SIZES(this.assembly).size;
+            const chromosomeSizes: { [k: string]: number } = computeChromSizes(this.assembly).size;
             const chromosomeCumPositions: { id: number; chr: string; pos: number }[] = [];
             const chromosomePositions: { [k: string]: { id: number; chr: string; pos: number } } = {};
             let prevEndPosition = 0;
 
-            Object.keys(GET_CHROM_SIZES(this.assembly).size).forEach((chrStr, i) => {
+            Object.keys(computeChromSizes(this.assembly).size).forEach((chrStr, i) => {
                 const positionInfo = {
                     id: i,
                     chr: chrStr,
@@ -48,7 +48,7 @@ function JsonDataFetcher(HGC: any, ...args: any): any {
                 chromosomeCumPositions.push(positionInfo);
                 chromosomePositions[chrStr] = positionInfo;
 
-                prevEndPosition += GET_CHROM_SIZES(this.assembly).size[chrStr];
+                prevEndPosition += computeChromSizes(this.assembly).size[chrStr];
             });
             this.chromSizes = {
                 chrToAbs: (chrom: string, chromPos: number) => this.chromSizes.chrPositions[chrom].pos + chromPos,
@@ -70,7 +70,7 @@ function JsonDataFetcher(HGC: any, ...args: any): any {
                         }
                         try {
                             const chrName = sanitizeChrName(row[chromosomeField], this.assembly);
-                            row[g] = GET_CHROM_SIZES(this.assembly).interval[chrName][0] + +row[g];
+                            row[g] = computeChromSizes(this.assembly).interval[chrName][0] + +row[g];
                         } catch (e) {
                             // genomic position did not parse properly
                             successfullyGotChrInfo = false;

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -5,7 +5,7 @@
 import { spawn } from 'threads';
 import Worker from './vcf-worker.ts?worker&inline';
 
-import { GET_CHROM_SIZES } from '../../core/utils/assembly';
+import { computeChromSizes } from '../../core/utils/assembly';
 
 import type { ModuleThread } from 'threads';
 import type { Assembly, VcfData } from '../../core/gosling.schema';
@@ -29,7 +29,7 @@ class VcfDataFetcher {
         this.toFetch = new Set();
         const { url, indexUrl, assembly, ...options } = config;
         this.worker = spawn<WorkerApi>(new Worker()).then(async worker => {
-            const chromSizes = Object.entries(GET_CHROM_SIZES(assembly).size);
+            const chromSizes = Object.entries(computeChromSizes(assembly).size);
             await worker.init(this.uid, { url, indexUrl }, chromSizes, options);
             return worker;
         });

--- a/src/gosling-genomic-axis/axis-track.ts
+++ b/src/gosling-genomic-axis/axis-track.ts
@@ -5,7 +5,7 @@ import type * as PIXI from 'pixi.js';
 import RBush from 'rbush';
 import { scaleLinear } from 'd3-scale';
 import { format, precisionPrefix, formatPrefix } from 'd3-format';
-import { GET_CHROM_SIZES } from '../core/utils/assembly';
+import { computeChromSizes } from '../core/utils/assembly';
 import { cartesianToPolar } from '../core/utils/polar';
 import { getTextStyle } from '../core/utils/text-style';
 import { definePluginTrack } from '../core/utils/define-plugin-track';
@@ -200,15 +200,15 @@ const factory: PluginTrackFactory<AxisTrackOptions> = (HGC, context, options) =>
 
             const assembly = this.options.assembly;
             const chrPositions: { [k: string]: ChrPosInfo } = {};
-            const chromLengths: { [k: string]: number } = { ...GET_CHROM_SIZES(assembly).size };
+            const chromLengths: { [k: string]: number } = { ...computeChromSizes(assembly).size };
             const cumPositions: ChrPosInfo[] = [];
 
-            Object.keys(GET_CHROM_SIZES(assembly).size).forEach(k => {
-                chrPositions[k] = { chr: k, pos: GET_CHROM_SIZES(assembly).size[k] };
+            Object.keys(computeChromSizes(assembly).size).forEach(k => {
+                chrPositions[k] = { chr: k, pos: computeChromSizes(assembly).size[k] };
             });
 
-            Object.keys(GET_CHROM_SIZES(assembly).interval).forEach(k => {
-                cumPositions.push({ chr: k, pos: GET_CHROM_SIZES(assembly).interval[k][0] });
+            Object.keys(computeChromSizes(assembly).interval).forEach(k => {
+                cumPositions.push({ chr: k, pos: computeChromSizes(assembly).interval[k][0] });
             });
 
             this.chromInfo = { chrPositions, chromLengths, cumPositions };


### PR DESCRIPTION
Fix #793

## Change List
 - Change the type of `chromosome` to `string` so that any custom chromosome names can be used.
 - Removes some magics about handling chromosome names which were really unnecessary.
 - Change all demo examples that used chromosome names without the "chr" prefix.

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [x] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
