### PR TITLE
feat: support optional INFO fields of VCF files

### DIFF
--- a/.github/workflows/deploy-editor.yml
+++ b/.github/workflows/deploy-editor.yml
@@ -18,7 +18,7 @@ jobs:
             - run: yarn install
             - run: yarn build-editor
               env:
-                  NODE_OPTIONS: '--max_old_space_size=4096'
+                  NODE_OPTIONS: '--max_old_space_size=8192'
             - name: Deploy editor
               run: |
                   git config --global user.name "action@github.com"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "build": "run-s build-clear build-types build-lib",
         "build-lib": "vite build --mode lib && node scripts/build-umd && node scripts/build-embed",
         "build-types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
-        "build-editor": "node --max_old_space_size=4096 ./node_modules/vite/bin/vite.js build",
+        "build-editor": "node --max_old_space_size=8192 ./node_modules/vite/bin/vite.js build",
         "build-clear": "rm -rf ./dist",
         "preview": "vite preview",
         "check": "tsc --noEmit",

--- a/src/data-fetchers/vcf/utils.ts
+++ b/src/data-fetchers/vcf/utils.ts
@@ -1,0 +1,81 @@
+import type { VcfRecord, VcfTile } from './vcf-data-fetcher';
+
+export const getMutationType = (ref: string, alt?: string) => {
+    if (!alt) return 'unknown';
+    if (ref.length === alt.length) return 'substitution';
+    if (ref.length > alt.length) return 'deletion';
+    if (ref.length < alt.length) return 'insertion';
+    return 'unknown';
+};
+
+export const getSubstitutionType = (ref: string, alt?: string) => {
+    switch (ref + alt) {
+        case 'CA':
+        case 'GT':
+            return 'C>A';
+        case 'CG':
+        case 'GC':
+            return 'C>G';
+        case 'CT':
+        case 'GA':
+            return 'C>T';
+        case 'TA':
+        case 'AT':
+            return 'T>A';
+        case 'TC':
+        case 'AG':
+            return 'T>C';
+        case 'TG':
+        case 'AC':
+            return 'T>G';
+        default:
+            return 'unknown';
+    }
+};
+
+/**
+ * Convert a VCF record to a tile data
+ * @param vcfRecord A row of a VCF files loaded
+ * @param chrPos Cumulative start position of a chromosome
+ * @param prevPos Previous position of a point mutation for calculating 'distance to previous'
+ */
+export function recordToTile(vcfRecord: VcfRecord, chrPos: number, prevPos?: number) {
+    const POS = chrPos + vcfRecord.POS + 1;
+
+    let ALT: string | undefined;
+    if (Array.isArray(vcfRecord.ALT) && vcfRecord.ALT.length > 0) {
+        ALT = vcfRecord.ALT[0];
+    }
+
+    // Additionally inferred values
+    const DISTPREV = !prevPos ? null : vcfRecord.POS - prevPos;
+    const DISTPREVLOGE = !prevPos ? null : Math.log(vcfRecord.POS - prevPos);
+    const MUTTYPE = getMutationType(vcfRecord.REF, ALT);
+    const SUBTYPE = getSubstitutionType(vcfRecord.REF, ALT);
+    const POSEND = POS + vcfRecord.REF.length;
+
+    // Create key values
+    const data: VcfTile = {
+        ...vcfRecord,
+        ALT,
+        MUTTYPE,
+        SUBTYPE,
+        INFO: JSON.stringify(vcfRecord.INFO),
+        ORIGINALPOS: vcfRecord.POS,
+        POS,
+        POSEND,
+        DISTPREV,
+        DISTPREVLOGE
+    };
+
+    // Add optional INFO columns
+    Object.keys(vcfRecord.INFO).forEach(key => {
+        const val = vcfRecord.INFO[key];
+        if (Array.isArray(val)) {
+            data[key] = val.join(', ');
+        } else {
+            data[key] = val;
+        }
+    });
+    return data;
+}

