### PR TITLE
fix: tile values are correctly filtered based on genomics windows

### DIFF
--- a/src/data-fetchers/utils.test.ts
+++ b/src/data-fetchers/utils.test.ts
@@ -1,0 +1,55 @@
+import type { Datum } from '@gosling.schema';
+import { filterUsingGenoPos } from './utils';
+
+describe('Data Fetcher Utils', () => {
+    it('Filter data based on genomic window', () => {
+        const data: Datum[] = [
+            { x: '1', xe: '2' }, // outside
+            { x: '3', xe: '5' }, // partly overlap
+            { x: '5', xe: '6' }, // entirely inside
+            { x: '7', xe: '10' } // partly overlap
+        ];
+        const range: [number, number] = [4, 7];
+
+        // Filtering based on two genomic fields
+        expect(
+            filterUsingGenoPos(data, range, {
+                x: 'x',
+                xe: 'xe'
+            })
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "x": "3",
+              "xe": "5",
+            },
+            {
+              "x": "5",
+              "xe": "6",
+            },
+            {
+              "x": "7",
+              "xe": "10",
+            },
+          ]
+        `);
+
+        // Filtering based on a single genomic field
+        expect(
+            filterUsingGenoPos(data, range, {
+                x: 'x'
+            })
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "x": "5",
+              "xe": "6",
+            },
+            {
+              "x": "7",
+              "xe": "10",
+            },
+          ]
+        `);
+    });
+});

--- a/src/data-fetchers/utils.ts
+++ b/src/data-fetchers/utils.ts
@@ -39,7 +39,7 @@ export function filterUsingGenoPos(
             return true;
         } else if (definedXFields.length === 1) {
             // filter based on one genomic position
-            const value = d[definedXFields[0]];
+            const value = +d[definedXFields[0]];
             return typeof value === 'number' && minX < value && value <= maxX;
         } else {
             // filter based on two genomic positions, i.e., check overlaps


### PR DESCRIPTION
Fix #886

## Change List
 - Correctly convert type to `number` so that genomic positions can be accurately calculated for filtering.

<img width="862" alt="Screenshot 2023-05-05 at 16 38 04" src="https://user-images.githubusercontent.com/9922882/236564743-66201985-fa6d-4670-9a6d-178c5d34cd8a.png">


## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [x] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
