### PR TITLE
fix(track): remove private properties from draw()

### DIFF
--- a/src/gosling-track/gosling-track.ts
+++ b/src/gosling-track/gosling-track.ts
@@ -147,7 +147,7 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
         mRangeBrush: LinearBrushModel;
         #assembly?: Assembly; // Used to get the relative genomic position
         #processedTileInfo: Record<string, ProcessedTileInfo>;
-        #firstDraw = true; // False if draw has been called once already. Used with onNewTrack API
+        firstDraw = true; // False if draw has been called once already. Used with onNewTrack API. Public because used in draw()
         // Used in mark/legend.ts
         gLegend? = HGC.libraries.d3Selection.select(context.svgElement).append('g');
         displayedLegends: DisplayedLegend[] = []; // Store the color legends added so far so that we can avoid overlaps and redundancy
@@ -296,9 +296,9 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             // Based on the updated marks, update range selection
             this.mRangeBrush?.drawBrush(true);
             // Publish onNewTrack if this is the first draw
-            if (this.#firstDraw) {
+            if (this.firstDraw) {
                 this.#publishOnNewTrack();
-                this.#firstDraw = false;
+                this.firstDraw = false;
             }
         }
 


### PR DESCRIPTION
Fix #950
Toward #

## Change List
 - Make `firstDraw` property public. Private class properties can't be used in `draw()` because technically the class constructor hasn't been called yet. 

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
