### PR TITLE
fix(data-fetcher): gmod/gff stream issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
         "quick-lru": "^6.1.1",
         "rbush": "^3.0.1",
         "react-grid-layout": "^1.2.5",
+        "stream-browserify": "^3.0.0",
         "threads": "^1.6.4",
         "uuid": "^8.3.2"
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -64,7 +64,8 @@ const alias = {
     "@gosling-lang/dummy-track": path.resolve(__dirname, "./src/dummy-track/index.ts"),
     "@data-fetchers": path.resolve(__dirname, "./src/data-fetchers/index.ts"),
     zlib: path.resolve(__dirname, './src/alias/zlib.ts'),
-    uuid: path.resolve(__dirname, './node_modules/uuid/dist/esm-browser/index.js')
+    uuid: path.resolve(__dirname, './node_modules/uuid/dist/esm-browser/index.js'),
+    stream: path.resolve(__dirname, './node_modules/stream-browserify')
 };
 
 const skipExt = new Set(['@gmod/bbi', 'uuid']);


### PR DESCRIPTION
Fix #956 
Toward #

## Change List
- Alias for `stream-browserify`

gmod/gff uses `stream-browserify`, but defines it using the `browser` [field in package.json](https://github.com/GMOD/gff-js/blob/6373b3afb432fc4524f99f69b1116d70934f4a21/package.json#L9C1-L11). Apparently, [vite has trouble](https://github.com/vitejs/vite/issues/7576#issue-1190601191) using packages that are defined that way. 

HiGlass has `stream` as a dependency, so vite uses `stream` instead of `stream-browserify` for gmod/gff. This caused the gff fetcher to not work in gosling. 

I just added an alias for `stream-browserify` so gmod/gff uses the correct stream. This doesn't appear to impact HiGlass. 

before: 
<img width="300" alt="image" src="https://github.com/gosling-lang/gosling.js/assets/14843470/adcbef93-6bed-4693-ad1a-af2a3b28afdc">

after: 
<img width="300" alt="image" src="https://github.com/gosling-lang/gosling.js/assets/14843470/d9fed595-fcd7-462f-98ac-4dec858ec9a3"> 

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
