### PR TITLE
fix(data-fetcher): support genomicFieldsToConvert

### DIFF
--- a/src/data-fetchers/json/json-data-fetcher.test.ts
+++ b/src/data-fetchers/json/json-data-fetcher.test.ts
@@ -42,3 +42,70 @@ describe('JSON data fetcher', () => {
             );
         }));
 });
+
+describe('JSON data fetcher', () => {
+    const fetcher = new (JsonDataFetcher as any)(
+        {},
+        {
+            type: 'json',
+            genomicFieldsToConvert: [
+                {
+                    chromosomeField: 'chr1',
+                    genomicFields: ['start1', 'end1']
+                },
+                {
+                    chromosomeField: 'chr2',
+                    genomicFields: ['start2', 'end2']
+                }
+            ],
+            values: [
+                {
+                    chr1: 'chr1',
+                    start1: 1221574,
+                    end1: 1221575,
+                    chr2: 'chr13',
+                    start2: 36001515,
+                    end2: 36001516
+                },
+                {
+                    chr1: 'chr10',
+                    start1: 9257519,
+                    end1: 9257520,
+                    chr2: 'chr18',
+                    start2: 82441834,
+                    end2: 82441835
+                }
+            ]
+        }
+    );
+
+    it('converts genomic fields correctly', () =>
+        new Promise<void>(resolve => {
+            fetcher.fetchTilesDebounced(
+                (loadedTile: any) => {
+                    expect(loadedTile['0.0'].tabularData).toMatchInlineSnapshot(`
+                      [
+                        {
+                          "chr1": "chr1",
+                          "chr2": "chr13",
+                          "end1": "1221575",
+                          "end2": "2113044498",
+                          "start1": "1221574",
+                          "start2": "2113044497",
+                        },
+                        {
+                          "chr1": "chr10",
+                          "chr2": "chr18",
+                          "end1": "1684141149",
+                          "end2": "2656479838",
+                          "start1": "1684141148",
+                          "start2": "2656479837",
+                        },
+                      ]
+                    `);
+                    resolve();
+                },
+                ['0.0']
+            );
+        }));
+});


### PR DESCRIPTION
Fix  #931
Toward #

## Change List
 - Added support for `genomicFieldsToConvert` in the JSON data fetcher

It seems the JSON datafetcher uses the same `dataConfig` as the CSV data fetcher. The CSV data fetcher was expanded to support genomicFieldsToConvert, but not the JSON datafetcher. 


Before:

<img width="536" alt="image" src="https://github.com/gosling-lang/gosling.js/assets/14843470/e9514a5c-f544-4be0-bb2e-9a09b0ab0fa7">


After:
<img width="545" alt="image" src="https://github.com/gosling-lang/gosling.js/assets/14843470/9d92c200-dee2-496c-929b-f47b8c3d0018">


## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [x] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
