### PR TITLE
fix: revert breaking React 18 changes

### DIFF
--- a/editor/index.tsx
+++ b/editor/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 import { BrowserRouter, Route } from 'react-router-dom';
 import Editor from './Editor';
 import './index.css';
 import 'higlass/dist/hglib.css';
 
-const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-root.render(
+ReactDOM.render(
     <BrowserRouter>
         <Route component={Editor} />
-    </BrowserRouter>
+    </BrowserRouter>,
+    document.getElementById('root') as HTMLElement
 );

--- a/src/core/gosling-embed.ts
+++ b/src/core/gosling-embed.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 
 import type { GoslingSpec } from './gosling.schema';
 import type { HiGlassSpec } from './higlass.schema';
@@ -41,8 +41,7 @@ const launchHiglass = (
         className: opts.className,
         options: opts
     });
-    const root = ReactDOM.createRoot(element);
-    root.render(component);
+    ReactDOM.render(component, element);
 
     // For some reason our wrapper component fails to initialize the provided `ref`
     // immediately like `hglib.launch()`. This is a work-around to poll `ref`


### PR DESCRIPTION
Changes from #898 are breaking to end users who use React 16 or 17 and `gosling.embed` (e.g., Gos). The peer-dependencies in Gosling allow for `react-dom` v16/17/18, but only `react-dom` v18 has `react-dom/client`. The top-level `ReactDOM.render()` will eventually be [deprecated](https://react.dev/reference/react-dom/render), but it's totally fine to use for the moment.

This PR reverts use of `react-dom/client` (and `createRoot`), which is specific to react-dom v18, for the backward compatible `ReactDOM.render`.

I'm happy to discuss narrowing support for React versions in Gosling, but the previous changes seemed a bit too restrictive and would likely break many existing Gosling usage for folks who allow for upgrading patches in their dependencies.

## Change List
 - Reverts use of `react-dom/client` to `react-dom` to avoid breaking change in patch release.

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