--- a/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
@@ -1,5 +1,5 @@
-import { recordToTile } from './vcf-worker';
-import type { VcfRecord } from './vcf-worker';
+import { recordToTile } from './vcf-data-fetcher';
+import type { VcfRecord } from './vcf-data-fetcher';
 
 describe('VCF file parser', () => {
     it('Convert a VCF record to a tile data', () => {

--- a/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
@@ -21,6 +21,28 @@ describe('VCF file parser', () => {
         const prevPos = record.POS - 100;
         const tile = recordToTile(record, chrPos, prevPos);
 
-        expect(tile).toMatchInlineSnapshot();
+        expect(tile).toMatchInlineSnapshot(`
+          {
+            "AF": "0.5, DB, H2",
+            "ALT": "A",
+            "CHROM": "20",
+            "DISTPREV": 100,
+            "DISTPREVLOGE": 4.605170185988092,
+            "DP": "14",
+            "FILTER": "PASS",
+            "ID": [
+              "rs6054257",
+            ],
+            "INFO": "{\\"NS\\":[3],\\"DP\\":[14],\\"AF\\":[\\"0.5\\",\\"DB\\",\\"H2\\"]}",
+            "MUTTYPE": "substitution",
+            "NS": "3",
+            "ORIGINALPOS": 14370,
+            "POS": 137827,
+            "POSEND": 137828,
+            "QUAL": 29,
+            "REF": "G",
+            "SUBTYPE": "C>T",
+          }
+        `);
     });
 });

--- a/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
@@ -22,7 +22,7 @@ describe('VCF file parser', () => {
         const tile = recordToTile(record, chrPos, prevPos);
 
         expect(tile.MUTTYPE).toBe('substitution');
-        expect(tile.SUBTYPE).toBe('G>A');
+        expect(tile.SUBTYPE).toBe('C>T');
         expect(tile.DISTPREV).toBe(chrPos + record.POS - prevPos);
         expect(tile.NS).toBe(3);
     });

--- a/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
@@ -21,9 +21,6 @@ describe('VCF file parser', () => {
         const prevPos = record.POS - 100;
         const tile = recordToTile(record, chrPos, prevPos);
 
-        expect(tile.MUTTYPE).toBe('substitution');
-        expect(tile.SUBTYPE).toBe('C>T');
-        expect(tile.DISTPREV).toBe(100);
-        expect(tile.NS).toBe('3'); // always string
+        expect(tile).toMatchInlineSnapshot();
     });
 });

--- a/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
@@ -1,4 +1,4 @@
-import { recordToTile } from './vcf-data-fetcher';
+import { recordToTile } from './utils';
 import type { VcfRecord } from './vcf-data-fetcher';
 
 describe('VCF file parser', () => {

--- a/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
@@ -24,6 +24,6 @@ describe('VCF file parser', () => {
         expect(tile.MUTTYPE).toBe('substitution');
         expect(tile.SUBTYPE).toBe('C>T');
         expect(tile.DISTPREV).toBe(100);
-        expect(tile.NS).toBe(3);
+        expect(tile.NS).toBe('3'); // always string
     });
 });

--- a/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.test.ts
@@ -18,12 +18,12 @@ describe('VCF file parser', () => {
             }
         };
         const chrPos = 123456;
-        const prevPos = chrPos - 100;
+        const prevPos = record.POS - 100;
         const tile = recordToTile(record, chrPos, prevPos);
 
         expect(tile.MUTTYPE).toBe('substitution');
         expect(tile.SUBTYPE).toBe('C>T');
-        expect(tile.DISTPREV).toBe(chrPos + record.POS - prevPos);
+        expect(tile.DISTPREV).toBe(100);
         expect(tile.NS).toBe(3);
     });
 });

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -11,6 +11,7 @@ import type { ModuleThread } from 'threads';
 import type { Assembly, VcfData } from '../../core/gosling.schema';
 import type { WorkerApi, TilesetInfo } from './vcf-worker';
 import type { TabularDataFetcher } from '../utils';
+import { getSubstitutionType, getMutationType } from './utils';
 
 const DEBOUNCE_TIME = 200;
 
