### PR TITLE
refactor: register bam & vcf data-fetchers with HiGlass

### DIFF
--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -32,8 +32,10 @@ import type {
     BamData,
     Range,
     TemplateTrack,
-    MouseEventsDeep
+    MouseEventsDeep,
+    DataTransform
 } from './gosling.schema';
+import type { BamDataFetcher, VcfDataFetcher } from '../data-fetchers';
 import { SUPPORTED_CHANNELS } from './mark';
 import { isArray } from 'lodash-es';
 import {
@@ -61,12 +63,24 @@ export const PREDEFINED_COLOR_STR_MAP: { [k: string]: (t: number) => string } = 
     pink: interpolateRdPu
 };
 
+export function isObject(x: unknown): x is Record<PropertyKey, unknown> {
+    return typeof x === 'object' && x !== null;
+}
+
+export function isTabularDataFetcher(dataFetcher: unknown): dataFetcher is BamDataFetcher | VcfDataFetcher {
+    return isObject(dataFetcher) && 'getTabularData' in dataFetcher;
+}
+
+export function hasDataTransform(spec: SingleTrack | OverlaidTrack, type: DataTransform['type']) {
+    return (spec.dataTransform ?? []).some(d => d.type === type);
+}
+
 /**
  * This returns an array of color strings that can be assigned to HiGlass' option, `colorRange`
  */
 export function getHiGlassColorRange(colorStr = 'viridis', step = 100) {
     const interpolate = PREDEFINED_COLOR_STR_MAP[colorStr] ?? PREDEFINED_COLOR_STR_MAP['viridis'];
-    return [...Array(step)].map((v, i) => interpolate((1 / step) * i));
+    return [...Array(step)].map((_, i) => interpolate((1 / step) * i));
 }
 
 export function IsFlatTracks(_: SingleView): _ is FlatTracks {

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -1,11 +1,11 @@
 // @ts-ignore
-import { default as higlassRegister } from 'higlass-register';
+import higlassRegister from 'higlass-register';
 // @ts-ignore
 import { TextTrack } from 'higlass-text';
 import { AxisTrack } from '../gosling-genomic-axis';
 import { BrushTrack } from '../gosling-brush';
-import { BigWigDataFetcher, CsvDataFetcher, JsonDataFetcher } from '../data-fetchers';
 import { GoslingTrack } from '../gosling-track/index';
+import * as dataFetchers from '../data-fetchers';
 
 let once = false;
 
@@ -67,12 +67,10 @@ export function init() {
     /**
      * Register data fetchers to HiGlassComponent
      */
-    higlassRegister({ dataFetcher: CsvDataFetcher, config: CsvDataFetcher.config }, { pluginType: 'dataFetcher' });
-    higlassRegister({ dataFetcher: JsonDataFetcher, config: JsonDataFetcher.config }, { pluginType: 'dataFetcher' });
-    higlassRegister(
-        { dataFetcher: BigWigDataFetcher, config: BigWigDataFetcher.config },
-        { pluginType: 'dataFetcher' }
-    );
+    for (const dataFetcher of Object.values(dataFetchers)) {
+        const { config } = dataFetcher;
+        higlassRegister({ dataFetcher, config }, { pluginType: 'dataFetcher' });
+    }
 
     once = true;
 }

--- a/src/data-fetchers/bam/bam-data-fetcher.ts
+++ b/src/data-fetchers/bam/bam-data-fetcher.ts
@@ -13,6 +13,7 @@ import { GET_CHROM_SIZES } from '../../core/utils/assembly';
 const DEBOUNCE_TIME = 200;
 
 class BamDataFetcher {
+    static config = { type: 'bam' };
     dataConfig = {}; // required for higlass
     uid: string;
     fetchTimeout?: ReturnType<typeof setTimeout>;

--- a/src/data-fetchers/bam/bam-data-fetcher.ts
+++ b/src/data-fetchers/bam/bam-data-fetcher.ts
@@ -19,6 +19,8 @@ class BamDataFetcher {
     fetchTimeout?: ReturnType<typeof setTimeout>;
     toFetch: Set<string>;
 
+    MAX_TILE_WIDTH: 2e4 = 2e4;
+
     private worker: Promise<ModuleThread<WorkerApi>>;
 
     // This is set by us but is accessed in `fetchTilesDebounced`

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -20,6 +20,8 @@ class VcfDataFetcher {
     prevRequestTime: number;
     track?: any;
 
+    MAX_TILE_WIDTH = undefined;
+
     private toFetch: Set<string>;
     private fetchTimeout?: ReturnType<typeof setTimeout>;
     private worker: Promise<ModuleThread<WorkerApi>>;

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -20,8 +20,6 @@ class VcfDataFetcher {
     prevRequestTime: number;
     track?: any;
 
-    MAX_TILE_WIDTH = undefined;
-
     private toFetch: Set<string>;
     private fetchTimeout?: ReturnType<typeof setTimeout>;
     private worker: Promise<ModuleThread<WorkerApi>>;

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -14,6 +14,7 @@ import type { WorkerApi, TilesetInfo, Tile } from './vcf-worker';
 const DEBOUNCE_TIME = 200;
 
 class VcfDataFetcher {
+    static config = { type: 'vcf' };
     dataConfig = {}; // required for higlass
     uid: string;
     prevRequestTime: number;

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -506,21 +506,25 @@ function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
             if (isTabularDataFetcher(this.dataFetcher)) {
                 const tiles = HGC.utils.trackUtils.calculate1DVisibleTiles(this.tilesetInfo, this._xScale);
 
+                // determine max tile size
+                let maxTileWith = Number.MAX_SAFE_INTEGER;
+                if ('MAX_TILE_WIDTH' in this.dataFetcher) {
+                    maxTileWith = this.dataFetcher.MAX_TILE_WIDTH;
+                }
+                if (typeof this.tilesetInfo.max_tile_width === 'number') {
+                    maxTileWith = this.tilesetInfo.max_tile_width;
+                }
+
                 for (const tile of tiles) {
                     const { tileWidth } = this.getTilePosAndDimensions(
                         tile[0],
                         [tile[1], tile[1]],
                         this.tilesetInfo.tile_size
                     );
-
-                    // base pairs
-                    const DEFAULT_MAX_TILE_WIDTH = this.dataFetcher?.MAX_TILE_WIDTH ?? Number.MAX_SAFE_INTEGER;
-
-                    if (tileWidth > (this.tilesetInfo.max_tile_width || DEFAULT_MAX_TILE_WIDTH)) {
-                        this.forceDraw();
+                    this.forceDraw();
+                    if (tileWidth > maxTileWith) {
                         return;
                     }
-                    this.forceDraw();
                 }
 
                 this.setVisibleTiles(tiles);

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -3,15 +3,7 @@ import PubSub from 'pubsub-js';
 import * as uuid from 'uuid';
 import { isEqual, sampleSize, uniqBy } from 'lodash-es';
 import type { ScaleLinear } from 'd3-scale';
-import type {
-    SingleTrack,
-    OverlaidTrack,
-    Datum,
-    EventStyle,
-    GenomicPosition,
-    Assembly,
-    DataTransform
-} from '@gosling.schema';
+import type { SingleTrack, OverlaidTrack, Datum, EventStyle, GenomicPosition, Assembly } from '@gosling.schema';
 import type { CompleteThemeDeep } from '../core/utils/theme';
 import { drawMark, drawPostEmbellishment, drawPreEmbellishment } from '../core/mark';
 import { GoslingTrackModel } from '../core/gosling-track-model';
@@ -35,7 +27,14 @@ import { getTabularData } from './data-abstraction';
 import { publish } from '../core/pubsub';
 import { getRelativeGenomicPosition } from '../core/utils/assembly';
 import { getTextStyle } from '../core/utils/text-style';
-import { Is2DTrack, IsChannelDeep, IsMouseEventsDeep, IsXAxis } from '../core/gosling.schema.guards';
+import {
+    Is2DTrack,
+    IsChannelDeep,
+    IsMouseEventsDeep,
+    IsXAxis,
+    isTabularDataFetcher,
+    hasDataTransform
+} from '../core/gosling.schema.guards';
 import { HIGLASS_AXIS_SIZE } from '../core/higlass-model';
 import type { MouseEventData } from '../gosling-mouse-event/mouse-event-model';
 import { flatArrayToPairArray } from '../core/utils/array';
@@ -64,18 +63,6 @@ interface GoslingTrackOption {
     spec: SingleTrack | OverlaidTrack;
     showMousePosition: boolean;
     theme: CompleteThemeDeep;
-}
-
-function isObject(x: unknown): x is Record<PropertyKey, unknown> {
-    return typeof x === 'object' || x !== null;
-}
-
-function isTabularDataFetcher(dataFetcher: unknown): dataFetcher is BamDataFetcher | VcfDataFetcher {
-    return isObject(dataFetcher) && 'getTabularData' in dataFetcher;
-}
-
-function hasDataTransform(spec: SingleTrack | OverlaidTrack, type: DataTransform['type']) {
-    return (spec.dataTransform ?? []).some(d => d.type === type);
 }
 
 /**


### PR DESCRIPTION
The `bam` and `vcf` data-loaders can now registered like others in `higlass-register` (since we don't need to intialize the Worker modules as of ). This PR refactors Gosling internals to register these data fetchers within `init()`.

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
