### PR TITLE
fix: ensure to use non-null `hgRef`

### DIFF
--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -39,13 +39,13 @@ export interface GoslingApi {
 }
 
 export function createApi(
-    hg: HiGlassApi,
+    hg: Readonly<HiGlassApi>,
     hgSpec: HiGlassSpec | undefined,
-    trackInfos: TrackMouseEventData[],
+    trackInfos: readonly TrackMouseEventData[],
     theme: Required<CompleteThemeDeep>
 ): GoslingApi {
     const getTracks = () => {
-        return trackInfos;
+        return [...trackInfos];
     };
     const getTrack = (trackId: string) => {
         const trackInfoFound = trackInfos.find(d => d.id === trackId);

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import { HiGlassApi, HiGlassComponentWrapper } from './higlass-component-wrapper';
-import React, { useState, useEffect, useMemo, useRef, forwardRef, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useRef, forwardRef, useCallback, useImperativeHandle } from 'react';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
 import * as gosling from '..';
 import { getTheme, Theme } from './utils/theme';
@@ -52,16 +52,16 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
     const wrapperDivId = props.id ?? uuid.v4();
 
     // Gosling APIs
-    useEffect(() => {
-        if (!ref || !hgRef?.current) return;
-        const hgApi = hgRef.current;
-        const api = createApi(hgApi, viewConfig, trackInfos.current, theme);
-        if (typeof ref == 'function') {
-            ref({ api, hgApi });
-        } else {
-            ref.current = { api, hgApi };
-        }
-    }, [hgRef.current, viewConfig, theme]);
+    useImperativeHandle(
+        ref,
+        () => {
+            const hgApi = refAsReadonlyProxy(hgRef);
+            const infos = refAsReadonlyProxy(trackInfos);
+            const api = createApi(hgApi, viewConfig, infos, theme);
+            return { api, hgApi };
+        },
+        [viewConfig, theme]
+    );
 
     // TODO: add a `force` parameter since changing `linkingId` might not update vis
     const compile = useCallback(() => {
@@ -189,3 +189,14 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
 });
 
 GoslingComponent.displayName = 'GoslingComponent';
+
+/** Wraps the `.current` property of a React.RefObject as a readonly object. */
+function refAsReadonlyProxy<T extends object>(ref: React.RefObject<T>): Readonly<T> {
+    // Readonly because because we only implement `get`.
+    return new Proxy({} as Readonly<T>, {
+        get(_target, prop, reciever) {
+            if (!ref.current) throw Error('ref is not set!');
+            return Reflect.get(ref.current, prop, reciever);
+        }
+    });
+}

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -61,7 +61,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
         } else {
             ref.current = { api, hgApi };
         }
-    }, [viewConfig, theme]);
+    }, [hgRef.current, viewConfig, theme]);
 
     // TODO: add a `force` parameter since changing `linkingId` might not update vis
     const compile = useCallback(() => {


### PR DESCRIPTION
## Change List
 - Sometimes, `api.exportPng()` was making errors since `hgRef` is null. I believe this addresses the issue.

<img width="1062" alt="Screen Shot 2022-08-19 at 16 34 48" src="https://user-images.githubusercontent.com/9922882/185704600-b0d09a51-c3b9-4096-9a20-cb26b9f090d6.png">


## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
