### PR TITLE
fix(core): rule mark calculation in circular layout

### DIFF
--- a/src/core/mark/rule.ts
+++ b/src/core/mark/rule.ts
@@ -142,7 +142,7 @@ export function drawRule(HGC: import('@higlass/types').HGC, trackInfo: any, tile
                         0.5 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
                     );
 
-                    const midR = trackOuterRadius - ((rowPosition + y) / trackHeight) * trackRingSize;
+                    const midR = trackOuterRadius - ((rowPosition + rowHeight - y) / trackHeight) * trackRingSize;
                     const farR = midR + strokeWidth / 2.0;
                     const nearR = midR - strokeWidth / 2.0;
 


### PR DESCRIPTION
Fix #966 
Toward #

## Change List
 - Fix the way the middle of the track is calculated for the rule mark.

Before:
<img width="400" alt="image" src="https://github.com/gosling-lang/gosling.js/assets/14843470/2d73a409-1a62-4629-a228-ec64256905fb">

After:
<img width="400" alt="image" src="https://github.com/gosling-lang/gosling.js/assets/14843470/47b66715-fdd3-4d0f-8975-61bb26118111">


## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
