### PR TITLE
fix: alias lodash to lodash-es for smaller bundle

### DIFF
--- a/editor/example/json-spec/matrix.ts
+++ b/editor/example/json-spec/matrix.ts
@@ -1,6 +1,6 @@
 import type { PredefinedColors, SingleTrack } from '@gosling.schema';
 import type { GoslingSpec } from 'gosling.js';
-import { random } from 'lodash';
+import { random } from 'lodash-es';
 import { GOSLING_PUBLIC_DATA } from './gosling-data';
 
 const generateToyJson = (length: number, chr: string, size: number) =>

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -7,7 +7,7 @@ import { getTheme, type Theme } from './utils/theme';
 import { createApi, type GoslingApi } from './api';
 import { GoslingTemplates } from '..';
 import { omitDeep } from './utils/omit-deep';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import * as uuid from 'uuid';
 
 import type { TemplateTrackDef, TrackMouseEventData } from './gosling.schema';

--- a/src/core/utils/omit-deep.ts
+++ b/src/core/utils/omit-deep.ts
@@ -1,9 +1,10 @@
 import type { GoslingSpec } from '@gosling.schema';
-import { cloneDeepWith, type CloneDeepWithCustomizer } from 'lodash';
+import { cloneDeepWith } from 'lodash-es';
+import { isObject } from '../gosling.schema.guards';
 
 export function omitDeep(spec: GoslingSpec, omitKeys: string[]) {
-    return cloneDeepWith(spec, (value: CloneDeepWithCustomizer<GoslingSpec>) => {
-        if (value && typeof value === 'object') {
+    return cloneDeepWith(spec, (value: unknown) => {
+        if (isObject(value)) {
             omitKeys.forEach(key => {
                 delete value[key];
             });


### PR DESCRIPTION
Fix #
Toward #

I was just curious and ran `npx vite-bundler-vizualizer` to see what largest contributors to the gosling bundle are currently.

I was surprised to see `lodash` as such a large contributor (531kb).

<img src="https://user-images.githubusercontent.com/24403730/234042881-88c27c5c-3a7f-4821-970b-b2fa9684d57b.png">

Digging deeper, I discovered that `lodash` is not a direct dependency of Gosling (it's not listed in `package.json`), but `yarn`'s module scoping doesn't prevent tools like `typescript` or `vite` from digging into `node_modules` and finding `lodash` if it's used by a different dependency. This means that we ended up including `lodash` (a commonjs, non-treeshakeable module) in all of our builds.

The fix here makes the use of `lodash-es` consistent in the code base and removes this issue from the build.

<img  src="https://user-images.githubusercontent.com/24403730/234042672-79e46411-e906-4601-a229-898c5005cd86.png">


## Change List
 - use only `lodash-es` in the source code (not `lodash`)

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