@@ -38,86 +39,6 @@ export type VcfTile = Omit<VcfRecord, 'ALT' | 'INFO'> & {
     DISTPREV: number | null;
     DISTPREVLOGE: number | null;
 } & { [infoKey: string]: any };
-
-const getMutationType = (ref: string, alt?: string) => {
-    if (!alt) return 'unknown';
-    if (ref.length === alt.length) return 'substitution';
-    if (ref.length > alt.length) return 'deletion';
-    if (ref.length < alt.length) return 'insertion';
-    return 'unknown';
-};
-
-const getSubstitutionType = (ref: string, alt?: string) => {
-    switch (ref + alt) {
-        case 'CA':
-        case 'GT':
-            return 'C>A';
-        case 'CG':
-        case 'GC':
-            return 'C>G';
-        case 'CT':
-        case 'GA':
-            return 'C>T';
-        case 'TA':
-        case 'AT':
-            return 'T>A';
-        case 'TC':
-        case 'AG':
-            return 'T>C';
-        case 'TG':
-        case 'AC':
-            return 'T>G';
-        default:
-            return 'unknown';
-    }
-};
-
-/**
- * Convert a VCF record to a tile data
- * @param vcfRecord A row of a VCF files loaded
- * @param chrPos Cumulative start position of a chromosome
- * @param prevPos Previous position of a point mutation for calculating 'distance to previous'
- */
-export function recordToTile(vcfRecord: VcfRecord, chrPos: number, prevPos?: number) {
-    const POS = chrPos + vcfRecord.POS + 1;
-
-    let ALT: string | undefined;
-    if (Array.isArray(vcfRecord.ALT) && vcfRecord.ALT.length > 0) {
-        ALT = vcfRecord.ALT[0];
-    }
-
-    // Additionally inferred values
-    const DISTPREV = !prevPos ? null : vcfRecord.POS - prevPos;
-    const DISTPREVLOGE = !prevPos ? null : Math.log(vcfRecord.POS - prevPos);
-    const MUTTYPE = getMutationType(vcfRecord.REF, ALT);
-    const SUBTYPE = getSubstitutionType(vcfRecord.REF, ALT);
-    const POSEND = POS + vcfRecord.REF.length;
-
-    // Create key values
-    const data: VcfTile = {
-        ...vcfRecord,
-        ALT,
-        MUTTYPE,
-        SUBTYPE,
-        INFO: JSON.stringify(vcfRecord.INFO),
-        ORIGINALPOS: vcfRecord.POS,
-        POS,
-        POSEND,
-        DISTPREV,
-        DISTPREVLOGE
-    };
-
-    // Add optional INFO columns
-    Object.keys(vcfRecord.INFO).forEach(key => {
-        const val = vcfRecord.INFO[key];
-        if (Array.isArray(val)) {
-            data[key] = val.join(', ');
-        } else {
-            data[key] = val;
-        }
-    });
-    return data;
-}
 
 class VcfDataFetcher implements TabularDataFetcher<VcfTile> {
     static config = { type: 'vcf' };

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -9,10 +9,115 @@ import { computeChromSizes } from '../../core/utils/assembly';
 
 import type { ModuleThread } from 'threads';
 import type { Assembly, VcfData } from '../../core/gosling.schema';
-import type { WorkerApi, TilesetInfo, VcfTile } from './vcf-worker';
+import type { WorkerApi, TilesetInfo } from './vcf-worker';
 import type { TabularDataFetcher } from '../utils';
 
 const DEBOUNCE_TIME = 200;
+
+// const MAX_TILES = 20;
+// https://github.com/GMOD/vcf-js/blob/c4a9cbad3ba5a3f0d1c817d685213f111bf9de9b/src/parse.ts#L284-L291
+export type VcfRecord = {
+    CHROM: string;
+    POS: number;
+    ID: null | string[];
+    REF: string;
+    ALT: null | string[];
+    QUAL: null | number;
+    FILTER: null | string;
+    INFO: Record<string, true | (number | null)[] | string[]>;
+};
+
+export type VcfTile = Omit<VcfRecord, 'ALT' | 'INFO'> & {
+    ALT: string | undefined;
+    MUTTYPE: ReturnType<typeof getMutationType>;
+    SUBTYPE: ReturnType<typeof getSubstitutionType>;
+    INFO: string;
+    ORIGINALPOS: number;
+    POS: number;
+    POSEND: number;
+    DISTPREV: number | null;
+    DISTPREVLOGE: number | null;
+} & { [infoKey: string]: any };
+
+const getMutationType = (ref: string, alt?: string) => {
+    if (!alt) return 'unknown';
+    if (ref.length === alt.length) return 'substitution';
+    if (ref.length > alt.length) return 'deletion';
+    if (ref.length < alt.length) return 'insertion';
+    return 'unknown';
+};
+
+const getSubstitutionType = (ref: string, alt?: string) => {
+    switch (ref + alt) {
+        case 'CA':
+        case 'GT':
+            return 'C>A';
+        case 'CG':
+        case 'GC':
+            return 'C>G';
+        case 'CT':
+        case 'GA':
+            return 'C>T';
+        case 'TA':
+        case 'AT':
+            return 'T>A';
+        case 'TC':
+        case 'AG':
+            return 'T>C';
+        case 'TG':
+        case 'AC':
+            return 'T>G';
+        default:
+            return 'unknown';
+    }
+};
+
+/**
+ * Convert a VCF record to a tile data
+ * @param vcfRecord A row of a VCF files loaded
+ * @param chrPos Cumulative start position of a chromosome
+ * @param prevPos Previous position of a point mutation for calculating 'distance to previous'
+ */
+export function recordToTile(vcfRecord: VcfRecord, chrPos: number, prevPos?: number) {
+    const POS = chrPos + vcfRecord.POS + 1;
+
+    let ALT: string | undefined;
+    if (Array.isArray(vcfRecord.ALT) && vcfRecord.ALT.length > 0) {
+        ALT = vcfRecord.ALT[0];
+    }
+
+    // Additionally inferred values
+    const DISTPREV = !prevPos ? null : vcfRecord.POS - prevPos;
+    const DISTPREVLOGE = !prevPos ? null : Math.log(vcfRecord.POS - prevPos);
+    const MUTTYPE = getMutationType(vcfRecord.REF, ALT);
+    const SUBTYPE = getSubstitutionType(vcfRecord.REF, ALT);
+    const POSEND = POS + vcfRecord.REF.length;
+
+    // Create key values
+    const data: VcfTile = {
+        ...vcfRecord,
+        ALT,
+        MUTTYPE,
+        SUBTYPE,
+        INFO: JSON.stringify(vcfRecord.INFO),
+        ORIGINALPOS: vcfRecord.POS,
+        POS,
+        POSEND,
+        DISTPREV,
+        DISTPREVLOGE
+    };
+
+    // Add optional INFO columns
+    Object.keys(vcfRecord.INFO).forEach(key => {
+        const val = vcfRecord.INFO[key];
+        if (Array.isArray(val)) {
+            data[key] = val.join(', ');
+        } else {
+            data[key] = val;
+        }
+    });
+    return data;
+}
 
 class VcfDataFetcher implements TabularDataFetcher<VcfTile> {
     static config = { type: 'vcf' };

--- a/src/data-fetchers/vcf/vcf-worker.test.ts
+++ b/src/data-fetchers/vcf/vcf-worker.test.ts
@@ -1,0 +1,29 @@
+import { recordToTile } from './vcf-worker';
+import type { VcfRecord } from './vcf-worker';
+
+describe('VCF file parser', () => {
+    it('Convert a VCF record to a tile data', () => {
+        const record: VcfRecord = {
+            CHROM: '20',
+            POS: 14370,
+            ID: ['rs6054257'],
+            REF: 'G',
+            ALT: ['A'],
+            QUAL: 29,
+            FILTER: 'PASS',
+            INFO: {
+                NS: [3],
+                DP: [14],
+                AF: ['0.5', 'DB', 'H2']
+            }
+        };
+        const chrPos = 123456;
+        const prevPos = chrPos - 100;
+        const tile = recordToTile(record, chrPos, prevPos);
+
+        expect(tile.MUTTYPE).toBe('substitution');
+        expect(tile.SUBTYPE).toBe('G>A');
+        expect(tile.DISTPREV).toBe(chrPos + record.POS - prevPos);
+        expect(tile.NS).toBe(3);
+    });
+});

--- a/src/data-fetchers/vcf/vcf-worker.ts
+++ b/src/data-fetchers/vcf/vcf-worker.ts
@@ -64,7 +64,7 @@ export type VcfTile = Omit<VcfRecord, 'ALT' | 'INFO'> & {
     POSEND: number;
     DISTPREV: number | null;
     DISTPREVLOGE: number | null;
-};
+} & { [k: string]: any };
 
 // promises indexed by url
 const tileValues: Record<string, VcfTile[]> = {}; // new LRU({ max: MAX_TILES });
@@ -184,10 +184,14 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
                 DISTPREVLOGE
             };
 
