### PR TITLE
feat(api): subscription for genomic axis changes

### DIFF
--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -332,12 +332,17 @@ function Editor(props: RouteComponentProps) {
             // gosRef.current.api.subscribe('trackClick', (type, eventData) => {
             //     console.warn(type, eventData.id, eventData.spec, eventData.shape);
             // });
+            // Location API
+            // gosRef.current.api.subscribe('location', (type, eventData) => {
+            //     console.warn(type, eventData.id, eventData.genomicRange);
+            // });
         }
         return () => {
             // gosRef.current?.api.unsubscribe('mouseOver');
             // gosRef.current?.api.unsubscribe('click');
             // gosRef.current?.api.unsubscribe('rangeSelect');
             // gosRef.current?.api.unsubscribe('trackClick');
+            // gosRef.current?.api.unsubscribe('location');
         };
     }, [gosRef.current]);
 

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -254,6 +254,13 @@ interface RangeMouseEventData extends CommonEventData {
 }
 
 /**
+ * Data about the genomic range of a track
+ */
+interface LocationEventData extends Omit<CommonEventData, 'data'> {
+    genomicRange: [GenomicPosition, GenomicPosition];
+}
+
+/**
  * The visual parameters that determine the shape of a linear track.
  * Origin is the left top corner.
  */
@@ -295,6 +302,7 @@ export type _EventMap = {
     rawData: CommonEventData;
     trackMouseOver: TrackMouseEventData;
     trackClick: TrackMouseEventData; // TODO (Jul-25-2022): with https://github.com/higlass/higlass/pull/1098, we can support circular layouts
+    location: LocationEventData;
 };
 
 /** Options for determining mouse events in detail, e.g., turning on specific events only */

--- a/src/core/utils/assembly.test.ts
+++ b/src/core/utils/assembly.test.ts
@@ -41,6 +41,18 @@ describe('Assembly', () => {
             chromosome: 'unknown',
             position: outOfPos
         });
+        expect(getRelativeGenomicPosition(outOfPos, 'hg38', true)).toMatchInlineSnapshot(`
+          {
+            "chromosome": "chrY",
+            "position": 3088269832,
+          }
+        `);
+        expect(getRelativeGenomicPosition(-1, 'hg38', true)).toMatchInlineSnapshot(`
+          {
+            "chromosome": "chr1",
+            "position": 0,
+          }
+        `);
     });
     it('Parse string to genomic positions', () => {
         const customChromSizes: Assembly = [

--- a/src/core/utils/assembly.ts
+++ b/src/core/utils/assembly.ts
@@ -18,19 +18,48 @@ export interface ChromSize {
 
 /**
  * Get relative chromosome position (e.g., `100` => `{ chromosome: 'chr1', position: 100 }`)
+ * @param absPos number which is the absolute chromosome position
+ * @param assembly the assembly used to calculate which chromosome position
+ * @param returnWithinAssembly If true, then if the absolute position is before the first chromosome, it returns the
+ * first position of the first chromosome. If the absolute position is after the last chromosome, it returns the last
+ * position of the last chromosome
+ * @returns the genomic position of the absPos
  */
-export function getRelativeGenomicPosition(absPos: number, assembly?: Assembly): GenomicPosition {
-    const [chromosome, absInterval] = Object.entries(computeChromSizes(assembly).interval).find(d => {
-        const [start, end] = d[1];
-        return start <= absPos && absPos < end;
-    }) ?? [null, null];
-
-    if (!chromosome || !absInterval) {
-        // The number is out of range
+export function getRelativeGenomicPosition(
+    absPos: number,
+    assembly?: Assembly,
+    returnWithinAssembly = false
+): GenomicPosition {
+    const chrSizes = Object.entries(computeChromSizes(assembly).interval);
+    const minPosChr = { chromosome: 'unknown', position: Infinity } as GenomicPosition;
+    const maxPosChr = { chromosome: 'unknown', position: 0 } as GenomicPosition;
+    for (const chrSize of chrSizes) {
+        const [chromosome, absInterval] = chrSize;
+        const [start, end] = absInterval;
+        // absPos was found within this chromosome
+        if (start <= absPos && absPos < end) {
+            return { chromosome, position: absPos - start } as GenomicPosition;
+        }
+        // Update the min and max chromosomes found
+        if (start < minPosChr.position) {
+            minPosChr.chromosome = chromosome;
+            minPosChr.position = start;
+        }
+        if (end > maxPosChr.position) {
+            maxPosChr.chromosome = chromosome;
+            maxPosChr.position = end;
+        }
+    }
+    if (returnWithinAssembly) {
+        // Return either the min or max chromosome position
+        if (absPos < minPosChr.position) {
+            return minPosChr;
+        } else {
+            return maxPosChr;
+        }
+    } else {
         return { chromosome: 'unknown', position: absPos };
     }
-
-    return { chromosome, position: absPos - absInterval[0] };
 }
 
 /**

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -453,7 +453,7 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             // Publish the new genomic axis domain
             const genomicRange = newXScale
                 .domain()
-                .map(absPos => getRelativeGenomicPosition(absPos, this.#assembly)) as [
+                .map(absPos => getRelativeGenomicPosition(absPos, this.#assembly, true)) as [
                 GenomicPosition,
                 GenomicPosition
             ];

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -449,6 +449,18 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             this.refreshTiles();
             this.draw();
             this.forceDraw();
+
+            // Publish the new genomic axis domain
+            const genomicRange = newXScale
+                .domain()
+                .map(absPos => getRelativeGenomicPosition(absPos, this.#assembly)) as [
+                GenomicPosition,
+                GenomicPosition
+            ];
+            publish('location', {
+                id: context.viewUid,
+                genomicRange: genomicRange
+            });
         }
 
         /* *


### PR DESCRIPTION
Fix #910 
Toward #

## Change List
 - Add a new API subscription `location` which returns the track ID and the genomic coordinates of a track when the track axis changes

Corresponding [documentation PR](https://github.com/gosling-lang/gosling-website/pull/70)

Example Spec
```
views: [
   { ..., tracks: [..., { type: 'brush', x: { linkingId: 'detail' } }]},
   { tracks: [{ ..., id: 'detail-track-1', x: { ..., linkingId: 'detail' } }]
]
```
Example API
```
gosRef.current.api.subscribe('location', (data) ⇒ {
  const { id, genomicPosition } = data;
  if(id === 'detail-track-1') {
      console.log('brush has been moved to ', genomicPosition);
   }
});
```

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [x] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
