### PR TITLE
chore: fix demos that use wrong chromosome names

### DIFF
--- a/editor/example/json-spec/circular-overview-linear-detail-views.ts
+++ b/editor/example/json-spec/circular-overview-linear-detail-views.ts
@@ -116,7 +116,12 @@ export const EX_SPEC_CIRCULAR_OVERVIEW_LINEAR_DETAIL: GoslingSpec = {
                                 binSize: 4
                             },
                             mark: 'bar',
-                            x: { field: 'start', type: 'genomic', linkingId: 'detail-1', domain: { chromosome: '5' } },
+                            x: {
+                                field: 'start',
+                                type: 'genomic',
+                                linkingId: 'detail-1',
+                                domain: { chromosome: 'chr5' }
+                            },
                             xe: { field: 'end', type: 'genomic' },
                             y: { field: 'peak', type: 'quantitative' },
                             row: { field: 'sample', type: 'nominal' },

--- a/editor/example/json-spec/gremlin.ts
+++ b/editor/example/json-spec/gremlin.ts
@@ -6,7 +6,7 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
     views: [
         {
             linkingId: 'view1',
-            xDomain: { chromosome: '5', interval: [0, 80000000] },
+            xDomain: { chromosome: 'chr5', interval: [0, 80000000] },
             tracks: [
                 {
                     alignment: 'overlay',
@@ -209,7 +209,7 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                                 type: 'genomic',
                                 linkingId: 'view2',
                                 axis: 'bottom',
-                                domain: { chromosome: '5', interval: [68000000, 71000000] }
+                                domain: { chromosome: 'chr5', interval: [68000000, 71000000] }
                             },
                             xe: { field: 'p2', type: 'genomic' },
                             row: {
@@ -260,7 +260,7 @@ export const EX_SPEC_GREMLIN: GoslingSpec = {
                                         type: 'genomic',
                                         axis: 'bottom',
                                         domain: {
-                                            chromosome: '5',
+                                            chromosome: 'chr5',
                                             interval: [69276000, 69282000]
                                         }
                                     },

--- a/editor/example/json-spec/responsive-track-wise-comparison.ts
+++ b/editor/example/json-spec/responsive-track-wise-comparison.ts
@@ -250,7 +250,7 @@ const _gene: (type: 1 | 2, compact?: boolean) => OverlaidTracks = (type, compact
 
 const xDomain: (type: 1 | 2) => DomainChrInterval = type => {
     if (type === 1) return { chromosome: 'chr12', interval: [10140000, 10210000] };
-    else return { chromosome: '8', interval: [127734000, 127744000] };
+    else return { chromosome: 'chr8', interval: [127734000, 127744000] };
 };
 
 export const EX_SPEC_RESPONSIVE_TRACK_WISE_COMPARISON: GoslingSpec = {

--- a/editor/example/json-spec/responsive.ts
+++ b/editor/example/json-spec/responsive.ts
@@ -431,7 +431,7 @@ export const EX_SPEC_RESPONSIVE_MULTIVEC_CIRCULAR: GoslingSpec = {
 // TODO: Add genes and allow rotation
 export const EX_SPEC_RESPONSIVE_IDEOGRAM: GoslingSpec = {
     responsiveSize: { width: true, height: true },
-    xDomain: { chromosome: '7' },
+    xDomain: { chromosome: 'chr7' },
     views: [
         {
             tracks: [
@@ -875,7 +875,7 @@ export const EX_SPEC_RESPONSIVE_COMPARATIVE_VIEWS: GoslingSpec = {
             ]
         },
         {
-            xDomain: { chromosome: '9', interval: [5000000, 15000000] },
+            xDomain: { chromosome: 'chr9', interval: [5000000, 15000000] },
             tracks: [
                 {
                     id: 'middle',


### PR DESCRIPTION
 - Fix some demos that still use no-prefix chromosome names (e.g., `5` instead of `chr5`) (#796)

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