+            // Add optional columns
             Object.keys(vcfRecord.INFO).forEach(key => {
                 const val = vcfRecord.INFO[key];
-                if (Array.isArray(val)) return [key, val[0]] as const;
-                return [key, val] as const;
+                if (Array.isArray(val)) {
+                    data[key] = val[0];
+                } else {
+                    data[key] = val;
+                 }
             });
 
             // Store this column

--- a/src/data-fetchers/vcf/vcf-worker.ts
+++ b/src/data-fetchers/vcf/vcf-worker.ts
@@ -191,7 +191,7 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
                     data[key] = val[0];
                 } else {
                     data[key] = val;
-                 }
+                }
             });
 
             // Store this column
@@ -260,7 +260,6 @@ const fetchTilesDebounced = async (uid: string, tileIds: string[]) => {
             const validTileId = validTileIds[i];
             // @ts-expect-error values is void, this should never happen.
             tiles[validTileId] = values[i];
-            // @ts-expect-error values is void, this should never happen.
             tiles[validTileId].tilePositionId = validTileId;
         }
         return tiles;

--- a/src/data-fetchers/vcf/vcf-worker.ts
+++ b/src/data-fetchers/vcf/vcf-worker.ts
@@ -11,6 +11,7 @@ import { DataSource, RemoteFile } from '../utils';
 
 import type { TilesetInfo } from '@higlass/types';
 import type { ChromSizes } from '@gosling.schema';
