### PR TITLE
fix: bind `hgApi` as a ES6 Proxy for `hgRef.current` to keep updated ref

### DIFF
--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -26,7 +26,7 @@ export interface GoslingApi {
     zoomToGene(viewId: string, gene: string, padding?: number, duration?: number): void;
     suggestGene(viewId: string, keyword: string, callback: (suggestions: GeneSuggestion[]) => void): void;
     getViewIds(): string[];
-    getTracks(): readonly TrackMouseEventData[];
+    getTracks(): TrackMouseEventData[];
     getTrack(trackId: string): TrackMouseEventData | undefined;
     exportPng(transparentBackground?: boolean): void;
     exportPdf(transparentBackground?: boolean): void;
@@ -39,13 +39,13 @@ export interface GoslingApi {
 }
 
 export function createApi(
-    hg: HiGlassApi,
+    hg: Readonly<HiGlassApi>,
     hgSpec: HiGlassSpec | undefined,
     trackInfos: readonly TrackMouseEventData[],
     theme: Required<CompleteThemeDeep>
 ): GoslingApi {
     const getTracks = () => {
-        return trackInfos;
+        return [...trackInfos];
     };
     const getTrack = (trackId: string) => {
         const trackInfoFound = trackInfos.find(d => d.id === trackId);

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -26,7 +26,7 @@ export interface GoslingApi {
     zoomToGene(viewId: string, gene: string, padding?: number, duration?: number): void;
     suggestGene(viewId: string, keyword: string, callback: (suggestions: GeneSuggestion[]) => void): void;
     getViewIds(): string[];
-    getTracks(): TrackMouseEventData[];
+    getTracks(): readonly TrackMouseEventData[];
     getTrack(trackId: string): TrackMouseEventData | undefined;
     exportPng(transparentBackground?: boolean): void;
     exportPdf(transparentBackground?: boolean): void;
@@ -41,7 +41,7 @@ export interface GoslingApi {
 export function createApi(
     hg: HiGlassApi,
     hgSpec: HiGlassSpec | undefined,
-    trackInfos: TrackMouseEventData[],
+    trackInfos: readonly TrackMouseEventData[],
     theme: Required<CompleteThemeDeep>
 ): GoslingApi {
     const getTracks = () => {


### PR DESCRIPTION
The issue with `hgRef` is that we cannot listen for changes to re-create the `api` in our `useEffect` (because it is a Ref not React State). I think I came up with a solution to keep the `hgRef` but make `hgApi` an ES6 Proxy to `hgRef.current`. This way we can just access `hgApi` as whatever the current ref is. 

Additionally, I replaced `useEffect` with [`useImperativeHandle`](https://reactjs.org/docs/hooks-reference.html#useimperativehandle) which seems to be the preferable hook for this use case.