### PR TITLE
fix: fix `displace` transform on non-higlass data

### DIFF
--- a/src/core/mark/area.ts
+++ b/src/core/mark/area.ts
@@ -4,11 +4,12 @@ import { min as d3min, max as d3max, group } from 'd3-array';
 import { IsStackedMark, getValueUsingChannel } from '../gosling.schema.guards';
 import { cartesianToPolar } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
+import type { Tile } from '@higlass/services';
 
 /**
  * Draw area marks
  */
-export function drawArea(HGC: import('@higlass/types').HGC, trackInfo: any, tile: any, model: GoslingTrackModel) {
+export function drawArea(HGC: import('@higlass/types').HGC, trackInfo: any, tile: Tile, model: GoslingTrackModel) {
     /* track spec */
     const spec = model.spec();
 
@@ -18,7 +19,7 @@ export function drawArea(HGC: import('@higlass/types').HGC, trackInfo: any, tile
     /* track size */
     const [trackWidth, trackHeight] = trackInfo.dimensions;
     const tileSize = trackInfo.tilesetInfo.tile_size;
-    const { tileX } = trackInfo.getTilePosAndDimensions(tile.gos.zoomLevel, tile.gos.tilePos, tileSize);
+    const { tileX } = trackInfo.getTilePosAndDimensions(tile.tileData.zoomLevel, tile.tileData.tilePos, tileSize);
 
     /* circular parameters */
     const circular = spec.layout === 'circular';

--- a/src/core/mark/area.ts
+++ b/src/core/mark/area.ts
@@ -4,7 +4,7 @@ import { min as d3min, max as d3max, group } from 'd3-array';
 import { IsStackedMark, getValueUsingChannel } from '../gosling.schema.guards';
 import { cartesianToPolar } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
-import type { Tile } from '@higlass/services';
+import type { Tile } from '../../gosling-track/gosling-track';
 
 /**
  * Draw area marks

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -5,6 +5,7 @@ import type { CompleteThemeDeep } from '../utils/theme';
 import { scaleLinear } from 'd3-scale';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import { getTextStyle } from '../utils/text-style';
+import type { Tile } from '@higlass/services';
 
 const EXTENT_TICK_SIZE = 8;
 const TICK_SIZE = 6;
@@ -15,21 +16,21 @@ const TICK_SIZE = 6;
 export function drawLinearYAxis(
     HGC: { libraries: { PIXI: typeof import('pixi.js') } },
     trackInfo: any,
-    tile: any,
-    gos: GoslingTrackModel,
+    tile: Tile,
+    model: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>
 ) {
-    const spec = gos.spec();
+    const spec = model.spec();
     const CIRCULAR = spec.layout === 'circular';
-    const yDomain = gos.getChannelDomainArray('y');
-    const yRange = gos.getChannelRangeArray('y');
+    const yDomain = model.getChannelDomainArray('y');
+    const yRange = model.getChannelRangeArray('y');
 
     if (CIRCULAR) {
         // Wrong function call, this is for linear tracks!
         return;
     }
 
-    if (!gos.isShowYAxis() || !yDomain || !yRange) {
+    if (!model.isShowYAxis() || !yDomain || !yRange) {
         // We do not need to draw a y-axis
         return;
     }
@@ -39,7 +40,7 @@ export function drawLinearYAxis(
     const [tx, ty] = trackInfo.position;
 
     /* row separation */
-    const rowCategories: string[] = (gos.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
+    const rowCategories: string[] = (model.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
     const rowHeight = th / rowCategories.length;
 
     if (rowHeight <= 20) {
@@ -48,7 +49,7 @@ export function drawLinearYAxis(
     }
 
     /* Axis components */
-    const yChannel = gos.spec().y;
+    const yChannel = model.spec().y;
     const isLeft = IsChannelDeep(yChannel) && 'axis' in yChannel && yChannel.axis === 'right' ? false : true; // Right position only if explicitly specified
     const yScale = scaleLinear()
         .domain(yDomain as number[])
@@ -64,7 +65,7 @@ export function drawLinearYAxis(
         //     return;
         // }
 
-        const rowPosition = gos.encodedValue('row', category);
+        const rowPosition = model.encodedValue('row', category);
         const dx = isLeft ? tx : tx + tw;
         const dy = ty + rowPosition;
 
@@ -137,21 +138,21 @@ export function drawLinearYAxis(
 export function drawCircularYAxis(
     HGC: import('@higlass/types').HGC,
     trackInfo: any,
-    tile: any,
-    gos: GoslingTrackModel,
+    tile: Tile,
+    model: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>
 ) {
-    const spec = gos.spec();
+    const spec = model.spec();
     const CIRCULAR = spec.layout === 'circular';
-    const yDomain = gos.getChannelDomainArray('y');
-    const yRange = gos.getChannelRangeArray('y');
+    const yDomain = model.getChannelDomainArray('y');
+    const yRange = model.getChannelRangeArray('y');
 
     if (!CIRCULAR) {
         // Wrong function call, this is for circular tracks.
         return;
     }
 
-    if (!gos.isShowYAxis() || !yDomain || !yRange) {
+    if (!model.isShowYAxis() || !yDomain || !yRange) {
         // We do not need to draw a y-axis
         return;
     }
@@ -169,7 +170,7 @@ export function drawCircularYAxis(
     const cy = th / 2.0;
 
     /* row separation */
-    const rowCategories: string[] = (gos.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
+    const rowCategories: string[] = (model.getChannelDomainArray('row') as string[]) ?? ['___SINGLE_ROW___'];
     const rowHeight = th / rowCategories.length;
 
     if ((rowHeight / th) * trackRingSize <= 20) {
@@ -178,7 +179,7 @@ export function drawCircularYAxis(
     }
 
     /* Axis components */
-    const yChannel = gos.spec().y;
+    const yChannel = model.spec().y;
     const isLeft = IsChannelDeep(yChannel) && 'axis' in yChannel && yChannel.axis === 'right' ? false : true; // Right position only if explicitly specified
     const yScale = scaleLinear()
         .domain(yDomain as number[])
@@ -194,7 +195,7 @@ export function drawCircularYAxis(
         //     return;
         // }
 
-        const rowPosition = gos.encodedValue('row', category);
+        const rowPosition = model.encodedValue('row', category);
 
         /* Axis Baseline */
         const innerR = trackOuterRadius - ((rowPosition + rowHeight) / th) * trackRingSize;

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -5,7 +5,7 @@ import type { CompleteThemeDeep } from '../utils/theme';
 import { scaleLinear } from 'd3-scale';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import { getTextStyle } from '../utils/text-style';
-import type { Tile } from '@higlass/services';
+import type { Tile } from '../../gosling-track/gosling-track';
 
 const EXTENT_TICK_SIZE = 8;
 const TICK_SIZE = 6;

--- a/src/core/mark/background.ts
+++ b/src/core/mark/background.ts
@@ -1,4 +1,4 @@
-import type { Tile } from '@higlass/services';
+import type { Tile } from '../../gosling-track/gosling-track';
 import { isUndefined } from 'lodash-es';
 import type { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';

--- a/src/core/mark/background.ts
+++ b/src/core/mark/background.ts
@@ -1,3 +1,4 @@
+import type { Tile } from '@higlass/services';
 import { isUndefined } from 'lodash-es';
 import type { GoslingTrackModel } from '../gosling-track-model';
 import { IsChannelDeep } from '../gosling.schema.guards';

--- a/src/core/mark/background.ts
+++ b/src/core/mark/background.ts
@@ -7,7 +7,7 @@ import type { CompleteThemeDeep } from '../utils/theme';
 export function drawBackground(
     HGC: import('@higlass/types').HGC,
     trackInfo: any,
-    tile: any,
+    tile: Tile,
     tm: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>
 ) {

--- a/src/core/mark/bar.test.ts
+++ b/src/core/mark/bar.test.ts
@@ -3,6 +3,7 @@ import type { SingleTrack } from '@gosling.schema';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { getTheme } from '../utils/theme';
 import { drawBar } from './bar';
+import { Tile } from '@higlass/services';
 
 describe('mark:= bar', () => {
     it('x:=G, y:=V, ye:=V', () => {
@@ -25,7 +26,7 @@ describe('mark:= bar', () => {
             }
         };
         const tileMock = { graphics: new PIXI.Graphics(), tileData: {} };
-        drawBar(trackMock, tileMock as any, model);
+        drawBar(trackMock, tileMock as Tile, model);
         // Should render all data (https://github.com/gosling-lang/gosling.js/pull/791)
         expect(model.getMouseEventModel().size()).toEqual(d.length);
     });

--- a/src/core/mark/bar.test.ts
+++ b/src/core/mark/bar.test.ts
@@ -3,7 +3,7 @@ import type { SingleTrack } from '@gosling.schema';
 import { GoslingTrackModel } from '../gosling-track-model';
 import { getTheme } from '../utils/theme';
 import { drawBar } from './bar';
-import { Tile } from '@higlass/services';
+import type { Tile } from '@higlass/services';
 
 describe('mark:= bar', () => {
     it('x:=G, y:=V, ye:=V', () => {

--- a/src/core/mark/bar.test.ts
+++ b/src/core/mark/bar.test.ts
@@ -24,8 +24,8 @@ describe('mark:= bar', () => {
                 return { tileX: null, tileWidth: null };
             }
         };
-        const tileMock = { graphics: new PIXI.Graphics(), gos: {} };
-        drawBar(trackMock, tileMock, model);
+        const tileMock = { graphics: new PIXI.Graphics(), tileData: {} };
+        drawBar(trackMock, tileMock as any, model);
         // Should render all data (https://github.com/gosling-lang/gosling.js/pull/791)
         expect(model.getMouseEventModel().size()).toEqual(d.length);
     });

--- a/src/core/mark/bar.ts
+++ b/src/core/mark/bar.ts
@@ -5,8 +5,9 @@ import type { PIXIVisualProperty } from '../visual-property.schema';
 import { IsChannelDeep, IsStackedMark, getValueUsingChannel } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
+import type { Tile } from '@higlass/services';
 
-export function drawBar(trackInfo: any, tile: any, model: GoslingTrackModel) {
+export function drawBar(trackInfo: any, tile: Tile, model: GoslingTrackModel) {
     /* track spec */
     const spec = model.spec();
 
@@ -21,7 +22,11 @@ export function drawBar(trackInfo: any, tile: any, model: GoslingTrackModel) {
     /* track size */
     const [trackWidth, trackHeight] = trackInfo.dimensions;
     const tileSize = trackInfo.tilesetInfo.tile_size;
-    const { tileX, tileWidth } = trackInfo.getTilePosAndDimensions(tile.gos.zoomLevel, tile.gos.tilePos, tileSize);
+    const { tileX, tileWidth } = trackInfo.getTilePosAndDimensions(
+        tile.tileData.zoomLevel,
+        tile.tileData.tilePos,
+        tileSize
+    );
     const zoomLevel =
         (model.getChannelScale('x') as any).invert(trackWidth) - (model.getChannelScale('x') as any).invert(0);
 

--- a/src/core/mark/bar.ts
+++ b/src/core/mark/bar.ts
@@ -5,7 +5,7 @@ import type { PIXIVisualProperty } from '../visual-property.schema';
 import { IsChannelDeep, IsStackedMark, getValueUsingChannel } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
-import type { Tile } from '@higlass/services';
+import type { Tile } from '../../gosling-track/gosling-track';
 
 export function drawBar(trackInfo: any, tile: Tile, model: GoslingTrackModel) {
     /* track spec */

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -1,4 +1,5 @@
 import type { GoslingTrackModel } from '../gosling-track-model';
+import type { Tile } from '../../gosling-track/gosling-track';
 import { drawPoint } from './point';
 import { drawLine } from './line';
 import { drawBar } from './bar';
@@ -19,7 +20,6 @@ import { drawBackground } from './background';
 import type { CompleteThemeDeep } from '../utils/theme';
 import { Is2DTrack, IsVerticalRule } from '../gosling.schema.guards';
 import { drawBetweenLink } from './betweenLink';
-import type { Tile } from '@higlass/services';
 
 /**
  * Visual channels currently supported for visual encoding.

--- a/src/core/mark/index.ts
+++ b/src/core/mark/index.ts
@@ -19,6 +19,7 @@ import { drawBackground } from './background';
 import type { CompleteThemeDeep } from '../utils/theme';
 import { Is2DTrack, IsVerticalRule } from '../gosling.schema.guards';
 import { drawBetweenLink } from './betweenLink';
+import type { Tile } from '@higlass/services';
 
 /**
  * Visual channels currently supported for visual encoding.
@@ -49,7 +50,7 @@ export const RESOLUTION = 4;
 /**
  * Draw a track based on the track specification in a Gosling grammar.
  */
-export function drawMark(HGC: import('@higlass/types').HGC, trackInfo: any, tile: any, model: GoslingTrackModel) {
+export function drawMark(HGC: import('@higlass/types').HGC, trackInfo: any, tile: Tile, model: GoslingTrackModel) {
     if (!HGC || !trackInfo || !tile) {
         // We did not receive parameters correctly.
         return;
@@ -133,7 +134,7 @@ export function drawMark(HGC: import('@higlass/types').HGC, trackInfo: any, tile
 export function drawPreEmbellishment(
     HGC: import('@higlass/types').HGC,
     trackInfo: any,
-    tile: any,
+    tile: Tile,
     model: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>
 ) {
@@ -179,7 +180,7 @@ export function drawPreEmbellishment(
 export function drawPostEmbellishment(
     HGC: import('@higlass/types').HGC,
     trackInfo: any,
-    tile: any,
+    tile: Tile,
     model: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>
 ) {

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -5,6 +5,7 @@ import type { CompleteThemeDeep } from '../utils/theme';
 import type { Dimension } from '../utils/position';
 import { scaleLinear, ScaleLinear } from 'd3-scale';
 import { getTextStyle } from '../utils/text-style';
+import type { Tile } from '@higlass/services';
 
 // Just the libraries necesssary fro this module
 type Libraries = Pick<typeof import('@higlass/libraries'), 'PIXI' | 'd3Selection' | 'd3Drag'>;
@@ -14,8 +15,8 @@ type LegendOffset = { offsetRight: number };
 export function drawColorLegend(
     HGC: { libraries: Libraries },
     trackInfo: any,
-    tile: any,
-    tm: GoslingTrackModel,
+    tile: Tile,
+    model: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>
 ) {
     if (!trackInfo.gLegend) {
@@ -25,16 +26,16 @@ export function drawColorLegend(
 
     trackInfo.gLegend.selectAll('.brush').remove();
 
-    const spec = tm.spec();
+    const spec = model.spec();
     const offset: LegendOffset = { offsetRight: 0 };
 
     if (IsChannelDeep(spec.color) && spec.color.legend) {
         switch (spec.color.type) {
             case 'nominal':
-                drawColorLegendCategories(HGC, trackInfo, tile, tm, theme);
+                drawColorLegendCategories(HGC, trackInfo, tile, model, theme);
                 break;
             case 'quantitative':
-                drawColorLegendQuantitative(HGC, trackInfo, tile, tm, theme, 'color', offset);
+                drawColorLegendQuantitative(HGC, trackInfo, tile, model, theme, 'color', offset);
                 break;
         }
     }
@@ -42,7 +43,7 @@ export function drawColorLegend(
     if (IsChannelDeep(spec.stroke) && spec.stroke.legend) {
         switch (spec.stroke.type) {
             case 'quantitative':
-                drawColorLegendQuantitative(HGC, trackInfo, tile, tm, theme, 'stroke', offset);
+                drawColorLegendQuantitative(HGC, trackInfo, tile, model, theme, 'stroke', offset);
                 break;
         }
     }
@@ -51,13 +52,13 @@ export function drawColorLegend(
 export function drawColorLegendQuantitative(
     HGC: { libraries: Libraries },
     trackInfo: any,
-    tile: any,
-    tm: GoslingTrackModel,
+    tile: Tile,
+    model: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>,
     channelKey: 'color' | 'stroke',
     offset: LegendOffset
 ) {
-    const spec = tm.spec();
+    const spec = model.spec();
 
     const channel = spec[channelKey];
     if (!IsChannelDeep(channel) || channel.type !== 'quantitative' || !channel.legend) {
@@ -82,8 +83,8 @@ export function drawColorLegendQuantitative(
     const legendY = trackY + 1;
 
     /* Legend Components */
-    const colorScale = tm.getChannelScale(channelKey);
-    const colorDomain = tm.getChannelDomainArray(channelKey);
+    const colorScale = model.getChannelScale(channelKey);
+    const colorDomain = model.getChannelDomainArray(channelKey);
 
     if (!colorScale || !colorDomain) {
         // We do not have enough information for creating a color legend
@@ -291,7 +292,7 @@ export function drawColorLegendQuantitative(
 export function drawColorLegendCategories(
     HGC: { libraries: Libraries },
     trackInfo: any,
-    tile: any,
+    tile: Tile,
     tm: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>
 ) {
@@ -447,7 +448,7 @@ export function drawColorLegendCategories(
 export function drawRowLegend(
     HGC: { libraries: Libraries },
     trackInfo: any,
-    tile: any,
+    tile: Tile,
     tm: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>
 ) {

--- a/src/core/mark/legend.ts
+++ b/src/core/mark/legend.ts
@@ -5,7 +5,7 @@ import type { CompleteThemeDeep } from '../utils/theme';
 import type { Dimension } from '../utils/position';
 import { scaleLinear, ScaleLinear } from 'd3-scale';
 import { getTextStyle } from '../utils/text-style';
-import type { Tile } from '@higlass/services';
+import type { Tile } from '../../gosling-track/gosling-track';
 
 // Just the libraries necesssary fro this module
 type Libraries = Pick<typeof import('@higlass/libraries'), 'PIXI' | 'd3Selection' | 'd3Drag'>;

--- a/src/core/mark/outline-circular.ts
+++ b/src/core/mark/outline-circular.ts
@@ -7,7 +7,7 @@ import type { CompleteThemeDeep } from '../utils/theme';
 export function drawCircularOutlines(
     HGC: import('@higlass/types').HGC,
     trackInfo: any,
-    tile: any,
+    tile: Tile,
     tm: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>
 ) {

--- a/src/core/mark/outline-circular.ts
+++ b/src/core/mark/outline-circular.ts
@@ -3,7 +3,7 @@ import { IsChannelDeep } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
 import type { CompleteThemeDeep } from '../utils/theme';
-import type { Tile } from '@higlass/services';
+import type { Tile } from '../../gosling-track/gosling-track';
 
 export function drawCircularOutlines(
     HGC: import('@higlass/types').HGC,

--- a/src/core/mark/outline-circular.ts
+++ b/src/core/mark/outline-circular.ts
@@ -3,6 +3,7 @@ import { IsChannelDeep } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
 import type { CompleteThemeDeep } from '../utils/theme';
+import type { Tile } from '@higlass/services';
 
 export function drawCircularOutlines(
     HGC: import('@higlass/types').HGC,

--- a/src/core/mark/rect.ts
+++ b/src/core/mark/rect.ts
@@ -3,8 +3,9 @@ import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import type { PIXIVisualProperty } from '../visual-property.schema';
 import colorToHex from '../utils/color-to-hex';
 import { IsChannelDeep } from '../gosling.schema.guards';
+import type { Tile } from '@higlass/services';
 
-export function drawRect(HGC: import('@higlass/types').HGC, trackInfo: any, tile: any, model: GoslingTrackModel) {
+export function drawRect(HGC: import('@higlass/types').HGC, track: any, tile: Tile, model: GoslingTrackModel) {
     /* track spec */
     const spec = model.spec();
 
@@ -12,9 +13,13 @@ export function drawRect(HGC: import('@higlass/types').HGC, trackInfo: any, tile
     const data = model.data();
 
     /* track size */
-    const [trackWidth, trackHeight] = trackInfo.dimensions;
-    const tileSize = trackInfo.tilesetInfo.tile_size;
-    const { tileX, tileWidth } = trackInfo.getTilePosAndDimensions(tile.gos.zoomLevel, tile.gos.tilePos, tileSize);
+    const [trackWidth, trackHeight] = track.dimensions;
+    const tileSize = track.tilesetInfo.tile_size;
+    const { tileX, tileWidth } = track.getTilePosAndDimensions(
+        tile.tileData.zoomLevel,
+        tile.tileData.tilePos,
+        tileSize
+    );
 
     /* circular parameters */
     const circular = spec.layout === 'circular';
@@ -27,7 +32,7 @@ export function drawRect(HGC: import('@higlass/types').HGC, trackInfo: any, tile
     const cy = trackHeight / 2.0;
 
     /* genomic scale */
-    const xScale = trackInfo._xScale;
+    const xScale = track._xScale;
     const tileUnitWidth = xScale(tileX + tileWidth / tileSize) - xScale(tileX);
 
     /* row separation */
@@ -54,7 +59,7 @@ export function drawRect(HGC: import('@higlass/types').HGC, trackInfo: any, tile
 
         const alphaTransition = model.markVisibility(d, {
             width: rectWidth,
-            zoomLevel: trackInfo._xScale.invert(trackWidth) - trackInfo._xScale.invert(0)
+            zoomLevel: track._xScale.invert(trackWidth) - track._xScale.invert(0)
         });
         const actualOpacity = Math.min(alphaTransition, opacity);
 

--- a/src/core/mark/rect.ts
+++ b/src/core/mark/rect.ts
@@ -3,7 +3,7 @@ import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import type { PIXIVisualProperty } from '../visual-property.schema';
 import colorToHex from '../utils/color-to-hex';
 import { IsChannelDeep } from '../gosling.schema.guards';
-import type { Tile } from '@higlass/services';
+import type { Tile } from '../../gosling-track/gosling-track';
 
 export function drawRect(HGC: import('@higlass/types').HGC, track: any, tile: Tile, model: GoslingTrackModel) {
     /* track spec */

--- a/src/core/mark/rule.ts
+++ b/src/core/mark/rule.ts
@@ -4,7 +4,7 @@ import { getValueUsingChannel } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
 
-export function drawRule(HGC: import('@higlass/types').HGC, trackInfo: any, tile: any, model: GoslingTrackModel) {
+export function drawRule(HGC: import('@higlass/types').HGC, trackInfo: any, tile: Tile, model: GoslingTrackModel) {
     /* track spec */
     const spec = model.spec();
 

--- a/src/core/mark/rule.ts
+++ b/src/core/mark/rule.ts
@@ -3,6 +3,7 @@ import type { Channel } from '../gosling.schema';
 import { getValueUsingChannel } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
+import type { Tile } from '@higlass/services';
 
 export function drawRule(HGC: import('@higlass/types').HGC, trackInfo: any, tile: Tile, model: GoslingTrackModel) {
     /* track spec */

--- a/src/core/mark/rule.ts
+++ b/src/core/mark/rule.ts
@@ -3,7 +3,7 @@ import type { Channel } from '../gosling.schema';
 import { getValueUsingChannel } from '../gosling.schema.guards';
 import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
-import type { Tile } from '@higlass/services';
+import type { Tile } from '../../gosling-track/gosling-track';
 
 export function drawRule(HGC: import('@higlass/types').HGC, trackInfo: any, tile: Tile, model: GoslingTrackModel) {
     /* track spec */

--- a/src/core/mark/text.ts
+++ b/src/core/mark/text.ts
@@ -3,7 +3,7 @@ import type { Channel } from '../gosling.schema';
 import { group } from 'd3-array';
 import { getValueUsingChannel, IsStackedMark } from '../gosling.schema.guards';
 import { cartesianToPolar } from '../utils/polar';
-import type { Tile } from '@higlass/services';
+import type { Tile } from '../../gosling-track/gosling-track';
 
 // Merge with the one in the `utils/text-style.ts`
 export const TEXT_STYLE_GLOBAL = {

--- a/src/core/mark/text.ts
+++ b/src/core/mark/text.ts
@@ -3,6 +3,7 @@ import type { Channel } from '../gosling.schema';
 import { group } from 'd3-array';
 import { getValueUsingChannel, IsStackedMark } from '../gosling.schema.guards';
 import { cartesianToPolar } from '../utils/polar';
+import type { Tile } from '@higlass/services';
 
 // Merge with the one in the `utils/text-style.ts`
 export const TEXT_STYLE_GLOBAL = {

--- a/src/core/mark/text.ts
+++ b/src/core/mark/text.ts
@@ -16,7 +16,7 @@ export const TEXT_STYLE_GLOBAL = {
     strokeThickness: 0
 } as const;
 
-export function drawText(HGC: import('@higlass/types').HGC, trackInfo: any, tile: any, model: GoslingTrackModel) {
+export function drawText(HGC: import('@higlass/types').HGC, trackInfo: any, tile: Tile, model: GoslingTrackModel) {
     /* track spec */
     const spec = model.spec();
 

--- a/src/core/mark/title.ts
+++ b/src/core/mark/title.ts
@@ -4,15 +4,16 @@ import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
 import type { CompleteThemeDeep } from '../utils/theme';
 import { getTextStyle } from '../utils/text-style';
+import type { Tile } from '@higlass/services';
 
 export function drawCircularTitle(
     HGC: import('@higlass/types').HGC,
     trackInfo: any,
-    tile: any,
-    gos: GoslingTrackModel,
+    tile: Tile,
+    model: GoslingTrackModel,
     theme: Required<CompleteThemeDeep>
 ) {
-    const spec = gos.spec();
+    const spec = model.spec();
     const { title } = spec;
 
     if (spec.layout !== 'circular') {

--- a/src/core/mark/title.ts
+++ b/src/core/mark/title.ts
@@ -4,7 +4,7 @@ import { cartesianToPolar, valueToRadian } from '../utils/polar';
 import colorToHex from '../utils/color-to-hex';
 import type { CompleteThemeDeep } from '../utils/theme';
 import { getTextStyle } from '../utils/text-style';
-import type { Tile } from '@higlass/services';
+import type { Tile } from '../../gosling-track/gosling-track';
 
 export function drawCircularTitle(
     HGC: import('@higlass/types').HGC,

--- a/src/gosling-track/data-abstraction.ts
+++ b/src/gosling-track/data-abstraction.ts
@@ -1,3 +1,4 @@
+import type { SparseTile, TileData } from '@higlass/services';
 import type { Datum, SingleTrack } from '../core/gosling.schema';
 import { IsDataDeepTileset } from '../core/gosling.schema.guards';
 
@@ -8,9 +9,8 @@ export const GOSLING_DATA_ROW_UID_FIELD = 'gosling-data-row-uid';
  */
 export function getTabularData(
     spec: SingleTrack,
-    data: {
-        dense?: number[];
-        raw?: Datum[];
+    data: TileData & {
+        sparse?: Array<SparseTile>;
         shape?: [number, number];
         tileX: number;
         tileWidth: number;
@@ -27,7 +27,7 @@ export function getTabularData(
     }
 
     if (spec.data.type === 'vector' || spec.data.type === 'bigwig') {
-        if (!data.dense) {
+        if (!('dense' in data)) {
             // we did not get sufficient data.
             return;
         }
@@ -106,7 +106,7 @@ export function getTabularData(
             }
         });
     } else if (spec.data.type === 'multivec') {
-        if (!data.dense || data.shape === undefined) {
+        if (!('dense' in data) || data.shape === undefined) {
             // we did not get sufficient data.
             return;
         }
@@ -194,7 +194,7 @@ export function getTabularData(
             });
         });
     } else if (spec.data.type === 'matrix') {
-        if (!data.dense || typeof data.tileY === 'undefined' || typeof data.tileHeight === 'undefined') {
+        if (!('dense' in data) || typeof data.tileY === 'undefined' || typeof data.tileHeight === 'undefined') {
             // we do not have sufficient data.
             return;
         }
@@ -257,14 +257,14 @@ export function getTabularData(
             });
         }
     } else if (spec.data.type === 'beddb') {
-        if (!data.raw) {
+        if (!data.sparse) {
             // we did not get sufficient data.
             return;
         }
 
         const { genomicFields, exonIntervalFields, valueFields } = spec.data;
 
-        data.raw.forEach((d: any, i: number) => {
+        data.sparse.forEach((d, i) => {
             const { chrOffset, fields } = d;
 
             const datum: { [k: string]: number | string } = {};

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -68,10 +68,11 @@ interface GoslingTile extends Tile {
     mergedToAnotherTile: boolean;
     goslingModels?: GoslingTrackModel[];
     gos: Record<string, any> & {
+        tabularData?: Record<string, any>[];
         raw?: Datum[];
     };
     tileData: TileData & {
-        tabularData?: Record<string, any>;
+        tabularData?: Record<string, any>[];
     };
 }
 
@@ -855,7 +856,7 @@ function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
          * Construct tabular data from a higlass tileset and a gosling track model.
          * Return the generated gosling track model.
          */
-        preprocessTile(tile: any) {
+        preprocessTile(tile: GoslingTile) {
             if (tile.mergedToAnotherTile) {
                 tile.goslingModels = [];
                 return;
@@ -902,7 +903,7 @@ function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
                     });
                 }
 
-                tile.gos.tabularDataFiltered = Array.from(tile.gos.tabularData);
+                tile.gos.tabularDataFiltered = Array.from(tile.gos.tabularData!);
 
                 /*
                  * Data Transformation applied to each of the overlaid tracks.
@@ -993,13 +994,13 @@ function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
                 const gm = new GoslingTrackModel(resolved, tile.gos.tabularDataFiltered, this.options.theme);
 
                 // Add a track model to the tile object
-                tile.goslingModels.push(gm);
+                tile.goslingModels!.push(gm);
             });
 
             return tile.goslingModels;
         }
 
-        getIndicesOfVisibleDataInTile(tile: any) {
+        getIndicesOfVisibleDataInTile(tile: GoslingTile) {
             const visible = this._xScale.range();
 
             if (!this.tilesetInfo) return [null, null];

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -736,7 +736,7 @@ function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
             // we do not need to combine dense tiles (from multivec, vector, matrix)
             const hasDenseTiles = () => {
                 const tiles = this.visibleAndFetchedTiles();
-                return tiles?.[0]?.tileData?.dense;
+                return tiles.length >= 1 && 'dense' in tiles[0].tileData;
             };
             // BAM data fetcher already combines the datasets;
             const isBamDataFetcher = this.dataFetcher instanceof BamDataFetcher;

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -81,7 +81,7 @@ interface ProcessedTileInfo {
     /** Single tile can contain multiple gosling models if multiple tracks are superposed */
     goslingModels: GoslingTrackModel[];
     tabularData: Datum[];
-    /** Flag variable that indicate that this rendering of this tile should be skipped */
+    /** Flag variable that indicate that rendering of this tile should be skipped */
     skipRendering: boolean;
 }
 

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -34,7 +34,7 @@ import { flatArrayToPairArray } from '../core/utils/array';
 import { BamDataFetcher, VcfDataFetcher } from '../data-fetchers';
 import { LinearBrushModel } from '../gosling-brush/linear-brush-model';
 import { isPointInsideDonutSlice } from '../gosling-mouse-event/polygon';
-import type { Tile, TileData } from '@higlass/services';
+import type { FetchedTiles, Tile, TileData } from '@higlass/services';
 
 // Set `true` to print in what order each function is called
 export const PRINT_RENDERING_CYCLE = false;
@@ -105,6 +105,7 @@ function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
         private pMouseHover: Graphics;
         private pMouseSelection: Graphics;
         private assembly?: Assembly;
+        private fetchedTiles: FetchedTiles;
         // TODO: add members that are used explicitly in the code
 
         constructor(params: any[]) {
@@ -139,6 +140,7 @@ function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
                 this.options.spec._renderingId = uuid.v1();
             }
 
+            this.fetchedTiles = {};
             this.tileSize = this.tilesetInfo?.tile_size ?? 1024;
 
             // This is tracking the xScale of an entire view, which is used when no tiling concepts are used
@@ -465,7 +467,7 @@ function GoslingTrack(HGC: import('@higlass/types').HGC, ...args: any[]): any {
             this.drawLoadingCue();
             const tabularData = await tabularDataFetcher.getTabularData(
                 this.dataFetcher.uid,
-                Object.values(this.fetchedTiles).map((x: any) => x.remoteId)
+                Object.values(this.fetchedTiles).map(x => x.remoteId)
             );
             this.drawLoadingCue();
             const tiles = this.visibleAndFetchedTiles();

--- a/src/missing-types.d.ts
+++ b/src/missing-types.d.ts
@@ -38,6 +38,10 @@ declare module '@higlass/libraries' {
 
 declare module '@higlass/services' {
     import type { ScaleContinuousNumeric } from 'd3-scale';
+    import type * as PIXI from 'pixi.js';
+
+    type Scale = ScaleContinuousNumeric<number, number>;
+
     export type TilesetInfo = {
         min_pos: number[];
         max_pos: number[];
@@ -57,12 +61,16 @@ declare module '@higlass/services' {
         shape: number[];
         tilePos: unknown[];
         zoomLevel: number;
+        tileId: string;
     };
     export type Tile = {
+        tileId: string;
+        remoteId: string;
         drawnAtScale: Scale;
         graphics: PIXI.Graphics;
         tileData: TileData;
     };
+    export type FetchedTiles = Record<string, Tile>;
     type ColorRGBA = [r: number, g: number, b: number, a: number];
 
     export const tileProxy: {

--- a/src/missing-types.d.ts
+++ b/src/missing-types.d.ts
@@ -56,13 +56,28 @@ declare module '@higlass/services' {
               bins_per_dimension?: number;
           }
     );
-    export type TileData = Array<Record<string, string | number>> & {
-        dense: number[];
-        shape: number[];
-        tilePos: unknown[];
+    interface TileDataBase {
+        shape: [number, number];
+        tilePos?: [number, number];
         zoomLevel: number;
         tileId: string;
+    }
+    interface DenseTileData extends TileDataBase {
+        dense: number[];
+    }
+    type SparseTile = {
+        xStart: number;
+        xEnd: number;
+        chrOffset: number;
+        importance: number;
+        uid: string;
+        fields: string[];
     };
+    interface TabularTileData extends TileDataBase {
+        tabularData: Record<string, any>[];
+    }
+    type SparseTileData = TileDataBase & Array<SparseTile>;
+    export type TileData = DenseTileData | SparseTileData | TabularTileData;
     export type Tile = {
         tileId: string;
         remoteId: string;

--- a/src/missing-types.d.ts
+++ b/src/missing-types.d.ts
@@ -56,7 +56,7 @@ declare module '@higlass/services' {
               bins_per_dimension?: number;
           }
     );
-    interface TileDataBase {
+    export interface TileDataBase {
         shape: [number, number];
         tilePos?: [number, number];
         zoomLevel: number;
@@ -73,11 +73,8 @@ declare module '@higlass/services' {
         uid: string;
         fields: string[];
     };
-    interface TabularTileData extends TileDataBase {
-        tabularData: Record<string, any>[];
-    }
     type SparseTileData = TileDataBase & Array<SparseTile>;
-    export type TileData = DenseTileData | SparseTileData | TabularTileData;
+    export type TileData = DenseTileData | SparseTileData;
     export type Tile = {
         tileId: string;
         remoteId: string;

--- a/src/missing-types.d.ts
+++ b/src/missing-types.d.ts
@@ -52,12 +52,15 @@ declare module '@higlass/services' {
               bins_per_dimension?: number;
           }
     );
-    type TileData = {
+    export type TileData = Array<Record<string, string | number>> & {
         dense: number[];
         shape: number[];
         tilePos: unknown[];
+        zoomLevel: number;
     };
-    type Tile = {
+    export type Tile = {
+        drawnAtScale: Scale;
+        graphics: PIXI.Graphics;
         tileData: TileData;
     };
     type ColorRGBA = [r: number, g: number, b: number, a: number];


### PR DESCRIPTION
Fix #800

## Change List
 - Fix a bug that `displace` transform does not work on non-higlass datasets (#800)
<img width="542" alt="Screen Shot 2022-08-19 at 16 47 07" src="https://user-images.githubusercontent.com/9922882/185706171-ab3185a6-3ac3-4cee-9c67-ea3cd8c00f59.png">

```ts
{
  "tracks": [
    {
      "data": {
        "type": "json",
        "values": [
          {"c": "chr1", "s": 150, "e": 200},
          {"c": "chr1", "s": 100, "e": 200},
          {"c": "chr1", "s": 125, "e": 160},
          {"c": "chr1", "s": 100, "e": 160}
        ],
        "chromosomeField": "c",
        "genomicFields": ["s", "e"]
      },
      "dataTransform": [
        {
          "type": "displace",
          "method": "pile",
          "boundingBox": {"startField": "s", "endField": "e"},
          "newField": "r"
        }
      ],
      "mark": "rect",
      "x": {"field": "s", "type": "genomic", "domain": {"interval": [1, 300]}},
      "xe": {"field": "e", "type": "genomic"},
      "row": {"field": "r", "type": "nominal"},
      "color": {"value": "red"},
      "stroke": {"value": "black"},
      "strokeWidth": {"value": 1}
    }
  ]
}
```

 - Type out `tile` and `tileData` more and remove a lot of `any` usage from `gosling-track.ts`
 - Remove `tile.gos` object entirely which was largely redundant with `tileData`. Instead, we are using a separate object that stores processed tabular data per tile:

```ts
private processedTileInfo: Record<string, ProcessedTileInfo>; // key is the `tile.tileId`

interface ProcessedTileInfo {
    mergedToAnotherTile: boolean;
    goslingModels: GoslingTrackModel[];
    tabularData: Record<string, any>[];
    tabularDataTransformed: Record<string, any>[];
}
```

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