+import { recordToTile, type VcfRecord, type VcfTile } from './vcf-data-fetcher';
 
 // promises indexed by urls
 const vcfFiles: Map<string, VcfFile> = new Map();
@@ -41,31 +42,6 @@ class VcfFile {
     }
 }
 
-// const MAX_TILES = 20;
-// https://github.com/GMOD/vcf-js/blob/c4a9cbad3ba5a3f0d1c817d685213f111bf9de9b/src/parse.ts#L284-L291
-export type VcfRecord = {
-    CHROM: string;
-    POS: number;
-    ID: null | string[];
-    REF: string;
-    ALT: null | string[];
-    QUAL: null | number;
-    FILTER: null | string;
-    INFO: Record<string, true | (number | null)[] | string[]>;
-};
-
-export type VcfTile = Omit<VcfRecord, 'ALT' | 'INFO'> & {
-    ALT: string | undefined;
-    MUTTYPE: ReturnType<typeof getMutationType>;
-    SUBTYPE: ReturnType<typeof getSubstitutionType>;
-    INFO: string;
-    ORIGINALPOS: number;
-    POS: number;
-    POSEND: number;
-    DISTPREV: number | null;
-    DISTPREVLOGE: number | null;
-} & { [infoKey: string]: any };
-
 // promises indexed by url
 const tileValues: Record<string, VcfTile[]> = {}; // new LRU({ max: MAX_TILES });
 
