### PR TITLE
feat: show `null` `DISTPREVLOGE` from VCF files

### DIFF
--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -3723,21 +3723,15 @@
           "type": "boolean"
         },
         "oneOf": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Check whether the value is an element in the provided list."
+          "description": "Check whether the value is an element in the provided list.",
+          "items": {
+            "type": [
+              "string",
+              "number",
+              "null"
+            ]
+          },
+          "type": "array"
         },
         "type": {
           "const": "filter",

--- a/schema/higlass.schema.json
+++ b/schema/higlass.schema.json
@@ -488,21 +488,15 @@
           "type": "boolean"
         },
         "oneOf": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Check whether the value is an element in the provided list."
+          "description": "Check whether the value is an element in the provided list.",
+          "items": {
+            "type": [
+              "string",
+              "number",
+              "null"
+            ]
+          },
+          "type": "array"
         },
         "type": {
           "const": "filter",

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -678,21 +678,15 @@
           "type": "boolean"
         },
         "oneOf": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Check whether the value is an element in the provided list."
+          "description": "Check whether the value is an element in the provided list.",
+          "items": {
+            "type": [
+              "string",
+              "number",
+              "null"
+            ]
+          },
+          "type": "array"
         },
         "replace": {
           "items": {

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -269,7 +269,8 @@ export class GoslingTrackModel {
             : IsChannelValue(channel)
             ? 'constant'
             : undefined;
-
+        // if(channelFieldType === 'quantitative' && value === undefined)
+        //     console.log(value, channel)
         if (!channelFieldType) {
             // Shouldn't be reached. Channel should be either encoded with data or a constant value.
             return undefined;
@@ -283,6 +284,10 @@ export class GoslingTrackModel {
         if (value === undefined) {
             // Value is undefined, so returning undefined.
             return undefined;
+        }
+
+        if (value === null && channelFieldType === 'quantitative') {
+            value = 0;
         }
 
         if (typeof this.channelScales[channelKey] !== 'function') {

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -286,8 +286,12 @@ export class GoslingTrackModel {
             return undefined;
         }
 
-        if (value === null && channelFieldType === 'quantitative') {
-            value = 0;
+        if (value === null) {
+            if (channelFieldType === 'quantitative') {
+                value = 0;
+            } else if (channelFieldType === 'nominal') {
+                value = 'null';
+            }
         }
 
         if (typeof this.channelScales[channelKey] !== 'function') {
@@ -696,7 +700,9 @@ export class GoslingTrackModel {
                     }
                 } else if (IsChannelDeep(channel) && channel.type === 'nominal') {
                     if (channel.domain === undefined) {
-                        channel.domain = Array.from(new Set(data.map(d => d[channel.field as string]))) as string[];
+                        channel.domain = Array.from(
+                            new Set(data.map(d => d[channel.field as string] ?? 'null'))
+                        ) as string[];
                     }
                     if (!channel.range) {
                         let startSize = 2;

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -269,8 +269,7 @@ export class GoslingTrackModel {
             : IsChannelValue(channel)
             ? 'constant'
             : undefined;
-        // if(channelFieldType === 'quantitative' && value === undefined)
-        //     console.log(value, channel)
+
         if (!channelFieldType) {
             // Shouldn't be reached. Channel should be either encoded with data or a constant value.
             return undefined;

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -1136,7 +1136,7 @@ export interface IncludeFilter extends CommonFilterTransform {
 
 export interface OneOfFilter extends CommonFilterTransform {
     /** Check whether the value is an element in the provided list. */
-    oneOf: string[] | number[];
+    oneOf: (string | number | null)[];
 }
 
 // !! Not supported yet


### PR DESCRIPTION
## Change
We were not drawing marks if encoded values are `null` (e.g., `DISTPREVLOGE` being `null` due to missing previous mutation). I think it makes more sense to enable users to display such the "missing" data. [Similar Vega-Lite](https://vega.github.io/vega-lite/examples/point_invalid_color.html), this PR treats a missing value as `0` (`quantitative` field) or `null` (`nominal` field). Users can filter the `null` value using `oneOf` filter:

```ts
{
  "layout": "linear",
  "arrangement": "vertical",
  "centerRadius": 0.8,
  "views": [
    {
      "tracks": [
        {
          "dataTransform": [
            {"type": "filter", "field": "DISTPREVLOGE", "oneOf": [null]}
          ],
          "id": "track-1",
          "data": {
            "url": "https://s3.amazonaws.com/gosling-lang.org/data/SV/SNV_test_tumor_normal_with_panel.vcf.gz",
            "type": "vcf",
            "indexUrl": "https://s3.amazonaws.com/gosling-lang.org/data/SV/SNV_test_tumor_normal_with_panel.vcf.gz.tbi",
            "sampleLength": 5000
          },
          "tooltip": [
            {"field": "DISTPREVLOGE", "type": "nominal", "format": "s1"},
            {"field": "POS", "type": "genomic"}
          ],
          "mark": "point",
          "x": {"field": "POS", "type": "genomic", "axis": "top"},
          "color": {
            "field": "SUBTYPE",
            "type": "nominal",
            "legend": true,
            "domain": ["C>A", "C>G", "C>T", "T>A", "T>C", "T>G"]
          },
          "y": {"field": "DISTPREVLOGE", "type": "quantitative", "axis": "top"},
          "opacity": {"value": 0.9},
          "width": 600,
          "height": 130
        }
      ]
    }
  ]
}
```

![Screen Shot 2022-09-12 at 17 59 29](https://user-images.githubusercontent.com/9922882/189766083-ae73f614-3abb-4c92-940e-62e35c5b8fcd.png)

Need to add tests

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
