### PR TITLE
feat(api): onNewTrack, onNewView

### DIFF
--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -334,6 +334,10 @@ function Editor(props: RouteComponentProps) {
             // gosRef.current.api.subscribe('trackClick', (type, eventData) => {
             //     console.warn(type, eventData.id, eventData.spec, eventData.shape);
             // });
+            // New Track
+            gosRef.current.api.subscribe('onNewTrack', (type, eventData) => {
+                console.warn(type, eventData);
+            });
         }
         return () => {
             // gosRef.current?.api.unsubscribe('mouseOver');

--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -335,9 +335,13 @@ function Editor(props: RouteComponentProps) {
             //     console.warn(type, eventData.id, eventData.spec, eventData.shape);
             // });
             // New Track
-            gosRef.current.api.subscribe('onNewTrack', (type, eventData) => {
-                console.warn(type, eventData);
-            });
+            // gosRef.current.api.subscribe('onNewTrack', (type, eventData) => {
+            //     console.warn(type, eventData);
+            // });
+            // New View
+            // gosRef.current.api.subscribe('onNewView', (type, eventData) => {
+            //     console.warn(type, eventData);
+            // });
         }
         return () => {
             // gosRef.current?.api.unsubscribe('mouseOver');

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -63,7 +63,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
         const newViews = currentViews.filter(view => !prevViewIds.has(view.id));
         // Publish if there are any new changes
         newViews.forEach(view => {
-            publish('onNewView', { id: view.id, shape: view.shape });
+            publish('onNewView', { id: view.id });
         });
     };
 

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -91,18 +91,18 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
 
             gosling.compile(
                 props.spec,
-                (newHs, newSize, newGs, newTrackInfos) => {
+                (newHiGlassSpec, newSize, newGoslingSpec, newTracksAndViews) => {
                     // TODO: `linkingId` should be updated
                     // We may not want to re-render this
                     if (
                         prevSpec.current &&
-                        isEqual(omitDeep(prevSpec.current, ['linkingId']), omitDeep(newGs, ['linkingId']))
+                        isEqual(omitDeep(prevSpec.current, ['linkingId']), omitDeep(newGoslingSpec, ['linkingId']))
                     ) {
                         return;
                     }
 
                     // If a callback function is provided, return compiled information.
-                    props.compiled?.(props.spec!, newHs);
+                    props.compiled?.(props.spec!, newHiGlassSpec);
 
                     // Change the size of wrapper `<div/>` elements
                     setSize(newSize);
@@ -112,15 +112,15 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
                     if (props.experimental?.reactive && isMountedOnce) {
                         // Use API to update visualization.
                         setTimeout(() => {
-                            hgRef.current?.api.setViewConfig(newHs);
+                            hgRef.current?.api.setViewConfig(newHiGlassSpec);
                         }, DELAY_FOR_CONTAINER_RESIZE_BEFORE_RERENDER);
                     } else {
                         // Mount `HiGlassComponent` using this view config.
-                        setViewConfig(newHs);
+                        setViewConfig(newHiGlassSpec);
                     }
-                    publishOnNewView(newTrackInfos);
-                    prevSpec.current = newGs;
-                    tracksAndViews.current = newTrackInfos;
+                    publishOnNewView(newTracksAndViews);
+                    prevSpec.current = newGoslingSpec;
+                    tracksAndViews.current = newTracksAndViews;
                 },
                 [...GoslingTemplates], // TODO: allow user definitions
                 theme,

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -248,6 +248,12 @@ interface OnNewTrackEventData {
     /** The shape of the source track */
     shape: BoundingBox | CircularTrackShape;
 }
+interface OnNewViewEventData {
+    /** Source visualization ID, i.e., `track.id` */
+    id: string;
+    /** The shape of the source track */
+    shape: BoundingBox;
+}
 
 interface PointMouseEventData extends CommonEventData {
     /** A genomic coordinate, e.g., `chr1:100,000`. */
@@ -320,6 +326,7 @@ export type _EventMap = {
     trackMouseOver: TrackApiData;
     trackClick: TrackApiData; // TODO (Jul-25-2022): with https://github.com/higlass/higlass/pull/1098, we can support circular layouts
     onNewTrack: OnNewTrackEventData;
+    onNewView: OnNewViewEventData;
 };
 
 /** Options for determining mouse events in detail, e.g., turning on specific events only */

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -242,6 +242,12 @@ export interface GenomicPosition {
     chromosome: string;
     position: number;
 }
+interface OnNewTrackEventData {
+    /** Source visualization ID, i.e., `track.id` */
+    id: string;
+    /** The shape of the source track */
+    shape: BoundingBox | CircularTrackShape;
+}
 
 interface PointMouseEventData extends CommonEventData {
     /** A genomic coordinate, e.g., `chr1:100,000`. */
@@ -313,6 +319,7 @@ export type _EventMap = {
     rawData: CommonEventData;
     trackMouseOver: TrackApiData;
     trackClick: TrackApiData; // TODO (Jul-25-2022): with https://github.com/higlass/higlass/pull/1098, we can support circular layouts
+    onNewTrack: OnNewTrackEventData;
 };
 
 /** Options for determining mouse events in detail, e.g., turning on specific events only */

--- a/src/core/gosling.schema.ts
+++ b/src/core/gosling.schema.ts
@@ -245,14 +245,10 @@ export interface GenomicPosition {
 interface OnNewTrackEventData {
     /** Source visualization ID, i.e., `track.id` */
     id: string;
-    /** The shape of the source track */
-    shape: BoundingBox | CircularTrackShape;
 }
 interface OnNewViewEventData {
     /** Source visualization ID, i.e., `track.id` */
     id: string;
-    /** The shape of the source track */
-    shape: BoundingBox;
 }
 
 interface PointMouseEventData extends CommonEventData {

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -1307,33 +1307,9 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
          * Publishes track information. Triggered when track gets created
          */
         #publishOnNewTrack() {
-            const [x, y] = this.position;
-            const [width, height] = this.dimensions;
-            if (this.options.spec.layout === 'circular') {
-                const cx = x + width / 2.0;
-                const cy = y + height / 2.0;
-                const innerRadius = this.options.spec.innerRadius!;
-                const outerRadius = this.options.spec.outerRadius!;
-                publish('onNewTrack', {
-                    id: context.viewUid,
-                    shape: {
-                        x: cx,
-                        y: cy,
-                        width: innerRadius,
-                        height: outerRadius
-                    }
-                });
-            } else {
-                publish('onNewTrack', {
-                    id: context.viewUid,
-                    shape: {
-                        x,
-                        y,
-                        width,
-                        height
-                    }
-                });
-            }
+            publish('onNewTrack', {
+                id: context.viewUid
+            });
         }
 
         /* *

--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -147,6 +147,7 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
         mRangeBrush: LinearBrushModel;
         #assembly?: Assembly; // Used to get the relative genomic position
         #processedTileInfo: Record<string, ProcessedTileInfo>;
+        #firstDraw = true; // False if draw has been called once already. Used with onNewTrack API
         // Used in mark/legend.ts
         gLegend? = HGC.libraries.d3Selection.select(context.svgElement).append('g');
         displayedLegends: DisplayedLegend[] = []; // Store the color legends added so far so that we can avoid overlaps and redundancy
@@ -294,6 +295,11 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
 
             // Based on the updated marks, update range selection
             this.mRangeBrush?.drawBrush(true);
+            // Publish onNewTrack if this is the first draw
+            if (this.#firstDraw) {
+                this.#publishOnNewTrack();
+                this.#firstDraw = false;
+            }
         }
 
         /*
@@ -1291,6 +1297,43 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
                 }
             }
             return '';
+        }
+
+        /**
+         * Javscript subscription API methods (besides for mouse)
+         */
+
+        /**
+         * Publishes track information. Triggered when track gets created
+         */
+        #publishOnNewTrack() {
+            const [x, y] = this.position;
+            const [width, height] = this.dimensions;
+            if (this.options.spec.layout === 'circular') {
+                const cx = x + width / 2.0;
+                const cy = y + height / 2.0;
+                const innerRadius = this.options.spec.innerRadius!;
+                const outerRadius = this.options.spec.outerRadius!;
+                publish('onNewTrack', {
+                    id: context.viewUid,
+                    shape: {
+                        x: cx,
+                        y: cy,
+                        width: innerRadius,
+                        height: outerRadius
+                    }
+                });
+            } else {
+                publish('onNewTrack', {
+                    id: context.viewUid,
+                    shape: {
+                        x,
+                        y,
+                        width,
+                        height
+                    }
+                });
+            }
         }
 
         /* *


### PR DESCRIPTION
Fix #926
Toward #

## Change List
 - Add `onNewTrack` API
 - Add `onNewView` API

```
// New Track
gosRef.current.api.subscribe('onNewTrack', (type, eventData) => {
    console.warn(eventData.id, eventData.shape);
});
// New View
gosRef.current.api.subscribe('onNewView', (type, eventData) => {
     console.warn(eventData.id, eventData.shape);
});
```

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
