### PR TITLE
chore: remove lodash-es isArray

### DIFF
--- a/src/core/gosling.schema.guards.ts
+++ b/src/core/gosling.schema.guards.ts
@@ -35,7 +35,6 @@ import type {
     DataTransform
 } from './gosling.schema';
 import { SUPPORTED_CHANNELS } from './mark';
-import { isArray } from 'lodash-es';
 import {
     interpolateGreys,
     interpolateWarm,
@@ -206,14 +205,14 @@ export function IsIncludeFilter(_: FilterTransform): _ is IncludeFilter {
  * Check whether domain is in array shape.
  */
 export function IsDomainArray(domain?: Domain): domain is string[] | number[] {
-    return isArray(domain);
+    return Array.isArray(domain);
 }
 
 /**
  * Check whether range is in array shape.
  */
 export function IsRangeArray(range?: Range): range is string[] | number[] {
-    return isArray(range);
+    return Array.isArray(range);
 }
 
 // TODO: perhaps, combine this with `isStackedChannel`


### PR DESCRIPTION
Fix #
Toward #

## Change List
 - Remove usage of `isArray` from `lodash` in favor of the browser's builtin `Array.isArray`.

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
