### PR TITLE
ci: specify allowed scopes in semantic-pull-request.yml

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -18,8 +18,10 @@ jobs:
         with:
           # Configure which scopes are allowed.
           scopes: |
+            core
+            track
             data-fetcher
             api
             editor
           # Configure if a scope must always be provided.
-          requireScope: false
+          requireScope: true

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -15,3 +15,11 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which scopes are allowed.
+          scopes: |
+            data-fetcher
+            api
+            editor
+          # Configure if a scope must always be provided.
+          requireScope: false

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -16,6 +16,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # Configure which types are allowed (newline-delimited).
+          types: |
+            feat
+            fix
+            ci
+            chore
+            docs
+            refactor
+            test
           # Configure which scopes are allowed.
           scopes: |
             core
@@ -25,3 +34,11 @@ jobs:
             editor
           # Configure if a scope must always be provided.
           requireScope: true
+          # Configure which scopes are disallowed in PR titles (newline-delimited).
+          # Anything but `feat` and `fix`
+          disallowScopes: |
+            ci
+            chore
+            docs
+            refactor
+            test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,19 +26,20 @@ The allowed pattern of commit messages is:
 type(scope?): subject  # scope is optional; multiple scopes are supported (current delimiter options: "/", "\" and ",")
 ```
 
-where `type` can be either `build`, `ci`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, or `test`.
+where `type` can be either `feat`, `fix`, `ci`, `chore`, `docs`, `perf`, `refactor`, or `test`.
 
-Additionally, `scope` can be one of the following: 
+Additionally, `scope` should be defined for `feat` and `fix` which should be one of the following: 
 
+- `core`: any general updates to the library, e.g., grammar change, new rendering, etc.
+- `track`: any updates that are specific to tracks in the library, including `gosling-track` and `gosling-axis`.
 - `data-fetcher`: any updates related to data fetchers
 - `editor`: UI and other updates to the online editor
 - `api`: the Gosling APIs
-- ` ` (No scope): any general updates to the library, e.g., grammar change, new rendering, etc.
 
 Example commit messages are as follows:
 
 ```sh
-git commit -m 'fix: correctly position views'
+git commit -m 'fix(core): correctly position views'
 git commit -m 'feat(editor): add a data preview panel in editor'
 git commit -m 'docs: add details about commitlint in README.md'
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,38 @@ yarn start
 
 Then, you can open http://localhost:3000/ in a web browser to test the online editor.
 
+## Commit Messages
+
+We use [commitlint](https://github.com/conventional-changelog/commitlint#what-is-commitlint) to maintain commit messages in a consistent manner and automatically update a [CHANGELOG.md](/CHANGELOG.md) based on the commit messages.
+
+The allowed pattern of commit messages is:
+
+```sh
+type(scope?): subject  # scope is optional; multiple scopes are supported (current delimiter options: "/", "\" and ",")
+```
+
+where `type` can be either `build`, `ci`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, or `test`.
+
+Additionally, `scope` can be one of the following: 
+
+- `data-fetcher`: any updates related to data fetchers
+- `editor`: UI and other updates to the online editor
+- `api`: the Gosling APIs
+- ` ` (No scope): any general updates to the library, e.g., grammar change, new rendering, etc.
+
+Example commit messages are as follows:
+
+```sh
+git commit -m 'fix: correctly position views'
+git commit -m 'feat(editor): add a data preview panel in editor'
+git commit -m 'docs: add details about commitlint in README.md'
+```
+
+To learn more about the commitlint, please visit [conventional-changelog/commitlint](https://github.com/conventional-changelog/commitlint#what-is-commitlint).
+
+## Opening Pull Requests
+We use the [commitlint](#commitlint) for the title of PR. So, if the title of PR is not following the commitlint conventions, [Semantic Pull Request](https://github.com/zeke/semantic-pull-requests) will complain about it, disallowing your PR to be merged. When your PR is accepted and merged into the master branch, the title of the PR will be recorded as a single commit message which will then added as a single item in [CHANGELOG.md](/CHANGELOG.md).
+
 ## Testing Production Build Using Editor
 
 It is sometimes necessary to test the production build of Gosling.js. This frequently happened to us when we needed to ensure that certain data fetchers, like BAM and VCF, work correctly without errors in a deployed app.
@@ -96,37 +128,6 @@ If there is an example you would like to add to the editor example library, plea
 
 5. Select the example in the editor to make sure your example works as expected. 
 
-## Commit Messages
-
-We use [commitlint](https://github.com/conventional-changelog/commitlint#what-is-commitlint) to maintain commit messages in a consistent manner and automatically update a [CHANGELOG.md](/CHANGELOG.md) based on the commit messages.
-
-The allowed pattern of commit messages is:
-
-```sh
-type(scope?): subject  # scope is optional; multiple scopes are supported (current delimiter options: "/", "\" and ",")
-```
-
-where `type` can be either `build`, `ci`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, or `test`.
-
-Also, we have been using the following `scope` categories
-
-- `data-fetcher`: any updates related to data fetchers
-- `editor`: UI and other updates to the online editor
-- `api`: the Gosling APIs
-- ` ` (No scope): any general updates to the library, e.g., grammar change, new rendering, etc.
-
-Example commit messages are as follows:
-
-```sh
-git commit -m 'fix: correctly position views'
-git commit -m 'feat(editor): add a data preview panel in editor'
-git commit -m 'docs: add details about commitlint in README.md'
-```
-
-To learn more about the commitlint, please visit [conventional-changelog/commitlint](https://github.com/conventional-changelog/commitlint#what-is-commitlint).
-
-## Opening Pull Requests
-We use the [commitlint](#commitlint) for the title of PR. So, if the title of PR is not following the commitlint conventions, [Semantic Pull Request](https://github.com/zeke/semantic-pull-requests) will complain about it, disallowing your PR to be merged. When your PR is accepted and merged into the master branch, the title of the PR will be recorded as a single commit message which will then added as a single item in [CHANGELOG.md](/CHANGELOG.md).
 
 ## Bumping Gosling.js
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,11 +108,18 @@ type(scope?): subject  # scope is optional; multiple scopes are supported (curre
 
 where `type` can be either `build`, `ci`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, or `test`.
 
+Also, we have been using the following `scope` categories
+
+- `data-fetcher`: any updates related to data fetchers
+- `editor`: UI and other updates to the online editor
+- `api`: the Gosling APIs
+- ` ` (No scope): any general updates to the library, e.g., grammar change, new rendering, etc.
+
 Example commit messages are as follows:
 
 ```sh
 git commit -m 'fix: correctly position views'
-git commit -m 'feat: add a data preview panel in editor'
+git commit -m 'feat(editor): add a data preview panel in editor'
 git commit -m 'docs: add details about commitlint in README.md'
 ```
 


### PR DESCRIPTION
Specify the allowed scopes for the PR title so that we can make sure to use scope names consistently.

I have added five categories for `feat` and `fix` updates

- `core`: any general updates related to the library, such as the grammar and new rendering
- `track: updates specific to tracks in this library, such as gosling track and axis
- `data-fetcher`: any updates related to data fetchers
- `editor`: UI and other updates to the online editor
- `api`: the Gosling APIs

Usage:

```sh
feat(core): added A, B, C to the grammar
fix(data-fetcher): fix the bam data fetcher to ...
```

~~Feel free to suggest adding a new category. Also, maybe we can set `requireScope` to `true` and add a general scope (e.g., `core`) so that we make sure not to specify a proper scope. I found that I did not put a scope when I fixed the bam data fetcher!~~