### PR TITLE
feat(api): publish traversed spec to gosling api

### DIFF
--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -73,13 +73,13 @@ export function compile(
     // used for alt-gosling
     try {
         if (PubSub) {
-            PubSub.publish('spec-traversed', {
+            PubSub.publish('specTraversed', {
                 id: specCopy.id,
-                data:
-                    specCopy
+                data: specCopy
             });
         }
     } catch (e) {
+        //
     }
 
     // Make HiGlass models for individual tracks

--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -8,6 +8,7 @@ import type { UrlToFetchOptions } from 'src/core/gosling-component';
 import { renderHiGlass as createHiGlassModels } from './create-higlass-models';
 import { manageResponsiveSpecs } from './responsive';
 import type { IdTable } from '../api/track-and-view-ids';
+import { publish } from '../api/pubsub';
 
 /** The callback function called everytime after the spec has been compiled */
 export type CompileCallback = (
@@ -71,16 +72,10 @@ export function compile(
 
     // publish the fixed spec
     // used for alt-gosling
-    try {
-        if (PubSub) {
-            PubSub.publish('specTraversed', {
-                id: specCopy.id,
-                data: specCopy
-            });
-        }
-    } catch (e) {
-        //
-    }
+    publish('specProcessed', {
+        id: specCopy.id,
+        spec: specCopy
+    });
 
     // Make HiGlass models for individual tracks
     createHiGlassModels(specCopy, trackInfos, callback, theme, urlToFetchOptions);

--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -69,6 +69,19 @@ export function compile(
         trackInfos = getRelativeTrackInfo(specCopy, theme).trackInfos;
     }
 
+    // publish the fixed spec
+    // used for alt-gosling
+    try {
+        if (PubSub) {
+            PubSub.publish('spec-traversed', {
+                id: specCopy.id,
+                data:
+                    specCopy
+            });
+        }
+    } catch (e) {
+    }
+
     // Make HiGlass models for individual tracks
     createHiGlassModels(specCopy, trackInfos, callback, theme, urlToFetchOptions);
 }

--- a/src/gosling-schema/gosling.schema.ts
+++ b/src/gosling-schema/gosling.schema.ts
@@ -284,6 +284,13 @@ interface CommonEventData {
     data: Datum[];
 }
 
+interface SpecEventData {
+    /** Source visualization ID, i.e., `track.id` */
+    id: string;
+    /** Gosling spec */
+    spec: GoslingSpec;
+}
+
 export interface GenomicPosition {
     chromosome: string;
     position: number;
@@ -372,6 +379,7 @@ export type _EventMap = {
     click: PointMouseEventData;
     rangeSelect: RangeMouseEventData;
     rawData: CommonEventData;
+    specProcessed: SpecEventData;
     trackMouseOver: TrackApiData;
     trackClick: TrackApiData; // TODO (Jul-25-2022): with https://github.com/higlass/higlass/pull/1098, we can support circular layouts
     onNewTrack: OnNewTrackEventData;


### PR DESCRIPTION
Fix #
Toward #

## Change List
 - Added the spec as changed by overrideDataTemplates, replaceTrackTemplates and most importantly traverseToFixSpecDownstream to the Gosling api. This is used in the AltGoslingComponent.

## Checklist
 - [X] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [X] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