@@ -92,86 +68,6 @@ function init(
 const tilesetInfo = (uid: string) => {
     return dataSources.get(uid)!.tilesetInfo;
 };
-
-const getMutationType = (ref: string, alt?: string) => {
-    if (!alt) return 'unknown';
-    if (ref.length === alt.length) return 'substitution';
-    if (ref.length > alt.length) return 'deletion';
-    if (ref.length < alt.length) return 'insertion';
-    return 'unknown';
-};
-
-const getSubstitutionType = (ref: string, alt?: string) => {
-    switch (ref + alt) {
-        case 'CA':
-        case 'GT':
-            return 'C>A';
-        case 'CG':
-        case 'GC':
-            return 'C>G';
-        case 'CT':
-        case 'GA':
-            return 'C>T';
-        case 'TA':
-        case 'AT':
-            return 'T>A';
-        case 'TC':
-        case 'AG':
-            return 'T>C';
-        case 'TG':
-        case 'AC':
-            return 'T>G';
-        default:
-            return 'unknown';
-    }
-};
-
-/**
- * Convert a VCF record to a tile data
- * @param vcfRecord A row of a VCF files loaded
- * @param chrPos Cumulative start position of a chromosome
- * @param prevPos Previous position of a point mutation for calculating 'distance to previous'
- */
-export function recordToTile(vcfRecord: VcfRecord, chrPos: number, prevPos?: number) {
-    const POS = chrPos + vcfRecord.POS + 1;
-
-    let ALT: string | undefined;
-    if (Array.isArray(vcfRecord.ALT) && vcfRecord.ALT.length > 0) {
-        ALT = vcfRecord.ALT[0];
-    }
-
-    // Additionally inferred values
-    const DISTPREV = !prevPos ? null : vcfRecord.POS - prevPos;
-    const DISTPREVLOGE = !prevPos ? null : Math.log(vcfRecord.POS - prevPos);
-    const MUTTYPE = getMutationType(vcfRecord.REF, ALT);
-    const SUBTYPE = getSubstitutionType(vcfRecord.REF, ALT);
-    const POSEND = POS + vcfRecord.REF.length;
-
-    // Create key values
-    const data: VcfTile = {
-        ...vcfRecord,
-        ALT,
-        MUTTYPE,
-        SUBTYPE,
-        INFO: JSON.stringify(vcfRecord.INFO),
-        ORIGINALPOS: vcfRecord.POS,
-        POS,
-        POSEND,
-        DISTPREV,
-        DISTPREVLOGE
-    };
-
-    // Add optional INFO columns
-    Object.keys(vcfRecord.INFO).forEach(key => {
-        const val = vcfRecord.INFO[key];
-        if (Array.isArray(val)) {
-            data[key] = val.join(', ');
-        } else {
-            data[key] = val;
-        }
-    });
-    return data;
-}
 
 // We return an empty tile. We get the data from SvTrack
 const tile = async (uid: string, z: number, x: number): Promise<void[]> => {

--- a/src/data-fetchers/vcf/vcf-worker.ts
+++ b/src/data-fetchers/vcf/vcf-worker.ts
@@ -64,7 +64,7 @@ export type VcfTile = Omit<VcfRecord, 'ALT' | 'INFO'> & {
     POSEND: number;
     DISTPREV: number | null;
     DISTPREVLOGE: number | null;
-} & { [infoFieldKey: string]: any };
+} & { [infoKey: string]: any };
 
 // promises indexed by url
 const tileValues: Record<string, VcfTile[]> = {}; // new LRU({ max: MAX_TILES });
@@ -184,11 +184,11 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
                 DISTPREVLOGE
             };
 
