### PR TITLE
fix(core): first track ID should not be lost after compile

### DIFF
--- a/src/compiler/compile.test.ts
+++ b/src/compiler/compile.test.ts
@@ -2,6 +2,9 @@ import { EX_SPEC_VISUAL_ENCODING } from '../../editor/example/json-spec/visual-e
 import { compile } from './compile';
 import { getTheme } from '../core/utils/theme';
 import type { GoslingSpec } from '../index';
+import { convertToFlatTracks } from './spec-preprocess';
+import type { SingleView } from '@gosling-lang/gosling-schema';
+import { spreadTracksByData } from '../core/utils/overlay';
 
 describe('compile', () => {
     it('compile should not touch the original spec of users', () => {
@@ -240,5 +243,56 @@ describe('Dummy track', () => {
             getTheme(),
             {}
         );
+    });
+});
+
+describe('Maintain IDs', () => {
+    it('Overlaid tracks', () => {
+        const twoTracksWithDiffData: SingleView = {
+            alignment: 'overlay',
+            tracks: [
+                {
+                    id: 'first',
+                    data: { type: 'csv', url: 'http://abc' }
+                },
+                {
+                    id: 'second',
+                    data: { type: 'csv', url: 'http://def' }
+                }
+            ]
+        }
+        const flattened = convertToFlatTracks(twoTracksWithDiffData);
+        const spread = spreadTracksByData(flattened);
+        expect(spread).toMatchInlineSnapshot(`
+          [
+            {
+              "data": {
+                "type": "csv",
+                "url": "http://abc",
+              },
+              "id": "first",
+              "overlay": [
+                {
+                  "data": {
+                    "type": "csv",
+                    "url": "http://abc",
+                  },
+                  "id": "first",
+                },
+              ],
+              "overlayOnPreviousTrack": false,
+              "y": undefined,
+            },
+            {
+              "data": {
+                "type": "csv",
+                "url": "http://def",
+              },
+              "id": "second",
+              "overlayOnPreviousTrack": true,
+              "y": undefined,
+            },
+          ]
+        `);
     });
 });

--- a/src/compiler/compile.test.ts
+++ b/src/compiler/compile.test.ts
@@ -263,36 +263,6 @@ describe('Maintain IDs', () => {
         };
         const flattened = convertToFlatTracks(twoTracksWithDiffData);
         const spread = spreadTracksByData(flattened);
-        expect(spread).toMatchInlineSnapshot(`
-          [
-            {
-              "data": {
-                "type": "csv",
-                "url": "http://abc",
-              },
-              "id": "first",
-              "overlay": [
-                {
-                  "data": {
-                    "type": "csv",
-                    "url": "http://abc",
-                  },
-                  "id": "first",
-                },
-              ],
-              "overlayOnPreviousTrack": false,
-              "y": undefined,
-            },
-            {
-              "data": {
-                "type": "csv",
-                "url": "http://def",
-              },
-              "id": "second",
-              "overlayOnPreviousTrack": true,
-              "y": undefined,
-            },
-          ]
-        `);
+        expect(spread.map(d => d.id)).toEqual(['first', 'second']);
     });
 });

--- a/src/compiler/compile.test.ts
+++ b/src/compiler/compile.test.ts
@@ -260,7 +260,7 @@ describe('Maintain IDs', () => {
                     data: { type: 'csv', url: 'http://def' }
                 }
             ]
-        }
+        };
         const flattened = convertToFlatTracks(twoTracksWithDiffData);
         const spread = spreadTracksByData(flattened);
         expect(spread).toMatchInlineSnapshot(`

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -86,7 +86,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
      * This makes sure that all the current zooming status is preserved when new tracks are added
      */
     const preverseZoomStatus = (newSpec: gosling.HiGlassSpec, prevSpec: gosling.HiGlassSpec) => {
-        newSpec.views.forEach((view) => {
+        newSpec.views.forEach(view => {
             const viewUid = view.uid!;
             const newView = !prevSpec.views.find(v => v.uid === viewUid);
             if (newView) {

--- a/src/core/utils/overlay.ts
+++ b/src/core/utils/overlay.ts
@@ -96,7 +96,7 @@ export function spreadTracksByData(tracks: Track[]): Track[] {
                 }
 
                 // If the id is undefined, put the first spec to the parent
-                if(!original.id) {
+                if (!original.id) {
                     original.id = subSpec.id;
                 }
 

--- a/src/core/utils/overlay.ts
+++ b/src/core/utils/overlay.ts
@@ -95,6 +95,11 @@ export function spreadTracksByData(tracks: Track[]): Track[] {
                     original.data = subSpec.data;
                 }
 
+                // If the id is undefined, put the first spec to the parent
+                if(!original.id) {
+                    original.id = subSpec.id;
+                }
+
                 // Determine if this `subSpec` should be added to `overlay` or become a separate track
                 if (!subSpec.data || isIdenticalDataSpec([original.data, subSpec.data])) {
                     original.overlay.push(subSpec);


### PR DESCRIPTION
## Change List
 - Fix an issue that the ID of a first track in an overlaid view is lost after compiling (more specifically, after `spreadTracksByData`). I added a test to ensure that we do not have this issue again.

### Example

- Spec used: https://gist.github.com/sehilyi/b5bc4c1e05305979a3fe4018de0edf40

```
gosRef.current.api.getTracks();
```

![Screenshot 2023-09-25 at 17 15 30](https://github.com/gosling-lang/gosling.js/assets/9922882/bbe7aeb1-4845-4f18-9f08-2fdc5ebc6731)

cc @ThHarbig 

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [x] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
