### PR TITLE
fix: latest gosling version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "gosling.js",
     "author": "Sehi L'Yi",
-    "version": "0.9.21",
+    "version": "0.9.22",
     "license": "MIT",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Use the latest gosling version in the exported html

Fix #798