### PR TITLE
fix: pileup calculation works when start and end fields are the same

### DIFF
--- a/src/core/utils/data-transform.test.ts
+++ b/src/core/utils/data-transform.test.ts
@@ -1,4 +1,5 @@
-import { filterData, calculateData, aggregateData, splitExon, inferSvType } from './data-transform';
+import { filterData, calculateData, aggregateData, splitExon, inferSvType, displace } from './data-transform';
+import { scaleLinear } from 'd3-scale';
 
 describe('Data Transformation', () => {
     it('Filter', () => {
@@ -11,6 +12,110 @@ describe('Data Transformation', () => {
         expect(filtered).toHaveLength(2);
         expect(filtered.filter(d => d['c'] === 'b')).toHaveLength(0);
         expect(filtered.filter(d => d['q'] === 4)).toHaveLength(0);
+    });
+    it('Pile', () => {
+        const data = [
+            { s: 2, e: 3 },
+            { s: 4, e: 6 },
+            { s: 1, e: 2 },
+            { s: 1, e: 3 }
+        ];
+        const scale = scaleLinear().domain([1, 10]).range([1, 1000]);
+        expect(
+            displace(
+                { type: 'displace', method: 'pile', boundingBox: { startField: 's', endField: 'e' }, newField: 'row' },
+                data,
+                scale
+            )
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "e": 2,
+              "row": "0",
+              "s": 1,
+            },
+            {
+              "e": 3,
+              "row": "1",
+              "s": 1,
+            },
+            {
+              "e": 3,
+              "row": "2",
+              "s": 2,
+            },
+            {
+              "e": 6,
+              "row": "0",
+              "s": 4,
+            },
+          ]
+        `);
+        expect(
+            displace(
+                { type: 'displace', method: 'pile', boundingBox: { startField: 's', endField: 's' }, newField: 'row' },
+                data,
+                scale
+            )
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "e": 2,
+              "row": "0",
+              "s": 1,
+            },
+            {
+              "e": 3,
+              "row": "1",
+              "s": 1,
+            },
+            {
+              "e": 3,
+              "row": "0",
+              "s": 2,
+            },
+            {
+              "e": 6,
+              "row": "0",
+              "s": 4,
+            },
+          ]
+        `);
+        expect(
+            displace(
+                {
+                    type: 'displace',
+                    method: 'pile',
+                    boundingBox: { startField: 's', endField: 'e', padding: 1, isPaddingBP: true },
+                    newField: 'row'
+                },
+                data,
+                scale
+            )
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "e": 2,
+              "row": "0",
+              "s": 1,
+            },
+            {
+              "e": 3,
+              "row": "1",
+              "s": 1,
+            },
+            {
+              "e": 3,
+              "row": "2",
+              "s": 2,
+            },
+            {
+              "e": 6,
+              "row": "3",
+              "s": 4,
+            },
+          ]
+        `);
     });
     it('SV', () => {
         const svTypes = inferSvType(

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -228,21 +228,26 @@ export function aggregateCoverage(
     return output;
 }
 
+/**
+ * Mark displacement transform furnctions.
+ * @param t An object that contains data transformation spec.
+ * @param data An array of objects that contain data.
+ * @param scale A d3's linear scale that map between data-level values to screen-level values (px).
+ * @returns
+ */
 export function displace(
     t: DisplaceTransform,
     data: Datum[],
     scale: d3.ScaleContinuousNumeric<number, number>
 ): Datum[] {
-    // Logging.recordTime('displace()');
-
     const { boundingBox, method, newField } = t;
     const { startField, endField, groupField } = boundingBox;
 
-    let padding = 0; // This is a pixel value.
+    let paddingInBp = 0;
     if (boundingBox.padding && scale && !boundingBox.isPaddingBP) {
-        padding = Math.abs(scale.invert(boundingBox.padding) - scale.invert(0));
+        paddingInBp = Math.abs(scale.invert(boundingBox.padding) - scale.invert(0));
     } else if (boundingBox.padding && boundingBox.isPaddingBP) {
-        padding = boundingBox.padding;
+        paddingInBp = boundingBox.padding;
     }
 
     // Check whether we have sufficient information.
@@ -255,90 +260,50 @@ export function displace(
     }
 
     if (method === 'pile') {
-        const oldAlgorithm = false;
+        // This piling algorithm is heavily based on
+        // https://github.com/higlass/higlass-pileup/blob/8538a34c6d884c28455d6178377ee1ea2c2c90ae/src/bam-fetcher-worker.js#L626
+        const { maxRows } = t;
+        const occupiedSpaceInRows: { [group: string]: { start: number; end: number }[] } = {};
 
-        if (oldAlgorithm) {
-            // This will be deprecated soon.
-            const { maxRows } = t;
-            const boundingBoxes: { start: number; end: number; row: number }[] = [];
+        const sorted = base.sort((a: Datum, b: Datum) => (a[startField] as number) - (b[startField] as number));
 
-            base.sort((a: Datum, b: Datum) => (a[startField] as number) - (b[startField] as number)).forEach(
-                (d: Datum) => {
-                    const start = (d[startField] as number) - padding;
-                    const end = (d[endField] as number) + padding;
+        sorted.forEach((d: Datum) => {
+            const start = +d[startField] - paddingInBp;
+            const end = +d[endField] + paddingInBp;
 
-                    const overlapped = boundingBoxes.filter(
-                        box =>
-                            (box.start === start && end === box.end) ||
-                            (box.start <= start && start < box.end) ||
-                            (box.start < end && end <= box.end) ||
-                            (start < box.start && box.end < end)
-                    );
+            // Create object if none
+            const group = groupField ? d[groupField] : '__NO_GROUP__';
+            if (!occupiedSpaceInRows[group]) {
+                occupiedSpaceInRows[group] = [];
+            }
 
-                    // find the lowest non overlapped row
-                    const uniqueRows = [
-                        ...Array.from(new Set(boundingBoxes.map(d => d.row))),
-                        Math.max(...boundingBoxes.map(d => d.row)) + 1
-                    ];
-                    const overlappedRows = overlapped.map(d => d.row);
-                    const lowestNonOverlappedRow = Math.min(
-                        ...uniqueRows.filter(d => overlappedRows.indexOf(d) === -1)
-                    );
-
-                    // row index starts from zero
-                    const row: number = overlapped.length === 0 ? 0 : lowestNonOverlappedRow;
-
-                    d[newField] = `${maxRows && maxRows <= row ? maxRows - 1 : row}`;
-
-                    boundingBoxes.push({ start, end, row });
+            // Find a row to place this segment
+            let rowIndex = occupiedSpaceInRows[group].findIndex(d => {
+                // Find a space and update the occupancy info.
+                if (end < d.start) {
+                    d.start = start;
+                    return true;
+                } else if (d.end < start) {
+                    d.end = end;
+                    return true;
                 }
-            );
-        } else {
-            // This piling algorithm is heavily based on
-            // https://github.com/higlass/higlass-pileup/blob/8538a34c6d884c28455d6178377ee1ea2c2c90ae/src/bam-fetcher-worker.js#L626
-            const { maxRows } = t;
-            const occupiedSpaceInRows: { [group: string]: { start: number; end: number }[] } = {};
-
-            const sorted = base.sort((a: Datum, b: Datum) => (a[startField] as number) - (b[startField] as number));
-
-            sorted.forEach((d: Datum) => {
-                const start = (d[startField] as number) - padding;
-                const end = (d[endField] as number) + padding;
-
-                // Create object if none
-                const group = groupField ? d[groupField] : '__NO_GROUP__';
-                if (!occupiedSpaceInRows[group]) {
-                    occupiedSpaceInRows[group] = [];
-                }
-
-                // Find a row to place this segment
-                let rowIndex = occupiedSpaceInRows[group].findIndex(d => {
-                    // Find a space and update the occupancy info.
-                    if (end < d.start) {
-                        d.start = start;
-                        return true;
-                    } else if (d.end < start) {
-                        d.end = end;
-                        return true;
-                    }
-                    return false;
-                });
-
-                if (rowIndex === -1) {
-                    // We did not find sufficient space from the existing rows, so add a new row.
-                    occupiedSpaceInRows[group].push({ start, end });
-                    rowIndex = occupiedSpaceInRows[group].length - 1;
-                }
-
-                d[newField] = `${maxRows && maxRows <= rowIndex ? maxRows - 1 : rowIndex}`;
+                return false;
             });
-        }
+
+            if (rowIndex === -1) {
+                // We did not find sufficient space from the existing rows, so add a new row.
+                occupiedSpaceInRows[group].push({ start, end });
+                rowIndex = occupiedSpaceInRows[group].length - 1;
+            }
+
+            d[newField] = `${maxRows && maxRows <= rowIndex ? maxRows - 1 : rowIndex}`;
+        });
     } else if (method === 'spread') {
         const boundingBoxes: { start: number; end: number }[] = [];
 
         base.sort((a: Datum, b: Datum) => (a[startField] as number) - (b[startField] as number)).forEach((d: Datum) => {
-            let start = (d[startField] as number) - padding;
-            let end = (d[endField] as number) + padding;
+            let start = (d[startField] as number) - paddingInBp;
+            let end = (d[endField] as number) + paddingInBp;
 
             let overlapped = boundingBoxes.filter(
                 box =>
@@ -360,11 +325,11 @@ export function displace(
                     );
                     if (overlapped.length > 0) {
                         if (trial % 2 === 0) {
-                            start += padding * trial;
-                            end += padding * trial;
+                            start += paddingInBp * trial;
+                            end += paddingInBp * trial;
                         } else {
-                            start -= padding * trial;
-                            end -= padding * trial;
+                            start -= paddingInBp * trial;
+                            end -= paddingInBp * trial;
                         }
                     }
                     trial++;
@@ -372,8 +337,8 @@ export function displace(
                 } while (overlapped.length > 0 && trial < 1000);
             }
 
-            d[`${newField}Start`] = `${start + padding}`;
-            d[`${newField}Etart`] = `${end - padding}`;
+            d[`${newField}Start`] = `${start + paddingInBp}`;
+            d[`${newField}Etart`] = `${end - paddingInBp}`;
 
             boundingBoxes.push({ start, end });
         });


### PR DESCRIPTION
Toward #883 

## Change List
- Fix an issue that pileup was not working in a case of startField and endField being the same.
 - 🧪 Add tests
 - 🧹 Remove an unused pileup algorithm

<img width="662" alt="Screenshot 2023-05-05 at 16 10 12" src="https://user-images.githubusercontent.com/9922882/236559834-205698a2-d82e-456a-8072-fc54718912bf.png">

<a href="http://localhost:3000/?full=false&spec=(H%27assemblyO%5B%27Q%27P4791961%5D%5DR%27viewsOH*(HKalignmentUoverlay%27RKlayoutUlZear%27RKtracksOHj*(8%27qA(8*%27urlUhttps%3A%2F%2Fs3.amazonaws.com%2FgoslZg-lang.org%2Fq%2FIslandViewer%2FQ_annotations.csv%27E*%27Lcsv%27E*%27~FSsOM%5D8)YqTransformO8*(8KLdisplace%27EKmethodUpile%27EKboundZgBoxA(8*KpaddZgA3.5E*KstartFDE*KendFD8j)EKnewFSUrow%278*)8%5DYrowXfSUrow%27P%27LnomZal%27)YmarkUpoZt%27YxJYxeJYsizeXvalueA3)YcolorXvalueUgray%27)YwidthA700YheightA260Hj*)Hj%5DH*)H%5DR%27styleXoutlZeWidthA0)%0A)*%20%208HjjA!%20DSAME%2C8H%0A*JXfDP%27L~%27)Kj%27LtypeUM%27Gene%20start%27OA%5BP%2C%20QNC_004631.1R%2CHSieldUA%27XA(%27YE%27Zinj**qdata~genomic%01~qjZYXUSRQPOMLKJHEDA8*_">local demo</a>

cc @ThHarbig

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [x] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
