### PR TITLE
fix: flip the y-axis labels when the track is vertical

### DIFF
--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -663,7 +663,6 @@ export class GoslingTrackModel {
                         (channel as Color | Stroke).scaleOffset = [0, 1];
                     }
 
-                    const y_bottom_padding = 3;
                     if (!channel.range) {
                         let range;
                         switch (channelKey) {
@@ -674,7 +673,7 @@ export class GoslingTrackModel {
                                 range = [0, spec.width];
                                 break;
                             case 'y':
-                                range = [y_bottom_padding, rowHeight];
+                                range = [1, rowHeight];
                                 break;
                             case 'ye':
                                 range = [0, rowHeight];

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -663,6 +663,7 @@ export class GoslingTrackModel {
                         (channel as Color | Stroke).scaleOffset = [0, 1];
                     }
 
+                    const y_bottom_padding = 3;
                     if (!channel.range) {
                         let range;
                         switch (channelKey) {
@@ -673,6 +674,8 @@ export class GoslingTrackModel {
                                 range = [0, spec.width];
                                 break;
                             case 'y':
+                                range = [y_bottom_padding, rowHeight];
+                                break;
                             case 'ye':
                                 range = [0, rowHeight];
                                 break;

--- a/src/core/gosling-track-model.ts
+++ b/src/core/gosling-track-model.ts
@@ -673,8 +673,6 @@ export class GoslingTrackModel {
                                 range = [0, spec.width];
                                 break;
                             case 'y':
-                                range = [1, rowHeight];
-                                break;
                             case 'ye':
                                 range = [0, rowHeight];
                                 break;

--- a/src/core/mark/axis.ts
+++ b/src/core/mark/axis.ts
@@ -136,6 +136,11 @@ export function drawLinearYAxis(
             textGraphic.position.x = tickEnd;
             textGraphic.position.y = dy + rowHeight - y;
 
+            // Flip labels when orientation is vertical
+            if (spec.orientation === 'vertical') {
+                textGraphic.anchor.x = isLeft ? 1 : 0;
+                textGraphic.scale.x *= -1;
+            }
             graphics.addChild(textGraphic);
         });
     });


### PR DESCRIPTION
Fix #856 
Toward #

## Change List
 - Flip the y-axis labels so they are not mirrored when the track is vertical 

### Flip y-axis labels when track is vertical 
Before: 
![image](https://user-images.githubusercontent.com/14843470/229870183-8528060a-de84-4b97-8500-511b1a24b2db.png)

After, y-axis set to left:
![image](https://user-images.githubusercontent.com/14843470/229863929-1f6c85db-d152-42c4-933f-2927872baa2c.png)

After, y-axis set to right:
![image](https://user-images.githubusercontent.com/14843470/229864129-8349b8f4-811d-487c-8b50-8845dece8252.png)

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
