### PR TITLE
feat(core, api, editor): support using  view IDs

### DIFF
--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -693,8 +693,9 @@ function Editor(props: RouteComponentProps) {
     // Layers to be shown on top of the Gosling visualization to show the hiererchy of Gosling views and tracks
     const VisHierarchy = useMemo(() => {
         const tracksAndViews = gosRef.current?.api.getTracksAndViews();
+        const maxHeight = Math.max(...(tracksAndViews?.map(d => d.shape.height) ?? []));
         return (
-            <div style={{ position: 'absolute', top: '66px', left: '66px' }}>
+            <div style={{ position: 'absolute', top: '60px', left: '60px', height: maxHeight, pointerEvents: 'none' }}>
                 {tracksAndViews
                     ?.sort(a => (a.type === 'track' ? 1 : -1))
                     ?.map(d => {
@@ -713,8 +714,8 @@ function Editor(props: RouteComponentProps) {
                                 key={v4()}
                                 style={{
                                     position: 'absolute',
-                                    background,
                                     border: '1px solid black',
+                                    background,
                                     left,
                                     top,
                                     width,
@@ -1211,8 +1212,8 @@ function Editor(props: RouteComponentProps) {
                                                 setHg(h);
                                             }}
                                         />
+                                        {showViews ? VisHierarchy : null}
                                     </div>
-                                    {showViews ? VisHierarchy : null}
                                     {/* {expertMode && false ? (
                                             <div
                                                 style={{

--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -691,13 +691,13 @@ function Editor(props: RouteComponentProps) {
 
     // visual components that shows the hiererchy of Gosling views
     const viewLayers = useMemo(() => {
+        const tracks = gosRef.current?.api.getTracks();
         const views = gosRef.current?.api.getViews();
-        // XXX
-        console.log(views);
+        // console.log(views);
         return (
             <div style={{ position: 'absolute', top: '66px', left: '66px' }}>
-                {views?.map(view => {
-                    const { x: left, y: top, width, height } = view.shape; 
+                {[...(tracks ?? []), ...(views ?? [])].map(view => {
+                    const { x: left, y: top, width, height } = view.shape;
                     return (
                         <div
                             key={view.id}

--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -27,6 +27,7 @@ import EditorPanel, { type EditorLangauge } from './EditorPanel';
 import EditorExamples from './EditorExamples';
 
 import './Editor.css';
+import { v4 } from 'uuid'
 
 function json2js(jsonCode: string) {
     return `var spec = ${jsonCode} \nexport { spec }; \n`;
@@ -689,33 +690,42 @@ function Editor(props: RouteComponentProps) {
         setHideDescription(true);
     }
 
-    // visual components that shows the hiererchy of Gosling views
-    const viewLayers = useMemo(() => {
-        const tracks = gosRef.current?.api.getTracks();
-        const views = gosRef.current?.api.getViews();
-        // console.log(views);
+    // Layers to be shown on top of the Gosling visualization to show the hiererchy of Gosling views and tracks
+    const VisHierarchy = useMemo(() => {
+        const tracksAndViews = gosRef.current?.api.getTracksAndViews();
         return (
             <div style={{ position: 'absolute', top: '66px', left: '66px' }}>
-                {[...(tracks ?? []), ...(views ?? [])].map(view => {
-                    const { x: left, y: top, width, height } = view.shape;
-                    return (
-                        <div
-                            key={view.id}
-                            style={{
-                                position: 'absolute',
-                                background: 'rgba(100, 100, 255, 0.1)',
-                                // border: '2px solid black',
-                                left,
-                                top,
-                                width,
-                                height
-                            }}
-                        />
-                    );
-                })}
+                {tracksAndViews
+                    ?.sort(a => (a.type === 'track' ? 1 : -1))
+                    ?.map(d => {
+                        let { x: left, y: top, width, height } = d.shape;
+                        let background = 'rgba(255, 50, 50, 0.3)';
+                        if (d.type === 'view') {
+                            const VIEW_PADDING = 3;
+                            left -= VIEW_PADDING;
+                            top -= VIEW_PADDING;
+                            width += VIEW_PADDING * 2;
+                            height += VIEW_PADDING * 2;
+                            background = 'rgba(50, 50, 255, 0.1)';
+                        }
+                        return (
+                            <div
+                                key={v4()}
+                                style={{
+                                    position: 'absolute',
+                                    background,                                        
+                                    border: '1px solid black',
+                                    left,
+                                    top,
+                                    width,
+                                    height
+                                }}
+                            />
+                        );
+                    })}
             </div>
         );
-    }, [hg]);
+    }, [hg, demo]);
 
     // console.log('editor.render()');
     return (
@@ -1202,7 +1212,7 @@ function Editor(props: RouteComponentProps) {
                                             }}
                                         />
                                     </div>
-                                    {showViews ? viewLayers : null}
+                                    {showViews ? VisHierarchy : null}
                                     {/* {expertMode && false ? (
                                             <div
                                                 style={{

--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -27,7 +27,7 @@ import EditorPanel, { type EditorLangauge } from './EditorPanel';
 import EditorExamples from './EditorExamples';
 
 import './Editor.css';
-import { v4 } from 'uuid'
+import { v4 } from 'uuid';
 
 function json2js(jsonCode: string) {
     return `var spec = ${jsonCode} \nexport { spec }; \n`;
@@ -713,7 +713,7 @@ function Editor(props: RouteComponentProps) {
                                 key={v4()}
                                 style={{
                                     position: 'absolute',
-                                    background,                                        
+                                    background,
                                     border: '1px solid black',
                                     left,
                                     top,

--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -249,6 +249,7 @@ function Editor(props: RouteComponentProps) {
     const [selectedPreviewData, setSelectedPreviewData] = useState<number>(0);
     const [gistTitle, setGistTitle] = useState<string>();
     const [description, setDescription] = useState<string | null>();
+    const [showViews, setShowViews] = useState(false);
     const [expertMode, setExpertMode] = useState(false);
 
     // This parameter only matter when a markdown description was loaded from a gist but the user wants to hide it
@@ -688,6 +689,34 @@ function Editor(props: RouteComponentProps) {
         setHideDescription(true);
     }
 
+    // visual components that shows the hiererchy of Gosling views
+    const viewLayers = useMemo(() => {
+        const views = gosRef.current?.api.getViews();
+        // XXX
+        console.log(views);
+        return (
+            <div style={{ position: 'absolute', top: '66px', left: '66px' }}>
+                {views?.map(view => {
+                    const { x: left, y: top, width, height } = view.shape; 
+                    return (
+                        <div
+                            key={view.id}
+                            style={{
+                                position: 'absolute',
+                                background: 'rgba(100, 100, 255, 0.1)',
+                                // border: '2px solid black',
+                                left,
+                                top,
+                                width,
+                                height
+                            }}
+                        />
+                    );
+                })}
+            </div>
+        );
+    }, [hg]);
+
     // console.log('editor.render()');
     return (
         <>
@@ -990,7 +1019,19 @@ function Editor(props: RouteComponentProps) {
                                     </button>
                                 </span>
                             </span>
-
+                            <button
+                                title="Automatically update visualization upon editing code"
+                                className="side-panel-button"
+                                onClick={() => setShowViews(!showViews)}
+                            >
+                                {showViews
+                                    ? getIconSVG(ICONS.TOGGLE_ON, 23, 23, '#E18343')
+                                    : getIconSVG(ICONS.TOGGLE_OFF, 23, 23)}
+                                <br />
+                                SHOW
+                                <br />
+                                VIEWS
+                            </button>
                             <button
                                 title="Expert mode that turns on additional features, such as theme selection"
                                 className="side-panel-button"
@@ -1161,6 +1202,7 @@ function Editor(props: RouteComponentProps) {
                                             }}
                                         />
                                     </div>
+                                    {showViews ? viewLayers : null}
                                     {/* {expertMode && false ? (
                                             <div
                                                 style={{

--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -1034,10 +1034,11 @@ function Editor(props: RouteComponentProps) {
                                 title="Automatically update visualization upon editing code"
                                 className="side-panel-button"
                                 onClick={() => setShowViews(!showViews)}
+                                disabled={isResponsive}
                             >
                                 {showViews
-                                    ? getIconSVG(ICONS.TOGGLE_ON, 23, 23, '#E18343')
-                                    : getIconSVG(ICONS.TOGGLE_OFF, 23, 23)}
+                                    ? getIconSVG(ICONS.TOGGLE_ON, 23, 23, isResponsive ? 'lightgrey' : '#E18343')
+                                    : getIconSVG(ICONS.TOGGLE_OFF, 23, 23, isResponsive ? 'lightgrey' : undefined)}
                                 <br />
                                 SHOW
                                 <br />
@@ -1212,7 +1213,7 @@ function Editor(props: RouteComponentProps) {
                                                 setHg(h);
                                             }}
                                         />
-                                        {showViews ? VisHierarchy : null}
+                                        {showViews && !isResponsive ? VisHierarchy : null}
                                     </div>
                                     {/* {expertMode && false ? (
                                             <div

--- a/schema/gosling.schema.json
+++ b/schema/gosling.schema.json
@@ -595,6 +595,7 @@
           "type": "number"
         },
         "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
           "type": "string"
         },
         "innerRadius": {
@@ -1128,6 +1129,7 @@
               "type": "number"
             },
             "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
               "type": "string"
             },
             "innerRadius": {
@@ -1279,6 +1281,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -1894,6 +1897,7 @@
               "type": "number"
             },
             "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
               "type": "string"
             },
             "innerRadius": {
@@ -2045,6 +2049,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -2596,6 +2601,10 @@
             "description": {
               "type": "string"
             },
+            "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
+              "type": "string"
+            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -2713,6 +2722,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -3113,6 +3123,10 @@
             "description": {
               "type": "string"
             },
+            "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
+              "type": "string"
+            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -3166,6 +3180,10 @@
                       "centerRadius": {
                         "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
                         "type": "number"
+                      },
+                      "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
+                        "type": "string"
                       },
                       "layout": {
                         "$ref": "#/definitions/Layout",
@@ -3633,6 +3651,10 @@
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
           "type": "number"
         },
+        "id": {
+          "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
+          "type": "string"
+        },
         "layout": {
           "$ref": "#/definitions/Layout",
           "description": "Specify the layout type of all tracks."
@@ -3926,6 +3948,7 @@
           "type": "number"
         },
         "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
           "type": "string"
         },
         "innerRadius": {
@@ -4042,6 +4065,7 @@
                 "type": "boolean"
               },
               "id": {
+                "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
                 "type": "string"
               },
               "innerRadius": {
@@ -4613,6 +4637,7 @@
           "type": "number"
         },
         "id": {
+          "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
           "type": "string"
         },
         "innerRadius": {
@@ -4977,6 +5002,7 @@
           "type": "number"
         },
         "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
           "type": "string"
         },
         "innerRadius": {
@@ -5093,6 +5119,7 @@
                 "type": "boolean"
               },
               "id": {
+                "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
                 "type": "string"
               },
               "innerRadius": {
@@ -5806,6 +5833,7 @@
           "type": "number"
         },
         "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
           "type": "string"
         },
         "innerRadius": {
@@ -6164,6 +6192,7 @@
               "type": "number"
             },
             "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
               "type": "string"
             },
             "innerRadius": {
@@ -6311,6 +6340,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -6923,6 +6953,7 @@
               "type": "number"
             },
             "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
               "type": "string"
             },
             "innerRadius": {
@@ -7070,6 +7101,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -7618,6 +7650,10 @@
               "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
               "type": "number"
             },
+            "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
+              "type": "string"
+            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -7731,6 +7767,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -8606,6 +8643,7 @@
           "type": "number"
         },
         "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
           "type": "string"
         },
         "innerRadius": {

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -1269,6 +1269,7 @@
           "type": "boolean"
         },
         "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
           "type": "string"
         },
         "innerRadius": {

--- a/src/core/api-data.ts
+++ b/src/core/api-data.ts
@@ -1,9 +1,16 @@
-import type { GoslingSpec, PartialTrack, TrackMouseEventData, View } from '@gosling.schema';
+import type { GoslingSpec, PartialTrack, TrackApiData, View } from '@gosling.schema';
 import { getInternalSpecById, getTrackIds, getViewIds } from './track-and-view-ids';
 
-export function getViewApiData(spec: GoslingSpec, tracks: TrackMouseEventData[]) {
-    return getViewIds(spec).map(id => {
-        const internalSpec = getInternalSpecById(spec, id);
+/**
+ * This collect information of views by referring to the track information.
+ * The information includes the bounding box of tracks.
+ * @param spec
+ * @param tracks
+ * @returns
+ */
+export function getViewApiData(spec: GoslingSpec, tracks: TrackApiData[]) {
+    return getViewIds(spec).map(viewId => {
+        const internalSpec = getInternalSpecById(spec, viewId);
         const trackIds = getTrackIds(internalSpec as View | PartialTrack);
         const bb = {
             x: Number.MAX_SAFE_INTEGER,
@@ -30,7 +37,7 @@ export function getViewApiData(spec: GoslingSpec, tracks: TrackMouseEventData[])
                 }
             });
         return {
-            id,
+            id: viewId,
             spec: internalSpec as View,
             shape: { ...bb, width: bb.xe - bb.x, height: bb.ye - bb.y }
         };

--- a/src/core/api-data.ts
+++ b/src/core/api-data.ts
@@ -1,0 +1,53 @@
+import type { BoundingBox, GoslingSpec, PartialTrack, TrackMouseEventData, View } from "@gosling.schema";
+import { getInternalSpecById, getTrackIds, getViewIds } from "./track-and-view-ids";
+
+export function getViewApiData(spec: GoslingSpec, tracks: TrackMouseEventData[]) {
+    return getViewIds(spec).map(id => {
+        const internalSpec = getInternalSpecById(spec, id);
+        const trackIds = getTrackIds(internalSpec as View | PartialTrack);
+        const bb = { 
+            x: Number.MAX_SAFE_INTEGER, 
+            y: Number.MAX_SAFE_INTEGER, 
+            xe: -Number.MAX_SAFE_INTEGER, 
+            ye: -Number.MAX_SAFE_INTEGER 
+        };
+        trackIds.map(trackId => tracks.find(t => t.id === trackId)).forEach(track => {
+            if(!track) return;
+            const { shape } = track;
+            if('cx' in shape) {
+                // circular track
+                if(bb.x > shape.cx - shape.outerRadius) {
+                    bb.x = shape.cx - shape.outerRadius;
+                }
+                if(bb.y > shape.cy - shape.outerRadius) {
+                    bb.y = shape.cy - shape.outerRadius;
+                }
+                if(bb.xe < shape.cx + shape.outerRadius) {
+                    bb.xe = shape.cx + shape.outerRadius;
+                }
+                if(bb.ye < shape.cy + shape.outerRadius) {
+                    bb.ye = shape.cy + shape.outerRadius;
+                }
+            } else {
+                // linear track
+                if(bb.x > shape.x) {
+                    bb.x = shape.x;
+                }
+                if(bb.y > shape.y) {
+                    bb.y = shape.y;
+                }
+                if(bb.xe < shape.x + shape.width) {
+                    bb.xe = shape.x + shape.width;
+                }
+                if(bb.ye < shape.y + shape.height) {
+                    bb.ye = shape.y + shape.height;
+                }
+            }
+        });
+        return {
+            id,
+            spec: internalSpec as View,
+            shape: { ...bb, width: bb.xe - bb.x, height: bb.ye - bb.y }
+        }
+    });
+}

--- a/src/core/api-data.ts
+++ b/src/core/api-data.ts
@@ -1,53 +1,38 @@
-import type { BoundingBox, GoslingSpec, PartialTrack, TrackMouseEventData, View } from "@gosling.schema";
-import { getInternalSpecById, getTrackIds, getViewIds } from "./track-and-view-ids";
+import type { GoslingSpec, PartialTrack, TrackMouseEventData, View } from '@gosling.schema';
+import { getInternalSpecById, getTrackIds, getViewIds } from './track-and-view-ids';
 
 export function getViewApiData(spec: GoslingSpec, tracks: TrackMouseEventData[]) {
     return getViewIds(spec).map(id => {
         const internalSpec = getInternalSpecById(spec, id);
         const trackIds = getTrackIds(internalSpec as View | PartialTrack);
-        const bb = { 
-            x: Number.MAX_SAFE_INTEGER, 
-            y: Number.MAX_SAFE_INTEGER, 
-            xe: -Number.MAX_SAFE_INTEGER, 
-            ye: -Number.MAX_SAFE_INTEGER 
+        const bb = {
+            x: Number.MAX_SAFE_INTEGER,
+            y: Number.MAX_SAFE_INTEGER,
+            xe: -Number.MAX_SAFE_INTEGER,
+            ye: -Number.MAX_SAFE_INTEGER
         };
-        trackIds.map(trackId => tracks.find(t => t.id === trackId)).forEach(track => {
-            if(!track) return;
-            const { shape } = track;
-            if('cx' in shape) {
-                // circular track
-                if(bb.x > shape.cx - shape.outerRadius) {
-                    bb.x = shape.cx - shape.outerRadius;
-                }
-                if(bb.y > shape.cy - shape.outerRadius) {
-                    bb.y = shape.cy - shape.outerRadius;
-                }
-                if(bb.xe < shape.cx + shape.outerRadius) {
-                    bb.xe = shape.cx + shape.outerRadius;
-                }
-                if(bb.ye < shape.cy + shape.outerRadius) {
-                    bb.ye = shape.cy + shape.outerRadius;
-                }
-            } else {
-                // linear track
-                if(bb.x > shape.x) {
+        trackIds
+            .map(trackId => tracks.find(t => t.id === trackId))
+            .forEach(track => {
+                if (!track) return;
+                const { shape } = track;
+                if (bb.x > shape.x) {
                     bb.x = shape.x;
                 }
-                if(bb.y > shape.y) {
+                if (bb.y > shape.y) {
                     bb.y = shape.y;
                 }
-                if(bb.xe < shape.x + shape.width) {
+                if (bb.xe < shape.x + shape.width) {
                     bb.xe = shape.x + shape.width;
                 }
-                if(bb.ye < shape.y + shape.height) {
+                if (bb.ye < shape.y + shape.height) {
                     bb.ye = shape.y + shape.height;
                 }
-            }
-        });
+            });
         return {
             id,
             spec: internalSpec as View,
             shape: { ...bb, width: bb.xe - bb.x, height: bb.ye - bb.y }
-        }
+        };
     });
 }

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,5 +1,5 @@
 import * as PIXI from 'pixi.js';
-import type { TrackMouseEventData } from '@gosling.schema';
+import type { TrackMouseEventData, ViewApiData } from '@gosling.schema';
 import type { HiGlassApi } from './higlass-component-wrapper';
 import type { HiGlassSpec } from '@higlass.schema';
 import { subscribe, unsubscribe } from './pubsub';
@@ -28,6 +28,8 @@ export interface GoslingApi {
     getViewIds(): string[];
     getTracks(): TrackMouseEventData[];
     getTrack(trackId: string): TrackMouseEventData | undefined;
+    getViews(): ViewApiData[];
+    getView(viewId: string): ViewApiData | undefined;
     exportPng(transparentBackground?: boolean): void;
     exportPdf(transparentBackground?: boolean): void;
     getCanvas(options?: { resolution?: number; transparentBackground?: boolean }): {
@@ -42,6 +44,7 @@ export function createApi(
     hg: Readonly<HiGlassApi>,
     hgSpec: HiGlassSpec | undefined,
     trackInfos: readonly TrackMouseEventData[],
+    views: readonly ViewApiData[],
     theme: Required<CompleteThemeDeep>
 ): GoslingApi {
     const getTracks = () => {
@@ -54,6 +57,16 @@ export function createApi(
         }
         return trackInfoFound;
     };
+    const getViews = () => {
+        return [...views];
+    }
+    const getView = (viewId: string) => {
+        const view = getViews().find(d => d.id === viewId);
+        if (!view) {
+            console.warn(`Unable to find a view with the ID of ${viewId}`);
+        }
+        return view;
+    }
     const getCanvas: GoslingApi['getCanvas'] = options => {
         const resolution = options?.resolution ?? 4;
         const transparentBackground = options?.transparentBackground ?? false;
@@ -120,6 +133,8 @@ export function createApi(
         },
         getTracks,
         getTrack,
+        getView,
+        getViews,
         getCanvas,
         exportPng: transparentBackground => {
             const { canvas } = getCanvas({ resolution: 4, transparentBackground });

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -59,14 +59,14 @@ export function createApi(
     };
     const getViews = () => {
         return [...views];
-    }
+    };
     const getView = (viewId: string) => {
         const view = getViews().find(d => d.id === viewId);
         if (!view) {
             console.warn(`Unable to find a view with the ID of ${viewId}`);
         }
         return view;
-    }
+    };
     const getCanvas: GoslingApi['getCanvas'] = options => {
         const resolution = options?.resolution ?? 4;
         const transparentBackground = options?.transparentBackground ?? false;

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -1,4 +1,4 @@
-import type { GoslingSpec, TemplateTrackDef, TrackMouseEventData, ViewApiData } from './gosling.schema';
+import type { GoslingSpec, TemplateTrackDef, VisUnitApiData } from './gosling.schema';
 import type { HiGlassSpec } from './higlass.schema';
 import { traverseToFixSpecDownstream, overrideDataTemplates } from './utils/spec-preprocess';
 import { replaceTrackTemplates } from './utils/template';
@@ -7,13 +7,8 @@ import type { CompleteThemeDeep } from './utils/theme';
 import { renderHiGlass as createHiGlassModels } from './create-higlass-models';
 import { manageResponsiveSpecs } from './responsive';
 
-export type CompileCallback = (
-    hg: HiGlassSpec,
-    size: Size,
-    gs: GoslingSpec,
-    trackInfos: TrackMouseEventData[],
-    views: ViewApiData[]
-) => void;
+/** The callback function called everytime after the spec has been compiled */
+export type CompileCallback = (hg: HiGlassSpec, size: Size, gs: GoslingSpec, tracksAndViews: VisUnitApiData[]) => void;
 
 export function compile(
     spec: GoslingSpec,

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -8,9 +8,9 @@ import { renderHiGlass as createHiGlassModels } from './create-higlass-models';
 import { manageResponsiveSpecs } from './responsive';
 
 export type CompileCallback = (
-    hg: HiGlassSpec, 
-    size: Size, 
-    gs: GoslingSpec, 
+    hg: HiGlassSpec,
+    size: Size,
+    gs: GoslingSpec,
     trackInfos: TrackMouseEventData[],
     views: ViewApiData[]
 ) => void;

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -1,4 +1,4 @@
-import type { GoslingSpec, TemplateTrackDef, TrackMouseEventData } from './gosling.schema';
+import type { GoslingSpec, TemplateTrackDef, TrackMouseEventData, ViewApiData } from './gosling.schema';
 import type { HiGlassSpec } from './higlass.schema';
 import { traverseToFixSpecDownstream, overrideDataTemplates } from './utils/spec-preprocess';
 import { replaceTrackTemplates } from './utils/template';
@@ -7,7 +7,13 @@ import type { CompleteThemeDeep } from './utils/theme';
 import { renderHiGlass as createHiGlassModels } from './create-higlass-models';
 import { manageResponsiveSpecs } from './responsive';
 
-export type CompileCallback = (hg: HiGlassSpec, size: Size, gs: GoslingSpec, trackInfos: TrackMouseEventData[]) => void;
+export type CompileCallback = (
+    hg: HiGlassSpec, 
+    size: Size, 
+    gs: GoslingSpec, 
+    trackInfos: TrackMouseEventData[],
+    views: ViewApiData[]
+) => void;
 
 export function compile(
     spec: GoslingSpec,

--- a/src/core/create-higlass-models.ts
+++ b/src/core/create-higlass-models.ts
@@ -2,7 +2,7 @@ import { getBoundingBox, type TrackInfo } from './utils/bounding-box';
 import { goslingToHiGlass } from './gosling-to-higlass';
 import { HiGlassModel } from './higlass-model';
 import { getLinkingInfo } from './utils/linking';
-import type { GoslingSpec, OverlaidTrack, PartialTrack, SingleTrack, TrackMouseEventData, View, ViewApiData, BoundingBox } from '@gosling.schema';
+import type { GoslingSpec, OverlaidTrack, SingleTrack, TrackMouseEventData, ViewApiData } from '@gosling.schema';
 import type { CompleteThemeDeep } from './utils/theme';
 import type { CompileCallback } from './compile';
 import { getViewApiData } from './api-data';
@@ -77,6 +77,7 @@ export function renderHiGlass(
                 d.track.layout === 'linear'
                     ? d.boundingBox
                     : {
+                          ...d.boundingBox,
                           cx: d.boundingBox.x + d.boundingBox.width / 2.0,
                           cy: d.boundingBox.y + d.boundingBox.height / 2.0,
                           innerRadius: d.track.innerRadius!,

--- a/src/core/create-higlass-models.ts
+++ b/src/core/create-higlass-models.ts
@@ -2,9 +2,10 @@ import { getBoundingBox, type TrackInfo } from './utils/bounding-box';
 import { goslingToHiGlass } from './gosling-to-higlass';
 import { HiGlassModel } from './higlass-model';
 import { getLinkingInfo } from './utils/linking';
-import type { GoslingSpec, OverlaidTrack, SingleTrack, TrackMouseEventData } from './gosling.schema';
+import type { GoslingSpec, OverlaidTrack, PartialTrack, SingleTrack, TrackMouseEventData, View, ViewApiData, BoundingBox } from '@gosling.schema';
 import type { CompleteThemeDeep } from './utils/theme';
 import type { CompileCallback } from './compile';
+import { getViewApiData } from './api-data';
 
 export function renderHiGlass(
     spec: GoslingSpec,
@@ -68,7 +69,7 @@ export function renderHiGlass(
             });
     });
 
-    const trackInfosWithShapes: TrackMouseEventData[] = trackInfos.map(d => {
+    const tracks: TrackMouseEventData[] = trackInfos.map(d => {
         return {
             id: d.track.id!,
             spec: d.track as SingleTrack | OverlaidTrack,
@@ -86,5 +87,8 @@ export function renderHiGlass(
         };
     });
 
-    callback(hgModel.spec(), getBoundingBox(trackInfos), spec, trackInfosWithShapes);
+    // Get the view information needed to support JS APIs (e.g., providing view bounding boxes)
+    const views: ViewApiData[] = getViewApiData(spec, tracks);
+
+    callback(hgModel.spec(), getBoundingBox(trackInfos), spec, tracks, views);
 }

--- a/src/core/create-higlass-models.ts
+++ b/src/core/create-higlass-models.ts
@@ -2,7 +2,14 @@ import { getBoundingBox, type TrackInfo } from './utils/bounding-box';
 import { goslingToHiGlass } from './gosling-to-higlass';
 import { HiGlassModel } from './higlass-model';
 import { getLinkingInfo } from './utils/linking';
-import type { GoslingSpec, OverlaidTrack, SingleTrack, TrackMouseEventData, ViewApiData } from '@gosling.schema';
+import type {
+    GoslingSpec,
+    OverlaidTrack,
+    SingleTrack,
+    TrackApiData,
+    VisUnitApiData,
+    ViewApiData
+} from '@gosling.schema';
 import type { CompleteThemeDeep } from './utils/theme';
 import type { CompileCallback } from './compile';
 import { getViewApiData } from './api-data';
@@ -69,7 +76,7 @@ export function renderHiGlass(
             });
     });
 
-    const tracks: TrackMouseEventData[] = trackInfos.map(d => {
+    const tracks: TrackApiData[] = trackInfos.map(d => {
         return {
             id: d.track.id!,
             spec: d.track as SingleTrack | OverlaidTrack,
@@ -91,5 +98,11 @@ export function renderHiGlass(
     // Get the view information needed to support JS APIs (e.g., providing view bounding boxes)
     const views: ViewApiData[] = getViewApiData(spec, tracks);
 
-    callback(hgModel.spec(), getBoundingBox(trackInfos), spec, tracks, views);
+    // Merge the tracks and views
+    const tracksAndViews = [
+        ...tracks.map(d => ({ ...d, type: 'track' } as VisUnitApiData)),
+        ...views.map(d => ({ ...d, type: 'view' } as VisUnitApiData))
+    ];
+
+    callback(hgModel.spec(), getBoundingBox(trackInfos), spec, tracksAndViews);
 }

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -10,7 +10,7 @@ import { omitDeep } from './utils/omit-deep';
 import { isEqual } from 'lodash-es';
 import * as uuid from 'uuid';
 
-import type { TemplateTrackDef, TrackMouseEventData } from './gosling.schema';
+import type { ViewApiData, TemplateTrackDef, TrackMouseEventData } from './gosling.schema';
 
 // Before rerendering, wait for a few time so that HiGlass container is resized already.
 // If HiGlass is rendered and then the container resizes, the viewport position changes, unmatching `xDomain` specified by users.
@@ -43,6 +43,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
     const wrapperParentSize = useRef<undefined | { width: number; height: number }>();
     const prevSpec = useRef<undefined | gosling.GoslingSpec>();
     const trackInfos = useRef<TrackMouseEventData[]>([]);
+    const viewApiData = useRef<ViewApiData[]>([]);
 
     // HiGlass API
     // https://dev.to/wojciechmatuszewski/mutable-and-immutable-useref-semantics-with-react-typescript-30c9
@@ -57,7 +58,8 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
         () => {
             const hgApi = refAsReadonlyProxy(hgRef);
             const infos = refAsReadonlyProxy(trackInfos);
-            const api = createApi(hgApi, viewConfig, infos, theme);
+            const views = refAsReadonlyProxy(viewApiData);
+            const api = createApi(hgApi, viewConfig, infos, views, theme);
             return { api, hgApi };
         },
         [viewConfig, theme]
@@ -75,7 +77,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
 
             gosling.compile(
                 props.spec,
-                (newHs, newSize, newGs, newTrackInfos) => {
+                (newHs, newSize, newGs, newTrackInfos, newViewApiData) => {
                     // TODO: `linkingId` should be updated
                     // We may not want to re-render this
                     if (
@@ -105,6 +107,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
 
                     prevSpec.current = newGs;
                     trackInfos.current = newTrackInfos;
+                    viewApiData.current = newViewApiData;
                 },
                 [...GoslingTemplates], // TODO: allow user definitions
                 theme,

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -1,4 +1,3 @@
-import * as uuid from 'uuid';
 import type { Track as HiGlassTrack } from './higlass.schema';
 import { HiGlassModel, HIGLASS_AXIS_SIZE } from './higlass-model';
 import { parseServerAndTilesetUidFromUrl } from './utils';

--- a/src/core/gosling-to-higlass.ts
+++ b/src/core/gosling-to-higlass.ts
@@ -35,10 +35,6 @@ export function goslingToHiGlass(
     // we only look into the first resolved spec to get information, such as size of the track
     const firstResolvedSpec = resolveSuperposedTracks(gosTrack)[0];
 
-    if (!firstResolvedSpec.id) {
-        firstResolvedSpec.id = uuid.v4();
-    }
-
     const assembly = firstResolvedSpec.assembly;
 
     if (IsDataDeep(firstResolvedSpec.data)) {
@@ -171,7 +167,7 @@ export function goslingToHiGlass(
             hgModel
                 .setViewOrientation(firstResolvedSpec.orientation) // TODO: Orientation should be assigned to 'individual' views
                 .setAssembly(assembly) // TODO: Assembly should be assigned to 'individual' views
-                .addDefaultView(firstResolvedSpec.id, assembly)
+                .addDefaultView(firstResolvedSpec.id!, assembly)
                 .setDomain(xDomain, yDomain ?? xDomain)
                 .adjustDomain(firstResolvedSpec.orientation, width, height)
                 .setMainTrack(hgTrack)

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -289,7 +289,7 @@ export type ViewApiData = {
 
     /** The shape of the source view */
     shape: BoundingBox;
-}
+};
 
 /** The information for a track mouse event */
 export type TrackMouseEventData = {
@@ -300,7 +300,7 @@ export type TrackMouseEventData = {
     spec: SingleTrack | OverlaidTrack;
 
     /** The shape of the source track */
-    shape: BoundingBox | CircularTrackShape;
+    shape: BoundingBox | (BoundingBox & CircularTrackShape);
 };
 
 export type _EventMap = {

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -89,6 +89,8 @@ export type Assembly = 'hg38' | 'hg19' | 'hg18' | 'hg17' | 'hg16' | 'mm10' | 'mm
 export type ZoomLimits = [number | null, number | null];
 
 export interface CommonViewDef {
+    /** The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view */
+    id?: string;
     /** Specify the layout type of all tracks. */
     layout?: Layout;
     /** Specify the orientation. */
@@ -155,9 +157,8 @@ export interface CommonViewDef {
 export type Track = SingleTrack | OverlaidTrack | DataTrack | TemplateTrack;
 
 export interface CommonTrackDef extends CommonViewDef {
-    // !! TODO: we can check if the same id is used multiple times.
-    // !! TODO: this should be track-specific and not defined in views.
-    id?: string; // Assigned to `uid` in a HiGlass view config, used for API and caching.
+    /** Assigned to `uid` in a HiGlass view config, used for API and caching. */
+    id?: string;
 
     /** If defined, will show the textual label on the left-top corner of a track. */
     title?: string;

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -255,10 +255,10 @@ interface RangeMouseEventData extends CommonEventData {
 }
 
 /**
- * The visual parameters that determine the shape of a linear track.
+ * The visual parameters that determine the shape of a linear track or a view.
  * Origin is the left top corner.
  */
-interface LinearTrackShape {
+export interface BoundingBox {
     x: number;
     y: number;
     width: number;
@@ -277,6 +277,20 @@ interface CircularTrackShape {
     endAngle: number;
 }
 
+/**
+ * The information of a view.
+ */
+export type ViewApiData = {
+    /** ID of a source view, i.e., `view.id` */
+    id: string;
+
+    /** Expanded view specification processed by the Gosling compiler, e.g., default properties filled in. */
+    spec: View;
+
+    /** The shape of the source view */
+    shape: BoundingBox;
+}
+
 /** The information for a track mouse event */
 export type TrackMouseEventData = {
     /** ID of a source track, i.e., `track.id` */
@@ -286,7 +300,7 @@ export type TrackMouseEventData = {
     spec: SingleTrack | OverlaidTrack;
 
     /** The shape of the source track */
-    shape: LinearTrackShape | CircularTrackShape;
+    shape: BoundingBox | CircularTrackShape;
 };
 
 export type _EventMap = {

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -278,7 +278,7 @@ interface CircularTrackShape {
 }
 
 /**
- * The information of a view.
+ * The information of a view exposed to users through JS API.
  */
 export type ViewApiData = {
     /** ID of a source view, i.e., `view.id` */
@@ -292,7 +292,7 @@ export type ViewApiData = {
 };
 
 /** The information for a track mouse event */
-export type TrackMouseEventData = {
+export type TrackApiData = {
     /** ID of a source track, i.e., `track.id` */
     id: string;
 
@@ -303,13 +303,16 @@ export type TrackMouseEventData = {
     shape: BoundingBox | (BoundingBox & CircularTrackShape);
 };
 
+/** The API data of tracks or views */
+export type VisUnitApiData = ({ type: 'view' } & ViewApiData) | ({ type: 'track' } & TrackApiData);
+
 export type _EventMap = {
     mouseOver: PointMouseEventData;
     click: PointMouseEventData;
     rangeSelect: RangeMouseEventData;
     rawData: CommonEventData;
-    trackMouseOver: TrackMouseEventData;
-    trackClick: TrackMouseEventData; // TODO (Jul-25-2022): with https://github.com/higlass/higlass/pull/1098, we can support circular layouts
+    trackMouseOver: TrackApiData;
+    trackClick: TrackApiData; // TODO (Jul-25-2022): with https://github.com/higlass/higlass/pull/1098, we can support circular layouts
 };
 
 /** Options for determining mouse events in detail, e.g., turning on specific events only */

--- a/src/core/track-and-view-ids.test.ts
+++ b/src/core/track-and-view-ids.test.ts
@@ -1,4 +1,4 @@
-import type { GoslingSpec } from '@gosling.schema'
+import type { GoslingSpec } from '@gosling.schema';
 import { getInternalSpecById, getTrackIds, getViewIds } from './track-and-view-ids';
 
 describe('Retrieve IDs and Sub-spec', () => {
@@ -56,7 +56,7 @@ describe('Retrieve IDs and Sub-spec', () => {
                     ]
                 }
             ]
-        }
+        };
         expect(getViewIds(overlay)).toEqual(['a', 'b', 'c']);
         expect(getTrackIds(overlay)).toEqual(['d']);
         expect(getInternalSpecById(overlay, 'c')).toMatchInlineSnapshot(`

--- a/src/core/track-and-view-ids.test.ts
+++ b/src/core/track-and-view-ids.test.ts
@@ -1,0 +1,74 @@
+import type { GoslingSpec } from '@gosling.schema'
+import { getInternalSpecById, getTrackIds, getViewIds } from './track-and-view-ids';
+
+describe('Retrieve IDs and Sub-spec', () => {
+    it('Nested Spec', () => {
+        const nested: GoslingSpec = {
+            views: [
+                {
+                    id: 'a',
+                    views: [
+                        {
+                            id: 'b',
+                            tracks: [
+                                {
+                                    id: 'c'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+        expect(getViewIds(nested)).toEqual(['a', 'b']);
+        expect(getTrackIds(nested)).toEqual(['c']);
+        expect(getInternalSpecById(nested, 'b')).toMatchInlineSnapshot(`
+          {
+            "id": "b",
+            "tracks": [
+              {
+                "id": "c",
+              },
+            ],
+          }
+        `);
+    });
+    it('Nested Spec with Overlaid Track', () => {
+        const overlay: GoslingSpec = {
+            views: [
+                {
+                    id: 'a',
+                    views: [
+                        {
+                            id: 'b',
+                            tracks: [
+                                {
+                                    alignment: 'overlay',
+                                    id: 'c',
+                                    tracks: [
+                                        {
+                                            id: 'd'
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        expect(getViewIds(overlay)).toEqual(['a', 'b', 'c']);
+        expect(getTrackIds(overlay)).toEqual(['d']);
+        expect(getInternalSpecById(overlay, 'c')).toMatchInlineSnapshot(`
+          {
+            "alignment": "overlay",
+            "id": "c",
+            "tracks": [
+              {
+                "id": "d",
+              },
+            ],
+          }
+        `);
+    });
+});

--- a/src/core/track-and-view-ids.ts
+++ b/src/core/track-and-view-ids.ts
@@ -1,22 +1,22 @@
-import type { CommonTrackDef, CommonViewDef, GoslingSpec, PartialTrack, View } from "@gosling.schema";
-import { traverseTracksAndViews } from "./utils/spec-preprocess";
+import type { CommonTrackDef, CommonViewDef, GoslingSpec, PartialTrack, View } from '@gosling.schema';
+import { traverseTracksAndViews } from './utils/spec-preprocess';
 
 /**
  * Find all IDs of views in a spec.
- * @param spec 
+ * @param spec
  * @returns
  */
 export function getViewIds(spec: GoslingSpec | View | PartialTrack) {
     const viewIds = new Set<string>();
-    if(spec.id) {
+    if (spec.id) {
         // root view
         viewIds.add(spec.id);
     }
-    traverseTracksAndViews(spec, (subSpec) => {
-        if('views' in subSpec || 'tracks' in subSpec) {
+    traverseTracksAndViews(spec, subSpec => {
+        if ('views' in subSpec || 'tracks' in subSpec) {
             // encountered a view
-            if(subSpec.id) {
-                // found a valid view id 
+            if (subSpec.id) {
+                // found a valid view id
                 viewIds.add(subSpec.id);
             }
         }
@@ -26,16 +26,16 @@ export function getViewIds(spec: GoslingSpec | View | PartialTrack) {
 
 /**
  * Find all IDs of tracks in a spec.
- * @param spec 
+ * @param spec
  * @returns
  */
 export function getTrackIds(spec: GoslingSpec | View | PartialTrack) {
     const trackIds = new Set<string>();
-    traverseTracksAndViews(spec, (subSpec) => {
-        if(!('views' in subSpec) && !('tracks' in subSpec)) {
+    traverseTracksAndViews(spec, subSpec => {
+        if (!('views' in subSpec) && !('tracks' in subSpec)) {
             // encountered a track
-            if(subSpec.id) {
-                // found a valid track id 
+            if (subSpec.id) {
+                // found a valid track id
                 trackIds.add(subSpec.id);
             }
         }
@@ -45,17 +45,17 @@ export function getTrackIds(spec: GoslingSpec | View | PartialTrack) {
 
 /**
  * Get an internal spec using an ID of a track or a view. `undefined` if unfound.
- * @param spec 
+ * @param spec
  * @returns
  */
 export function getInternalSpecById(spec: GoslingSpec | View | PartialTrack, id: string) {
     let internalSpec: CommonViewDef | CommonTrackDef | undefined;
-    if(spec.id === id) {
+    if (spec.id === id) {
         // root view
         internalSpec = spec;
     }
-    traverseTracksAndViews(spec, (subSpec) => {
-        if(subSpec.id === id) {
+    traverseTracksAndViews(spec, subSpec => {
+        if (subSpec.id === id) {
             internalSpec = subSpec;
         }
     });

--- a/src/core/track-and-view-ids.ts
+++ b/src/core/track-and-view-ids.ts
@@ -1,0 +1,63 @@
+import type { CommonTrackDef, CommonViewDef, GoslingSpec, PartialTrack, View } from "@gosling.schema";
+import { traverseTracksAndViews } from "./utils/spec-preprocess";
+
+/**
+ * Find all IDs of views in a spec.
+ * @param spec 
+ * @returns
+ */
+export function getViewIds(spec: GoslingSpec | View | PartialTrack) {
+    const viewIds = new Set<string>();
+    if(spec.id) {
+        // root view
+        viewIds.add(spec.id);
+    }
+    traverseTracksAndViews(spec, (subSpec) => {
+        if('views' in subSpec || 'tracks' in subSpec) {
+            // encountered a view
+            if(subSpec.id) {
+                // found a valid view id 
+                viewIds.add(subSpec.id);
+            }
+        }
+    });
+    return Array.from(viewIds);
+}
+
+/**
+ * Find all IDs of tracks in a spec.
+ * @param spec 
+ * @returns
+ */
+export function getTrackIds(spec: GoslingSpec | View | PartialTrack) {
+    const trackIds = new Set<string>();
+    traverseTracksAndViews(spec, (subSpec) => {
+        if(!('views' in subSpec) && !('tracks' in subSpec)) {
+            // encountered a track
+            if(subSpec.id) {
+                // found a valid track id 
+                trackIds.add(subSpec.id);
+            }
+        }
+    });
+    return Array.from(trackIds);
+}
+
+/**
+ * Get an internal spec using an ID of a track or a view. `undefined` if unfound.
+ * @param spec 
+ * @returns
+ */
+export function getInternalSpecById(spec: GoslingSpec | View | PartialTrack, id: string) {
+    let internalSpec: CommonViewDef | CommonTrackDef | undefined;
+    if(spec.id === id) {
+        // root view
+        internalSpec = spec;
+    }
+    traverseTracksAndViews(spec, (subSpec) => {
+        if(subSpec.id === id) {
+            internalSpec = subSpec;
+        }
+    });
+    return internalSpec;
+}

--- a/src/core/track-and-view-ids.ts
+++ b/src/core/track-and-view-ids.ts
@@ -2,7 +2,7 @@ import type { CommonTrackDef, CommonViewDef, GoslingSpec, PartialTrack, View } f
 import { traverseTracksAndViews } from './utils/spec-preprocess';
 
 /**
- * Find all IDs of views in a spec.
+ * Find all unique IDs of 'views' in a Gosling spec and return them as an array.
  * @param spec
  * @returns
  */
@@ -25,7 +25,7 @@ export function getViewIds(spec: GoslingSpec | View | PartialTrack) {
 }
 
 /**
- * Find all IDs of tracks in a spec.
+ * Find all unique IDs of 'tracks' in a Gosling spec and return them as an array.
  * @param spec
  * @returns
  */

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -44,15 +44,6 @@ export interface TrackInfo {
 }
 
 /**
- * The information of a gosling viewk, including its spec and bounding box.
- */
-export type ViewInfo = {
-    id: string;
-    spec: View,
-    boundingBox: BoundingBox
-}
-
-/**
  * Return the size of entire visualization.
  * @param trackInfos
  */
@@ -84,7 +75,6 @@ export function getRelativeTrackInfo(
 ): { 
     trackInfos: TrackInfo[]; 
     size: { width: number; height: number };
-    views: ViewInfo[];
 } {
     let trackInfos: TrackInfo[] = [] as TrackInfo[];
 
@@ -125,8 +115,6 @@ export function getRelativeTrackInfo(
         // !! The total height should be multiples of 8. Refer to `getBoundingBox()`
         size.height = size.height + (8 - (size.height % 8));
     }
-
-    // 
 
     const pixelPreciseMarginPadding = !(typeof spec.responsiveSize !== 'object'
         ? spec.responsiveSize

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -1,4 +1,4 @@
-import type { MultipleViews, CommonViewDef, GoslingSpec, Track, SingleView } from '../gosling.schema';
+import type { MultipleViews, CommonViewDef, GoslingSpec, Track, View, SingleView } from '@gosling.schema';
 import { Is2DTrack, IsOverlaidTrack, IsXAxis, IsYAxis } from '../gosling.schema.guards';
 import { HIGLASS_AXIS_SIZE } from '../higlass-model';
 import {
@@ -14,13 +14,6 @@ import type { CompleteThemeDeep } from './theme';
 export interface Size {
     width: number;
     height: number;
-}
-
-export interface GridInfo extends Size {
-    columnSizes: number[];
-    rowSizes: number[];
-    columnGaps: number[];
-    rowGaps: number[];
 }
 
 /**
@@ -48,6 +41,15 @@ export interface TrackInfo {
     track: Track;
     boundingBox: BoundingBox;
     layout: RelativePosition;
+}
+
+/**
+ * The information of a gosling viewk, including its spec and bounding box.
+ */
+export type ViewInfo = {
+    id: string;
+    spec: View,
+    boundingBox: BoundingBox
 }
 
 /**
@@ -79,7 +81,11 @@ export function getBoundingBox(trackInfos: TrackInfo[]) {
 export function getRelativeTrackInfo(
     spec: GoslingSpec,
     theme: CompleteThemeDeep
-): { trackInfos: TrackInfo[]; size: { width: number; height: number } } {
+): { 
+    trackInfos: TrackInfo[]; 
+    size: { width: number; height: number };
+    views: ViewInfo[];
+} {
     let trackInfos: TrackInfo[] = [] as TrackInfo[];
 
     // Collect track information including spec, bounding boxes, and RGL' `layout`.
@@ -119,6 +125,8 @@ export function getRelativeTrackInfo(
         // !! The total height should be multiples of 8. Refer to `getBoundingBox()`
         size.height = size.height + (8 - (size.height % 8));
     }
+
+    // 
 
     const pixelPreciseMarginPadding = !(typeof spec.responsiveSize !== 'object'
         ? spec.responsiveSize

--- a/src/core/utils/bounding-box.ts
+++ b/src/core/utils/bounding-box.ts
@@ -1,4 +1,4 @@
-import type { MultipleViews, CommonViewDef, GoslingSpec, Track, View, SingleView } from '@gosling.schema';
+import type { MultipleViews, CommonViewDef, GoslingSpec, Track, SingleView } from '@gosling.schema';
 import { Is2DTrack, IsOverlaidTrack, IsXAxis, IsYAxis } from '../gosling.schema.guards';
 import { HIGLASS_AXIS_SIZE } from '../higlass-model';
 import {
@@ -72,8 +72,8 @@ export function getBoundingBox(trackInfos: TrackInfo[]) {
 export function getRelativeTrackInfo(
     spec: GoslingSpec,
     theme: CompleteThemeDeep
-): { 
-    trackInfos: TrackInfo[]; 
+): {
+    trackInfos: TrackInfo[];
     size: { width: number; height: number };
 } {
     let trackInfos: TrackInfo[] = [] as TrackInfo[];

--- a/src/core/utils/linking.test.ts
+++ b/src/core/utils/linking.test.ts
@@ -9,6 +9,7 @@ describe('Should get linking information correctly', () => {
             new HiGlassModel(),
             {
                 data: { type: 'csv', url: 'https://' },
+                id: 'track',
                 overlay: [
                     {
                         mark: 'point',

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -175,6 +175,11 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
         // Nothing to do when `xLinkID` not suggested
     }
 
+    // ID should be assigned to each view and track for an API usage
+    if (!!!spec.id) {
+        spec.id = uuid.v4();
+    }
+
     if ('tracks' in spec) {
         let tracks: Track[] = convertToFlatTracks(spec);
 

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -176,7 +176,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
     }
 
     // ID should be assigned to each view and track for an API usage
-    if (!!!spec.id) {
+    if (!spec.id) {
         spec.id = uuid.v4();
     }
 

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -192,6 +192,11 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
 
         const linkID = uuid.v4();
         tracks.forEach((track, i, array) => {
+            // ID should be assigned to each view and track for an API usage
+            if (!track.id) {
+                track.id = uuid.v4();
+            }
+            
             // If size not defined, set default ones
             if (!track.width) {
                 track.width = Is2DTrack(track) ? DEFAULT_TRACK_SIZE_2D : DEFAULT_TRACK_WIDTH_LINEAR;

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -196,7 +196,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
             if (!track.id) {
                 track.id = uuid.v4();
             }
-            
+
             // If size not defined, set default ones
             if (!track.width) {
                 track.width = Is2DTrack(track) ? DEFAULT_TRACK_SIZE_2D : DEFAULT_TRACK_WIDTH_LINEAR;

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -1077,7 +1077,7 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
                     publish(eventType, {
                         id: context.viewUid,
                         spec: structuredClone(this.options.spec),
-                        shape: { cx, cy, innerRadius, outerRadius, startAngle, endAngle }
+                        shape: { x, y, width, height, cx, cy, innerRadius, outerRadius, startAngle, endAngle }
                     });
                 }
             } else {


### PR DESCRIPTION
Fix #929 
Toward #183

## Change List
 - In the grammar, enable adding an `id` to a view at any level.
 - Using the `id`, users can get the bounding boxes and specs of views as well as tracks.
 - In the Editor, add a toggle button to display the hierarchy of tracks and views.

### APIs Added/Updated
```ts
const tracksAndViews = gosRef.api.current.getTracksAndViews();
const views = gosRef.api.current.getViews();
const tracks = gosRef.api.current.getTracks();

console.log(tracksAndViews[0]);

// { type: 'track', shape: { x: 0, y: 12, width: 400, height: 100 }, spec: { id: 'track-1', mark: 'point', ...} }
```

### Screenshot

The blue rectangles represent views, and the red rectangles represent tracks.

![Screenshot 2023-07-13 at 12 16 13](https://github.com/gosling-lang/gosling.js/assets/9922882/f61d29f8-a53d-455d-96ca-162f78a713e8)

<img width="1893" alt="Screenshot 2023-07-13 at 13 04 25" src="https://github.com/gosling-lang/gosling.js/assets/9922882/c713d6cc-8353-48f3-81b4-aa0976d498e5">

<img width="1893" alt="Screenshot 2023-07-13 at 13 04 35" src="https://github.com/gosling-lang/gosling.js/assets/9922882/3e2c998f-47d2-4ad9-b9ab-3ef173e6a485">

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [x] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
