### PR TITLE
feat(editor): add link to gosling-lang.org to editor header

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -6,6 +6,9 @@ button {
 .demo-navbar {
     /* color: white; */
     /* background-color: #24292F; */
+    display: flex;
+    flex-direction: row;
+    align-items: center;
     border-bottom: 1px solid lightgray;
     font-weight: bold;
     padding-left: 10px;
@@ -39,23 +42,13 @@ button {
 }
 
 .description-button {
-    position: fixed;
-    right: 0;
-    top: 0;
     color: #e18343;
-    display: inline-block;
-    vertical-align: middle;
-    padding-top: 8px;
-    padding-left: 8px;
-    padding-right: 8px;
-    margin-left: 10px;
+    margin-right: 8px;
     cursor: pointer;
     background-color: white;
 }
 
 .editor-nav-button {
-    display: inline-block;
-    vertical-align: middle;
     height: 100%;
     padding-top: 8px;
     padding-left: 8px;
@@ -70,6 +63,11 @@ button {
     font-weight: 400;
     color: #e18343;
     cursor: pointer;
+    margin-right: auto;
+}
+
+.mr-1 {
+    margin-right: 1rem;
 }
 
 .demo-navbar select {
@@ -84,6 +82,10 @@ button {
 
     /* Remove Safari's gradient */
     -webkit-appearance: none;
+}
+
+.demo-navbar a {
+    color: #000;
 }
 
 .demo-navbar select:focus {

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -776,7 +776,7 @@ function Editor(props: RouteComponentProps) {
                     </span>
                 ) : null}
                 <input type="hidden" id="spec-url-exporter" />
-                <a href="http://gosling-lang.org/" title="Go to the Gosling Project" className="mr-1" target="_blank">
+                <a href="http://gosling-lang.org/" title="Go to the Gosling Project" className="mr-1" target="_blank" rel="noreferrer">
                     Gosling Project
                 </a>
                 {description ? (

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -776,7 +776,7 @@ function Editor(props: RouteComponentProps) {
                     </span>
                 ) : null}
                 <input type="hidden" id="spec-url-exporter" />
-                <a href="http://gosling-lang.org/" title="Go to the Gosling Project" className="mr-1">
+                <a href="http://gosling-lang.org/" title="Go to the Gosling Project" className="mr-1" target="_blank">
                     Gosling Project
                 </a>
                 {description ? (

--- a/editor/editor.tsx
+++ b/editor/editor.tsx
@@ -776,6 +776,9 @@ function Editor(props: RouteComponentProps) {
                     </span>
                 ) : null}
                 <input type="hidden" id="spec-url-exporter" />
+                <a href="http://gosling-lang.org/" title="Go to the Gosling Project" className="mr-1">
+                    Gosling Project
+                </a>
                 {description ? (
                     <button title="Open Textual Description" className="description-button" onClick={openDescription}>
                         {getIconSVG(ICONS.INFO_CIRCLE, 23, 23)}


### PR DESCRIPTION
Fix #836 
Toward #

## Change List
 - Add link to gosling-lang.org to editor header 

![image](https://user-images.githubusercontent.com/14843470/228588546-d1317ecc-b605-4e25-b33a-359e7e33c0eb.png)

Editor with a gist 

![image](https://user-images.githubusercontent.com/14843470/228588745-489de85d-45d7-4115-89f6-b10868419d38.png)


## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
