### PR TITLE
fix: fix `inRange` filter

### DIFF
--- a/src/core/utils/data-transform.test.ts
+++ b/src/core/utils/data-transform.test.ts
@@ -5,13 +5,24 @@ describe('Data Transformation', () => {
     it('Filter', () => {
         let filtered = filterData({ type: 'filter', field: 'c', oneOf: ['a'] }, [
             { c: 'a', q: 1 },
+            { c: 'b', q: '1' }, // string should be converted
             { c: 'a', q: 3 },
-            { c: 'b', q: 4 }
+            { c: 'b', q: 4 },
+            { c: 'b', q: '4' } // string should be converted
         ]);
         filtered = filterData({ type: 'filter', field: 'q', inRange: [1, 3.5] }, filtered);
-        expect(filtered).toHaveLength(2);
-        expect(filtered.filter(d => d['c'] === 'b')).toHaveLength(0);
-        expect(filtered.filter(d => d['q'] === 4)).toHaveLength(0);
+        expect(filtered).toMatchInlineSnapshot(`
+          [
+            {
+              "c": "a",
+              "q": 1,
+            },
+            {
+              "c": "a",
+              "q": 3,
+            },
+          ]
+        `);
     });
     it('Pile', () => {
         const data = [

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -40,11 +40,7 @@ export function filterData(filter: FilterTransform, data: Datum[]): Datum[] {
     } else if (IsRangeFilter(filter)) {
         const { inRange } = filter;
         output = output.filter((d: Datum) => {
-            const value = d[field];
-            if (typeof value === 'string') {
-                // can't compare string with number
-                return false;
-            }
+            const value = +d[field];
             return not ? !(inRange[0] <= value && value <= inRange[1]) : inRange[0] <= value && value <= inRange[1];
         });
     } else if (IsIncludeFilter(filter)) {


### PR DESCRIPTION
Fix #
Toward #

## Change List
 - Convert types (string to number) so that the `inRange` filter can work. This might be due to https://github.com/gosling-lang/gosling.js/pull/613

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [x] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
