### PR TITLE
chore: show fixed size edges on circular brush

### DIFF
--- a/src/gosling-brush/brush-track.ts
+++ b/src/gosling-brush/brush-track.ts
@@ -55,11 +55,13 @@ function BrushTrack(HGC: any, ...args: any[]): any {
                 .append('path')
                 .attr('class', 'brush')
                 .attr('d', this.brush)
-                .attr('fill', this.options.projectionFillColor)
+                .attr('fill', (d: CircularBrushData) =>
+                    d.type === 'brush' ? this.options.projectionFillColor : this.options.projectionStrokeColor
+                )
                 .attr('stroke', this.options.projectionStrokeColor)
                 // Let's hide left and right resizer
                 .attr('fill-opacity', (d: CircularBrushData) =>
-                    d.type === 'brush' ? this.options.projectionFillOpacity : 0
+                    d.type === 'brush' ? this.options.projectionFillOpacity : this.options.projectionStrokeOpacity
                 )
                 .attr('stroke-opacity', (d: CircularBrushData) =>
                     d.type === 'brush' ? this.options.projectionStrokeOpacity : 0
@@ -88,14 +90,14 @@ function BrushTrack(HGC: any, ...args: any[]): any {
                 },
                 {
                     type: 'start',
-                    startAngle: extent[0],
-                    endAngle: extent[0] + this.RR,
+                    startAngle: extent[0] - this.RR,
+                    endAngle: extent[0],
                     cursor: 'move'
                 },
                 {
                     type: 'end',
-                    startAngle: extent[1] - this.RR,
-                    endAngle: extent[1],
+                    startAngle: extent[1],
+                    endAngle: extent[1] + this.RR,
                     cursor: 'move'
                 }
             ];


### PR DESCRIPTION
Toward #131
Toward #404
Toward #9
Toward #383

Perhaps, just separately draw 'lines' instead of arcs to be less ugly.

<img width="824" alt="Screenshot 2022-11-23 at 16 57 02" src="https://user-images.githubusercontent.com/9922882/203653034-52399903-3ecc-4ce5-9f5e-ee07678d8dc7.png">
