### PR TITLE
fix: fix an error when tilePos is undefined

### DIFF
--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -614,8 +614,8 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
         /**
          * Get the tile's position in its coordinate system.
          */
-        getTilePosAndDimensions(zoomLevel: number, tilePos: [number, number]) {
-            if (!this.tilesetInfo) {
+        getTilePosAndDimensions(zoomLevel: number, tilePos?: [number, number]) {
+            if (!this.tilesetInfo || !tilePos) {
                 throw Error('tilesetInfo not parsed');
             }
 


### PR DESCRIPTION
To fix an error after zooming and panning on an indel track (<a href="http://localhost:3001/?full=false&spec=(%0A*'idH'_-mid-indel'C'styleH('backgroundH'%23F6F6F6')C'dataH(J'urlH~%40_%24'C*'indexUrlH~%40_%24.tbi'C*'%3Evcf'C*'sampleLengthH5000%0A*)C'dataTransformH%5BJ(J*'%3Econcat'C**'fieldsH%5B'REFKALT'%5DC**'separatorH'%20%E2%86%92%20'%7DLAB'J)C*(J*'%3Ereplace'C**V%5E'C**'replaceH%5BJ**('fromH'i%7FKtoH'I%7F')C***('fromH'deletionKtoH'Deletion')J*%5D%7D%5E'J)%60alignmentH'overlay'C'tracksH%5BJ(J*'size%3B19)Cjtrac%26GT%3F%25%3DC*(J*'xeH(V%3Cjtrac%26LTET%3F%25%3DC*(J*'markH'text'C**'textH(VLABKZ)C**'xeH(V%3C**'color%3B'white')C**%7B0)C**'opacity%3B1)Cjmar%26LT%3F'measureH'width%3F'transitionPaddingH30C****'thresholdH'%7Cxe-x%7C'%3D%60markH'rect'C'xH(VPOS%22')C'strokeH(JV%2BX*)C%7B1)C'colorH(JV%2BX*)C'rowH(JV%2BX*)C'tooltipH%5BJ(VPOS%22')C*(VPOSEND%22')C*(V%5EKZ)C*(VALTKZ)C*(VREFKZ)C*(VQUALK%3Equantitative')%60opacity%3B0.9)C'widthH1320C'heightH40%0A)*%20%20C%2C%0A*H!%20J%0A**K'%2C%20'V'fieldH'XndHtrueC*'domainH%5B'I%7FKDeletion'%5D%0AZ%3Enominal'_7a921087-8e62-4a93-a757-fd8cdbe1eb8fj**'visibilityH%5BJ**(J***'targetH'~'https%3A%2F%2Fsomatic-browser-test.s3.amazonaws.com%2Fbr%22K%3Egenomic%24.consensus.20161006.somatic.indel.sorted.vcf.gz%25'measureH'zoomLevel%3F'thresholdH1000%26k%3F'operationH'%2B%5E'C*'ZC*'lege%3BH('valueH%3CPOSEND%22KaxisH'top')C%3DJ**)J*%5DJ)%3EtypeH'%3F'C****%40owserExamples%2F%5EMUTTYPE%60%0A*%5DC'%7B'strokeWidth%3B%7DC**'newFieldH'%7Fnsertion%01%7F%7D%7B%60%5E%40%3F%3E%3D%3C%3B%2B%26%25%24%22~j_ZXVKJHC*_">demo</a>)