### PR TITLE
fix(core): do not override ID in tracks from views

### DIFF
--- a/src/core/utils/overlay.ts
+++ b/src/core/utils/overlay.ts
@@ -77,7 +77,7 @@ export function spreadTracksByData(tracks: Track[]): Track[] {
                 return [t];
             }
 
-            const base: SingleTrack = JSON.parse(JSON.stringify(t));
+            const base: SingleTrack = JSON.parse(JSON.stringify({...t, id: undefined }));
             delete (base as Partial<OverlaidTrack>).overlay; // remove `overlay` from the base spec
 
             const spread: Track[] = [];

--- a/src/core/utils/overlay.ts
+++ b/src/core/utils/overlay.ts
@@ -77,9 +77,7 @@ export function spreadTracksByData(tracks: Track[]): Track[] {
                 return [t];
             }
 
-            const base: SingleTrack = JSON.parse(JSON.stringify({...t, id: undefined }));
-            delete (base as Partial<OverlaidTrack>).overlay; // remove `overlay` from the base spec
-
+            const base: Partial<OverlaidTrack> = {...t, id: undefined, overlay: undefined };
             const spread: Track[] = [];
             const original: OverlaidTrack = JSON.parse(JSON.stringify(base));
             original.overlay = [];

--- a/src/core/utils/spec-preprocess.test.ts
+++ b/src/core/utils/spec-preprocess.test.ts
@@ -299,6 +299,14 @@ describe('Spec Preprocess', () => {
         }
         {
             const flat = convertToFlatTracks({
+                id: 'view-id',
+                tracks: [{}]
+            });
+            expect(flat).toHaveLength(1);
+            expect(flat[0].id).toBeUndefined();
+        }
+        {
+            const flat = convertToFlatTracks({
                 tracks: [{ ...dummySpec, title: 'A' }]
             });
             expect(flat).toHaveLength(1);

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -93,9 +93,17 @@ export function traverseViewArrangements(spec: GoslingSpec, callback: (tv: Multi
  * @param spec
  */
 export function convertToFlatTracks(spec: SingleView): Track[] {
+    const getViewBaseDef = (view: SingleView) => {
+        const base: Partial<SingleView> = {
+            ...view,
+            tracks: undefined,
+            id: undefined
+        };
+        return base;
+    };
     if (IsFlatTracks(spec)) {
         // This is already `FlatTracks`, so just override the view definition
-        const base = JSON.parse(JSON.stringify(spec));
+        const base = getViewBaseDef(spec);
         delete (base as any).tracks;
         return spec.tracks
             .filter(track => !track._invalidTrack)
@@ -111,14 +119,14 @@ export function convertToFlatTracks(spec: SingleView): Track[] {
                     // This is OverlaidTracks
                     newTracks.push({
                         ...track,
+                        id: undefined,
                         overlay: [...track.tracks],
                         tracks: undefined,
                         alignment: undefined
                     } as Track);
                 } else {
                     // Override track definitions from views
-                    const base = JSON.parse(JSON.stringify(spec));
-                    delete (base as any).tracks;
+                    const base = getViewBaseDef(spec);
                     const newSpec = Object.assign(JSON.parse(JSON.stringify(base)), track) as SingleTrack;
                     newTracks.push(newSpec);
                 }

--- a/src/core/utils/spec-preprocess.ts
+++ b/src/core/utils/spec-preprocess.ts
@@ -93,18 +93,9 @@ export function traverseViewArrangements(spec: GoslingSpec, callback: (tv: Multi
  * @param spec
  */
 export function convertToFlatTracks(spec: SingleView): Track[] {
-    const getViewBaseDef = (view: SingleView) => {
-        const base: Partial<SingleView> = {
-            ...view,
-            tracks: undefined,
-            id: undefined
-        };
-        return base;
-    };
     if (IsFlatTracks(spec)) {
         // This is already `FlatTracks`, so just override the view definition
-        const base = getViewBaseDef(spec);
-        delete (base as any).tracks;
+        const base = {...spec, tracks: undefined, id: undefined };
         return spec.tracks
             .filter(track => !track._invalidTrack)
             .map(track => Object.assign(JSON.parse(JSON.stringify(base)), track) as SingleTrack);
@@ -119,14 +110,13 @@ export function convertToFlatTracks(spec: SingleView): Track[] {
                     // This is OverlaidTracks
                     newTracks.push({
                         ...track,
-                        id: undefined,
                         overlay: [...track.tracks],
                         tracks: undefined,
                         alignment: undefined
                     } as Track);
                 } else {
                     // Override track definitions from views
-                    const base = getViewBaseDef(spec);
+                    const base = {...spec, tracks: undefined, id: undefined };
                     const newSpec = Object.assign(JSON.parse(JSON.stringify(base)), track) as SingleTrack;
                     newTracks.push(newSpec);
                 }


### PR DESCRIPTION
Fix #953 
Toward #

## Change List
 - Do not override ID in tracks from views. Tracks ended up having the same IDs resulted in errors.

<img width="559" alt="Screenshot 2023-07-31 at 11 01 51" src="https://github.com/gosling-lang/gosling.js/assets/9922882/d4f007eb-2150-40a1-9d26-427789242246">

<img width="684" alt="Screenshot 2023-07-31 at 11 01 46" src="https://github.com/gosling-lang/gosling.js/assets/9922882/2c9e2e2a-a475-48e7-89fa-89439bd6d8b5">



## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [x] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)