-            // Add optional columns
+            // Add optional INFO columns
             Object.keys(vcfRecord.INFO).forEach(key => {
                 const val = vcfRecord.INFO[key];
                 if (Array.isArray(val)) {
-                    data[key] = val.join(',');
+                    data[key] = val.join(', ');
                 } else {
                     data[key] = val;
                 }

--- a/src/data-fetchers/vcf/vcf-worker.ts
+++ b/src/data-fetchers/vcf/vcf-worker.ts
@@ -11,7 +11,8 @@ import { DataSource, RemoteFile } from '../utils';
 
 import type { TilesetInfo } from '@higlass/types';
 import type { ChromSizes } from '@gosling.schema';
-import { recordToTile, type VcfRecord, type VcfTile } from './vcf-data-fetcher';
+import { recordToTile } from './utils';
+import type { VcfRecord, VcfTile } from './vcf-data-fetcher';
 
 // promises indexed by urls
 const vcfFiles: Map<string, VcfFile> = new Map();

--- a/src/data-fetchers/vcf/vcf-worker.ts
+++ b/src/data-fetchers/vcf/vcf-worker.ts
@@ -64,7 +64,7 @@ export type VcfTile = Omit<VcfRecord, 'ALT' | 'INFO'> & {
     POSEND: number;
     DISTPREV: number | null;
     DISTPREVLOGE: number | null;
-} & { [k: string]: any };
+} & { [infoFieldKey: string]: any };
 
 // promises indexed by url
 const tileValues: Record<string, VcfTile[]> = {}; // new LRU({ max: MAX_TILES });
@@ -188,7 +188,7 @@ const tile = async (uid: string, z: number, x: number): Promise<void[]> => {
             Object.keys(vcfRecord.INFO).forEach(key => {
                 const val = vcfRecord.INFO[key];
                 if (Array.isArray(val)) {
-                    data[key] = val[0];
+                    data[key] = val.join(',');
                 } else {
                     data[key] = val;
                 }


### PR DESCRIPTION
Fix #858

## Change List
 - Support parsing INFO fields of VCF files. 

### A tooltip showing the two of the INFO fields 
<img width="1197" alt="Screenshot 2023-04-06 at 11 17 57" src="https://user-images.githubusercontent.com/9922882/230425688-d2983c80-ea69-407f-90e9-4c52fa35d93d.png">

### A single line of a VCF file

> chr1	118168808	.	G	A	62.19	PASS	ECNT=1;FS=5.392;HCNT=1;MAX_ED=.;MIN_ED=.;NLOD=8.42;NLODF=4.13;PV=0.0028;PV2=0.0028;SOR=1.397;TLOD=41.24	GT:AD:AF:AFDP:ALTHC:ALT_F1R2:ALT_F2R1:BaseQRankSumPS:ClippingRankSumPS:DPHC:FOXOG:MQRankSumPS:NBQPS:QSS:REF_F1R2:REF_F2R1:ReadPosEndDistPS:ReadPosRankSumPS	0/

### Demo on Local Browser

[Link](HTTP://localhost:3000/?full=false&spec=(M%27layout4%27linear%27%2CM%27arrangement4%27vertical%27%2CM%27centerRadius40.8%2CM%27viewsXM*(M**%27tracksXM***(2%27dataTransformX2*(%27Qfilter7JoneOfXnull%5D)2%5DH%27id4%27track-1%27H%27data4(2*%27url4%27hFK~Qvcf~indexUrl4%27hFK.tbi~sampleLength450002)H%27tooltipX2*(%27JQnominal7format4%27s1%27)H*W%27)2%5DH%27mark4%27point%27H%27x4WZcolor4(2*%27jSUBTYPE~Qnominal~legend4trueH*%27domainX%27C%3EA7C%3EG7C%3ET7T%3EA7T%3EC7T%3EG%27%5D2)H%27y4(%27JQquantitativeZopacity4(%27value40.9)H%27width4600H%27height4130M***)M**%5DM*)M%5D%0A)*%20%202M****4!%207%27%2C%20%27Fttps%3A%2F%2Fs3.amazonaws.com%2Fgosling-lang.org%2Fdata%2FSV%2FH%2C2JjDISTPREVLOGE7KSNV_test_tumor_normal_with_panel.vcf.gzM%0A*Qtype4%27W(%27jPOS7QgenomicX4%5BZ7axis4%27top%27)H%27jfield4%27~%27H*%27%01~jZXWQMKJHF742*_)

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
