### PR TITLE
chore: add an experimental option for performance

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -1073,6 +1073,11 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
                 }
               },
               "type": "object"
@@ -1219,6 +1224,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"
@@ -1829,6 +1839,11 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
                 }
               },
               "type": "object"
@@ -1975,6 +1990,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"
@@ -2638,6 +2658,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"
@@ -3852,6 +3877,11 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
             }
           },
           "type": "object"
@@ -3967,6 +3997,11 @@
                         "$ref": "#/definitions/MouseEventsDeep"
                       }
                     ]
+                  },
+                  "performanceMode": {
+                    "default": false,
+                    "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                    "type": "boolean"
                   }
                 },
                 "type": "object"
@@ -4529,6 +4564,11 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
             }
           },
           "type": "object"
@@ -4888,6 +4928,11 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
             }
           },
           "type": "object"
@@ -5003,6 +5048,11 @@
                         "$ref": "#/definitions/MouseEventsDeep"
                       }
                     ]
+                  },
+                  "performanceMode": {
+                    "default": false,
+                    "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                    "type": "boolean"
                   }
                 },
                 "type": "object"
@@ -5707,6 +5757,11 @@
                   "$ref": "#/definitions/MouseEventsDeep"
                 }
               ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
             }
           },
           "type": "object"
@@ -6060,6 +6115,11 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
                 }
               },
               "type": "object"
@@ -6202,6 +6262,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"
@@ -6809,6 +6874,11 @@
                       "$ref": "#/definitions/MouseEventsDeep"
                     }
                   ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
                 }
               },
               "type": "object"
@@ -6951,6 +7021,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"
@@ -7607,6 +7682,11 @@
                                 "$ref": "#/definitions/MouseEventsDeep"
                               }
                             ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
                           }
                         },
                         "type": "object"

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -334,6 +334,13 @@ interface SingleTrackBase extends CommonTrackDef {
          * Determine whether to use mouse events, such as click and mouse over on marks. __Default__: `false`
          */
         mouseEvents?: boolean | MouseEventsDeep;
+
+        /**
+         * Render visual marks with less smooth curves to increase rendering performance.
+         * Only supported for `elliptical` `linkStyle` `withinLink` currently.
+         * @default false
+         */
+        performanceMode?: boolean;
     };
 
     // Mark

--- a/src/core/mark/withinLink.ts
+++ b/src/core/mark/withinLink.ts
@@ -44,6 +44,7 @@ export function drawWithinLink(g: PIXI.Graphics, trackInfo: any, model: GoslingT
 
     /* defaults */
     const MIN_HEIGHT = spec.style?.linkMinHeight ?? 0.5;
+    const NUM_STEPS = spec.experimental?.performanceMode ? 200 : 1000; // https://github.com/gosling-lang/gosling.js/issues/634
 
     // TODO: Can row be actually used for circular layouts?
     /* render */
@@ -231,10 +232,8 @@ export function drawWithinLink(g: PIXI.Graphics, trackInfo: any, model: GoslingT
                         // !! Not ready to use
                         const morePoints: { x: number; y: number }[] = [];
 
-                        // https://github.com/gosling-lang/gosling.js/issues/634
-                        const numSteps = 1000;
-                        for (let step = 0; step <= numSteps; step++) {
-                            const theta = (Math.PI * step) / numSteps;
+                        for (let step = 0; step <= NUM_STEPS; step++) {
+                            const theta = (Math.PI * step) / NUM_STEPS;
                             const mx = ((xe - x) / 2.0) * Math.cos(theta) + (x + xe) / 2.0;
                             const my =
                                 baseY -
@@ -248,7 +247,7 @@ export function drawWithinLink(g: PIXI.Graphics, trackInfo: any, model: GoslingT
                             const r = trackOuterRadius - (my / trackHeight) * trackRingSize;
                             const cmx = cartesianToPolar(mx, trackWidth, r, tcx, tcy, startAngle, endAngle);
 
-                            if (step % 20 === 0 || step === numSteps) {
+                            if (step % 20 === 0 || step === NUM_STEPS) {
                                 // we draw less points than the hidden points for mouse events
                                 if (step === 0) {
                                     g.moveTo(cmx.x, cmx.y);
@@ -319,10 +318,9 @@ export function drawWithinLink(g: PIXI.Graphics, trackInfo: any, model: GoslingT
                         const morePoints: { x: number; y: number }[] = [];
 
                         // https://github.com/gosling-lang/gosling.js/issues/634
-                        const numSteps = 1000;
                         const constantY = IsChannelDeep(spec.y);
-                        for (let step = 0; step <= numSteps; step++) {
-                            const theta = Math.PI * (step / numSteps);
+                        for (let step = 0; step <= NUM_STEPS; step++) {
+                            const theta = Math.PI * (step / NUM_STEPS);
                             const mx = ((xe - x) / 2.0) * Math.cos(theta) + (x + xe) / 2.0;
                             const my =
                                 baseY -
@@ -333,7 +331,7 @@ export function drawWithinLink(g: PIXI.Graphics, trackInfo: any, model: GoslingT
                                         : Math.min(xe - x + trackWidth * MIN_HEIGHT, trackWidth) / trackWidth) *
                                     (flipY ? -1 : 1);
 
-                            if (step % 20 === 0 || step === numSteps) {
+                            if (step % 20 === 0 || step === NUM_STEPS) {
                                 // we draw less points than the hidden points that captures mouse events
                                 if (step === 0) {
                                     g.moveTo(mx, my);


### PR DESCRIPTION
This adds a track-level experimental option, `performanceMode` (default `false`) to enable using more performant, less smooth curves for `withinLink`s. This simply reduces a hard-coded 'number of segments' for drawing curves. I think we would need to figure out a smarter calculation of the # of segments in the future, but I think, in general, having this kind of mode will be helpful to users for balancing between performance and rendering quality.