### PR TITLE
fix: fix duplicated data and odd tile load timing in the bam data fetcher

### DIFF
--- a/src/data-fetchers/bam/bam-worker.ts
+++ b/src/data-fetchers/bam/bam-worker.ts
@@ -333,12 +333,13 @@ const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]>
         // pairAcrossChr: typeof loadMates === 'undefined' ? false : loadMates,
     };
 
+    tileValues.set(`${uid}.${z}.${x}`, []);
+
     /* eslint-disable-next-line @typescript-eslint/prefer-for-of */
     for (let i = 0; i < cumPositions.length; i++) {
         const chromName = cumPositions[i].chr;
         const chromStart = cumPositions[i].pos;
         const chromEnd = cumPositions[i].pos + chromLengths[chromName];
-        tileValues.set(`${uid}.${z}.${x}`, []);
 
         if (chromStart <= minX && minX < chromEnd) {
             // start of the visible region is within this chromosome
@@ -390,6 +391,12 @@ const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]>
     });
 };
 
+/**
+ * Not like other data fetchers, the Bam Data Fetcher fetches all the tiles at once.
+ * @param uid 
+ * @param tileIds 
+ * @returns 
+ */
 const fetchTilesDebounced = async (uid: string, tileIds: string[]) => {
     const tiles: Record<string, JsonBamRecord[] & { tilePositionId: string }> = {};
     const validTileIds: string[] = [];

--- a/src/data-fetchers/bam/bam-worker.ts
+++ b/src/data-fetchers/bam/bam-worker.ts
@@ -393,9 +393,9 @@ const tile = async (uid: string, z: number, x: number): Promise<JsonBamRecord[]>
 
 /**
  * Not like other data fetchers, the Bam Data Fetcher fetches all the tiles at once.
- * @param uid 
- * @param tileIds 
- * @returns 
+ * @param uid
+ * @param tileIds
+ * @returns
  */
 const fetchTilesDebounced = async (uid: string, tileIds: string[]) => {
     const tiles: Record<string, JsonBamRecord[] & { tilePositionId: string }> = {};

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -495,12 +495,10 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             if (!this.tilesetInfo) return;
 
             const tiles = this.visibleAndFetchedTiles();
-            const tabularData = await tabularDataFetcher.getTabularData(
-                Object.values(tiles).map(x => x.remoteId)
-            );
+            const tabularData = await tabularDataFetcher.getTabularData(Object.values(tiles).map(x => x.remoteId));
             const tilesetInfo = this.tilesetInfo;
             tiles.forEach((tile, i) => {
-                if(i === 0) {
+                if (i === 0) {
                     const [refTile] = HGC.utils.trackUtils.calculate1DVisibleTiles(tilesetInfo, this._xScale);
                     tile.tileData.zoomLevel = refTile[0];
                     tile.tileData.tilePos = [refTile[1], refTile[1]];
@@ -773,7 +771,7 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             };
             // BAM data fetcher already combines the datasets;
             const isBamDataFetcher = this.dataFetcher instanceof BamDataFetcher;
-            return (includesDisplaceTransform && !hasDenseTiles()) && !isBamDataFetcher;
+            return includesDisplaceTransform && !hasDenseTiles() && !isBamDataFetcher;
         }
 
         /**


### PR DESCRIPTION
Fix #922

## Change List
 - Fixed an issue in which the BAM data fetcher loaded identical data multiple times, resulting in duplicated data.
 - Fixed the triggering timing for loading tiles (#922)

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
