### PR TITLE
refactor(core): make overlay private

### DIFF
--- a/src/compiler/bounding-box.test.ts
+++ b/src/compiler/bounding-box.test.ts
@@ -6,7 +6,7 @@ import { getTheme } from '../core/utils/theme';
 
 describe('Arrangement', () => {
     it('1 View, 1 Track', () => {
-        const spec = { tracks: [{ overlay: [], width: 40, height: 40 }] };
+        const spec = { tracks: [{ _overlay: [], width: 40, height: 40 }] };
         const info = getRelativeTrackInfo(spec, getTheme()).trackInfos;
         expect(info).toHaveLength(1);
 
@@ -18,8 +18,8 @@ describe('Arrangement', () => {
     it('1 View, 1 Track (N Overlaid Tracks)', () => {
         const spec1 = {
             tracks: [
-                { overlay: [], width: 40, height: 40 },
-                { overlay: [], width: 40, height: 40, overlayOnPreviousTrack: true }
+                { _overlay: [], width: 40, height: 40 },
+                { _overlay: [], width: 40, height: 40, overlayOnPreviousTrack: true }
             ]
         };
         expect(getRelativeTrackInfo(spec1, getTheme()).trackInfos).toHaveLength(2);
@@ -29,22 +29,22 @@ describe('Arrangement', () => {
     it('1 View, 2 Tracks (N Overlaid Tracks)', () => {
         const spec1 = {
             tracks: [
-                { overlay: [], width: 10, height: 10 },
-                { overlay: [], width: 10, height: 10 }
+                { _overlay: [], width: 10, height: 10 },
+                { _overlay: [], width: 10, height: 10 }
             ]
         };
         const spec2 = {
             tracks: [
-                { overlay: [{}, {}, {}], width: 10, height: 10 },
-                { overlay: [], width: 10, height: 10 }
+                { _overlay: [{}, {}, {}], width: 10, height: 10 },
+                { _overlay: [], width: 10, height: 10 }
             ]
         };
         const spec3 = {
             tracks: [
-                { overlay: [], width: 10, height: 10 },
-                { overlay: [], width: 10, height: 10, overlayOnPreviousTrack: true },
-                { overlay: [], width: 10, height: 10, overlayOnPreviousTrack: true },
-                { overlay: [], width: 10, height: 10 }
+                { _overlay: [], width: 10, height: 10 },
+                { _overlay: [], width: 10, height: 10, overlayOnPreviousTrack: true },
+                { _overlay: [], width: 10, height: 10, overlayOnPreviousTrack: true },
+                { _overlay: [], width: 10, height: 10 }
             ]
         };
         expect(getBoundingBox(getRelativeTrackInfo(spec1, getTheme()).trackInfos)).toEqual(
@@ -58,8 +58,8 @@ describe('Arrangement', () => {
     it('1 View, N Tracks', () => {
         const spec = {
             tracks: [
-                { overlay: [], width: 10, height: 10 },
-                { overlay: [], width: 10, height: 10 }
+                { _overlay: [], width: 10, height: 10 },
+                { _overlay: [], width: 10, height: 10 }
             ]
         };
         const info = getRelativeTrackInfo(spec, getTheme()).trackInfos;
@@ -80,14 +80,14 @@ describe('Arrangement', () => {
             views: [
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 },
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 }
             ]
@@ -110,14 +110,14 @@ describe('Arrangement', () => {
             views: [
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 },
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 }
             ]
@@ -140,14 +140,14 @@ describe('Arrangement', () => {
             views: [
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 },
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 }
             ]
@@ -157,14 +157,14 @@ describe('Arrangement', () => {
             views: [
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 },
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 }
             ]
@@ -178,14 +178,14 @@ describe('Arrangement', () => {
             views: [
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 },
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 }
             ]
@@ -195,14 +195,14 @@ describe('Arrangement', () => {
             views: [
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 },
                 {
                     tracks: [
-                        { overlay: [], width: 10, height: 10 },
-                        { overlay: [], width: 10, height: 10 }
+                        { _overlay: [], width: 10, height: 10 },
+                        { _overlay: [], width: 10, height: 10 }
                     ]
                 }
             ]
@@ -212,7 +212,7 @@ describe('Arrangement', () => {
 
     it('Complex Parallel Views in Linear Layout', () => {
         {
-            const t = { overlay: [], width: 10, height: 10 };
+            const t = { _overlay: [], width: 10, height: 10 };
             const spec: GoslingSpec = {
                 arrangement: 'parallel',
                 views: [
@@ -239,7 +239,7 @@ describe('Arrangement', () => {
 
     it('Complex Serial Views in Linear Layout', () => {
         {
-            const t = { overlay: [], width: 10, height: 10 };
+            const t = { _overlay: [], width: 10, height: 10 };
             const spec: GoslingSpec = {
                 arrangement: 'serial',
                 views: [
@@ -267,7 +267,7 @@ describe('Arrangement', () => {
     it('Remove Brush in Combined Circular Views', () => {
         {
             const t: Track = JSON.parse(
-                JSON.stringify({ overlay: [{ mark: 'brush', x: { linkingId: '_' } }], width: 10, height: 10 })
+                JSON.stringify({ _overlay: [{ mark: 'brush', x: { linkingId: '_' } }], width: 10, height: 10 })
             );
             const spec: GoslingSpec = {
                 layout: 'circular',
@@ -293,13 +293,13 @@ describe('Arrangement', () => {
             });
 
             expect(info[0].boundingBox).toEqual(info[1].boundingBox);
-            expect((info[0].track as any).overlay).toHaveLength(0); // brush should be removed
+            expect((info[0].track as any)._overlay).toHaveLength(0); // brush should be removed
         }
     });
 
     it('Complex Views in Linear Layout', () => {
         {
-            const t = { overlay: [], width: 10, height: 10 };
+            const t = { _overlay: [], width: 10, height: 10 };
             const spec1: GoslingSpec = {
                 arrangement: 'parallel',
                 views: [
@@ -317,7 +317,7 @@ describe('Arrangement', () => {
             expect(getRelativeTrackInfo(spec1, getTheme())).toEqual(getRelativeTrackInfo(spec2, getTheme()));
         }
         {
-            const t = { overlay: [], width: 10, height: 10 };
+            const t = { _overlay: [], width: 10, height: 10 };
             const spec1: GoslingSpec = {
                 arrangement: 'serial',
                 views: [
@@ -335,7 +335,7 @@ describe('Arrangement', () => {
             expect(getRelativeTrackInfo(spec1, getTheme())).toEqual(getRelativeTrackInfo(spec2, getTheme()));
         }
         {
-            const t = { overlay: [], width: 10, height: 10 };
+            const t = { _overlay: [], width: 10, height: 10 };
             const spec: GoslingSpec = {
                 arrangement: 'serial',
                 views: [
@@ -363,8 +363,8 @@ describe('Arrangement', () => {
 
     it('Uneven Size of Views', () => {
         {
-            const t = { overlay: [], width: 10, height: 10 };
-            const t_2w = { overlay: [], width: 20, height: 10 };
+            const t = { _overlay: [], width: 10, height: 10 };
+            const t_2w = { _overlay: [], width: 20, height: 10 };
             const spec: GoslingSpec = {
                 arrangement: 'serial',
                 views: [

--- a/src/compiler/bounding-box.ts
+++ b/src/compiler/bounding-box.ts
@@ -350,7 +350,7 @@ function traverseAndCollectTrackInfo(
             // !!! As circular tracks are not well supported now when parallelized or serialized, we do not support brush for now.
             if (ifMultipleViews) {
                 if (IsOverlaidTrack(t.track)) {
-                    t.track.overlay = t.track.overlay.filter(o => o.mark !== 'brush');
+                    t.track._overlay = t.track._overlay.filter(o => o.mark !== 'brush');
                 }
             }
         });

--- a/src/compiler/spec-preprocess.test.ts
+++ b/src/compiler/spec-preprocess.test.ts
@@ -25,7 +25,7 @@ describe('Fix Spec Downstream', () => {
         {
             const spec: GoslingSpec = {
                 style: { outline: 'red' },
-                views: [{ tracks: [{ overlay: [], width: 0, height: 0 }] }]
+                views: [{ tracks: [{ _overlay: [], width: 0, height: 0 }] }]
             };
             traverseToFixSpecDownstream(spec);
             expect((spec.views[0] as SingleView).style?.outline).toEqual('red');
@@ -34,7 +34,7 @@ describe('Fix Spec Downstream', () => {
         {
             const spec: GoslingSpec = {
                 style: { outline: 'red' },
-                views: [{ tracks: [{ overlay: [], width: 0, height: 0, style: { outline: 'green' } }] }]
+                views: [{ tracks: [{ _overlay: [], width: 0, height: 0, style: { outline: 'green' } }] }]
             };
             traverseToFixSpecDownstream(spec);
             expect((spec.views[0] as SingleView).style?.outline).toEqual('red');
@@ -47,7 +47,7 @@ describe('Fix Spec Downstream', () => {
             const spec: GoslingSpec = {
                 static: true,
                 arrangement: 'parallel',
-                views: [{ tracks: [{ overlay: [], width: 0, height: 0 }] }]
+                views: [{ tracks: [{ _overlay: [], width: 0, height: 0 }] }]
             };
             traverseToFixSpecDownstream(spec);
             expect(spec.views[0].static).toEqual(true);
@@ -57,7 +57,7 @@ describe('Fix Spec Downstream', () => {
             const spec: GoslingSpec = {
                 layout: 'circular',
                 arrangement: 'parallel',
-                views: [{ layout: 'linear', tracks: [{ overlay: [], width: 0, height: 0 }] }]
+                views: [{ layout: 'linear', tracks: [{ _overlay: [], width: 0, height: 0 }] }]
             };
             traverseToFixSpecDownstream(spec);
             expect(spec.views[0].static).toEqual(false);
@@ -70,7 +70,7 @@ describe('Fix Spec Downstream', () => {
             const spec: GoslingSpec = {
                 static: true,
                 arrangement: 'parallel',
-                views: [{ tracks: [{ overlay: [], mark: 'withinLink', width: 0, height: 0 }] }]
+                views: [{ tracks: [{ _overlay: [], mark: 'withinLink', width: 0, height: 0 }] }]
             };
             traverseToFixSpecDownstream(spec);
             expect((spec.views[0] as any).tracks[0].flipY).toBeUndefined(); // must not flip if there is only one track
@@ -82,8 +82,8 @@ describe('Fix Spec Downstream', () => {
                 views: [
                     {
                         tracks: [
-                            { overlay: [], width: 0, height: 0 },
-                            { overlay: [], mark: 'withinLink', width: 0, height: 0 }
+                            { _overlay: [], width: 0, height: 0 },
+                            { _overlay: [], mark: 'withinLink', width: 0, height: 0 }
                         ]
                     }
                 ]
@@ -99,8 +99,8 @@ describe('Fix Spec Downstream', () => {
                 views: [
                     {
                         tracks: [
-                            { overlay: [], width: 0, height: 0 },
-                            { overlay: [{ mark: 'withinLink' }], width: 0, height: 0 }
+                            { _overlay: [], width: 0, height: 0 },
+                            { _overlay: [{ mark: 'withinLink' }], width: 0, height: 0 }
                         ]
                     }
                 ]
@@ -108,7 +108,7 @@ describe('Fix Spec Downstream', () => {
             traverseToFixSpecDownstream(spec);
             expect((spec.views[0] as any).tracks[0].flipY).toBeUndefined();
             expect((spec.views[0] as any).tracks[1].flipY).toBeUndefined();
-            expect((spec.views[0] as any).tracks[1].overlay[0].flipY).toEqual(true);
+            expect((spec.views[0] as any).tracks[1]._overlay[0].flipY).toEqual(true);
         }
         {
             const spec: GoslingSpec = {
@@ -117,29 +117,8 @@ describe('Fix Spec Downstream', () => {
                 views: [
                     {
                         tracks: [
-                            { overlay: [{ mark: 'withinLink' }], width: 0, height: 0 },
-                            { overlay: [{ mark: 'withinLink' }], width: 0, height: 0, overlayOnPreviousTrack: true }
-                        ]
-                    }
-                ]
-            };
-            traverseToFixSpecDownstream(spec);
-            expect((spec.views[0] as any).tracks[0].flipY).toBeUndefined();
-            expect((spec.views[0] as any).tracks[1].flipY).toBeUndefined();
-            // only one track, so no flip on both
-            expect((spec.views[0] as any).tracks[0].overlay[0].flipY).toBeUndefined();
-            expect((spec.views[0] as any).tracks[1].overlay[0].flipY).toBeUndefined();
-        }
-        {
-            const spec: GoslingSpec = {
-                static: true,
-                arrangement: 'parallel',
-                views: [
-                    {
-                        tracks: [
-                            { overlay: [], width: 0, height: 0 },
-                            { overlay: [{ mark: 'withinLink' }], width: 0, height: 0 },
-                            { overlay: [{ mark: 'withinLink' }], width: 0, height: 0, overlayOnPreviousTrack: true }
+                            { _overlay: [{ mark: 'withinLink' }], width: 0, height: 0 },
+                            { _overlay: [{ mark: 'withinLink' }], width: 0, height: 0, overlayOnPreviousTrack: true }
                         ]
                     }
                 ]
@@ -148,9 +127,8 @@ describe('Fix Spec Downstream', () => {
             expect((spec.views[0] as any).tracks[0].flipY).toBeUndefined();
             expect((spec.views[0] as any).tracks[1].flipY).toBeUndefined();
             // only one track, so no flip on both
-            expect((spec.views[0] as any).tracks[0].flipY).toBeUndefined();
-            expect((spec.views[0] as any).tracks[1].overlay[0].flipY).toBe(true);
-            expect((spec.views[0] as any).tracks[2].overlay[0].flipY).toBe(true);
+            expect((spec.views[0] as any).tracks[0]._overlay[0].flipY).toBeUndefined();
+            expect((spec.views[0] as any).tracks[1]._overlay[0].flipY).toBeUndefined();
         }
         {
             const spec: GoslingSpec = {
@@ -159,9 +137,9 @@ describe('Fix Spec Downstream', () => {
                 views: [
                     {
                         tracks: [
-                            { overlay: [], width: 0, height: 0 },
-                            { overlay: [{ mark: 'withinLink' }], width: 0, height: 0, overlayOnPreviousTrack: true },
-                            { overlay: [{ mark: 'withinLink' }], width: 0, height: 0, overlayOnPreviousTrack: true }
+                            { _overlay: [], width: 0, height: 0 },
+                            { _overlay: [{ mark: 'withinLink' }], width: 0, height: 0 },
+                            { _overlay: [{ mark: 'withinLink' }], width: 0, height: 0, overlayOnPreviousTrack: true }
                         ]
                     }
                 ]
@@ -171,8 +149,30 @@ describe('Fix Spec Downstream', () => {
             expect((spec.views[0] as any).tracks[1].flipY).toBeUndefined();
             // only one track, so no flip on both
             expect((spec.views[0] as any).tracks[0].flipY).toBeUndefined();
-            expect((spec.views[0] as any).tracks[1].overlay[0].flipY).toBeUndefined();
-            expect((spec.views[0] as any).tracks[2].overlay[0].flipY).toBeUndefined();
+            expect((spec.views[0] as any).tracks[1]._overlay[0].flipY).toBe(true);
+            expect((spec.views[0] as any).tracks[2]._overlay[0].flipY).toBe(true);
+        }
+        {
+            const spec: GoslingSpec = {
+                static: true,
+                arrangement: 'parallel',
+                views: [
+                    {
+                        tracks: [
+                            { _overlay: [], width: 0, height: 0 },
+                            { _overlay: [{ mark: 'withinLink' }], width: 0, height: 0, overlayOnPreviousTrack: true },
+                            { _overlay: [{ mark: 'withinLink' }], width: 0, height: 0, overlayOnPreviousTrack: true }
+                        ]
+                    }
+                ]
+            };
+            traverseToFixSpecDownstream(spec);
+            expect((spec.views[0] as any).tracks[0].flipY).toBeUndefined();
+            expect((spec.views[0] as any).tracks[1].flipY).toBeUndefined();
+            // only one track, so no flip on both
+            expect((spec.views[0] as any).tracks[0].flipY).toBeUndefined();
+            expect((spec.views[0] as any).tracks[1]._overlay[0].flipY).toBeUndefined();
+            expect((spec.views[0] as any).tracks[2]._overlay[0].flipY).toBeUndefined();
         }
     });
 
@@ -181,7 +181,7 @@ describe('Fix Spec Downstream', () => {
             const spec: GoslingSpec = {
                 static: true,
                 arrangement: 'serial',
-                views: [{ views: [{ tracks: [{ overlay: [], width: 0, height: 0 }] }] }]
+                views: [{ views: [{ tracks: [{ _overlay: [], width: 0, height: 0 }] }] }]
             };
             traverseToFixSpecDownstream(spec);
             expect((spec.views[0] as any).arrangement).toEqual('serial');
@@ -189,7 +189,7 @@ describe('Fix Spec Downstream', () => {
         {
             const spec: GoslingSpec = {
                 static: true,
-                views: [{ views: [{ tracks: [{ overlay: [], width: 0, height: 0 }] }] }]
+                views: [{ views: [{ tracks: [{ _overlay: [], width: 0, height: 0 }] }] }]
             };
             traverseToFixSpecDownstream(spec);
             expect(spec.arrangement).toEqual('vertical'); // default one
@@ -205,7 +205,7 @@ describe('Fix Spec Downstream', () => {
                 views: [
                     {
                         arrangement: 'serial',
-                        views: [{ tracks: [{ overlay: [], width: 0, height: 0 }] }]
+                        views: [{ tracks: [{ _overlay: [], width: 0, height: 0 }] }]
                     }
                 ]
             };
@@ -220,7 +220,7 @@ describe('Fix Spec Downstream', () => {
             arrangement: 'parallel',
             views: [
                 {
-                    tracks: [{ layout: 'circular', overlay: [], width: 0, height: 0 }]
+                    tracks: [{ layout: 'circular', _overlay: [], width: 0, height: 0 }]
                 }
             ]
         };
@@ -323,8 +323,8 @@ describe('Spec Preprocess', () => {
             expect(flat).toHaveLength(2);
             expect(flat[0].title).toEqual('A');
             expect(flat[1].title).toEqual('B');
-            expect('overlay' in flat[1]).toEqual(true);
-            expect('overlay' in flat[1] && flat[1].overlay.length === 1).toEqual(true);
+            expect('_overlay' in flat[1]).toEqual(true);
+            expect('_overlay' in flat[1] && flat[1]._overlay.length === 1).toEqual(true);
         }
         {
             const flat2 = convertToFlatTracks({

--- a/src/compiler/spec-preprocess.ts
+++ b/src/compiler/spec-preprocess.ts
@@ -111,7 +111,7 @@ export function convertToFlatTracks(spec: SingleView): Track[] {
                     // This is OverlaidTracks
                     newTracks.push({
                         ...track,
-                        overlay: [...track.tracks],
+                        _overlay: [...track.tracks],
                         tracks: undefined,
                         alignment: undefined
                     } as Track);
@@ -125,7 +125,7 @@ export function convertToFlatTracks(spec: SingleView): Track[] {
     } else {
         newTracks.push({
             ...spec,
-            overlay: [...spec.tracks.filter(track => !track._invalidTrack)],
+            _overlay: [...spec.tracks.filter(track => !track._invalidTrack)],
             tracks: undefined,
             alignment: undefined
         } as Track);
@@ -263,10 +263,10 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
             track.style = getStyleOverridden(spec.style, track.style);
             if (IsOverlaidTrack(track)) {
                 // Remove the dummy tracks from an overlay track
-                track.overlay = track.overlay.filter(overlayTrack => {
+                track._overlay = track._overlay.filter(overlayTrack => {
                     return !('type' in overlayTrack && overlayTrack.type == 'dummy-track');
                 });
-                track.overlay.forEach(o => {
+                track._overlay.forEach(o => {
                     o.style = getStyleOverridden(track.style, o.style);
                 });
             }
@@ -291,7 +291,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
                 if ((IsSingleTrack(track) || IsOverlaidTrack(track)) && IsChannelDeep(track.y) && !track.y.domain) {
                     track.y.domain = spec.yDomain;
                 } else if (IsOverlaidTrack(track)) {
-                    track.overlay.forEach(o => {
+                    track._overlay.forEach(o => {
                         if (IsChannelDeep(o.y) && !o.y.domain) {
                             o.y.domain = spec.yDomain;
                         }
@@ -305,7 +305,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
             if ((IsSingleTrack(track) || IsOverlaidTrack(track)) && IsChannelDeep(track.x) && !track.x.domain) {
                 track.x.domain = spec.xDomain;
             } else if (IsOverlaidTrack(track)) {
-                track.overlay.forEach(o => {
+                track._overlay.forEach(o => {
                     if (IsChannelDeep(o.x) && !o.x.domain) {
                         o.x.domain = spec.xDomain;
                     }
@@ -319,7 +319,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
                 track.x.linkingId = spec.linkingId ?? linkID;
             } else if (IsOverlaidTrack(track)) {
                 let isAdded = false;
-                track.overlay.forEach(o => {
+                track._overlay.forEach(o => {
                     if (isAdded) return; // We want to add only once
 
                     if (IsChannelDeep(o.x) && !o.x.linkingId) {
@@ -353,7 +353,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
                     }
                 } else if (IsOverlaidTrack(track)) {
                     // let isNone = false; // If there is at least one 'none' axis, should not render axis.
-                    track.overlay.forEach(o => {
+                    track._overlay.forEach(o => {
                         if (IsChannelDeep(o.x) && !o.x.axis) {
                             if (track.orientation === 'vertical') {
                                 o.x.axis = 'left';
@@ -392,7 +392,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
                 }
             } else if (IsOverlaidTrack(track)) {
                 // let isNone = false; // If there is at least one 'none' axis, should not render axis.
-                track.overlay.forEach(o => {
+                track._overlay.forEach(o => {
                     if (IsChannelDeep(o.x) && o.x.axis && o.x.axis !== 'none') {
                         if (track.orientation === 'vertical') {
                             if (o.x.axis === 'top') {
@@ -433,7 +433,7 @@ export function traverseToFixSpecDownstream(spec: GoslingSpec | SingleView, pare
                     if (track.mark === 'withinLink' && track.flipY === undefined) {
                         track.flipY = true;
                     }
-                    track.overlay.forEach(o => {
+                    track._overlay.forEach(o => {
                         if (o.mark === 'withinLink' && o.flipY === undefined) {
                             o.flipY = true;
                         }

--- a/src/core/utils/linking.test.ts
+++ b/src/core/utils/linking.test.ts
@@ -11,7 +11,7 @@ describe('Should get linking information correctly', () => {
             {
                 data: { type: 'csv', url: 'https://' },
                 id: 'track',
-                overlay: [
+                _overlay: [
                     {
                         mark: 'point',
                         x: { linkingId: 'regular' }

--- a/src/core/utils/overlay.test.ts
+++ b/src/core/utils/overlay.test.ts
@@ -15,7 +15,7 @@ describe('Should handle superposition options correctly', () => {
     });
     it('Should resolve `superpose` options when the array length is one', () => {
         const tracks = resolveSuperposedTracks({
-            overlay: [{ mark: 'line' }],
+            _overlay: [{ mark: 'line' }],
             width: 100,
             height: 100
         });
@@ -24,7 +24,7 @@ describe('Should handle superposition options correctly', () => {
     });
     it('Should resolve `superpose` options', () => {
         const tracks = resolveSuperposedTracks({
-            overlay: [{ mark: 'line' }, { mark: 'point' }],
+            _overlay: [{ mark: 'line' }, { mark: 'point' }],
             width: 100,
             height: 100
         });
@@ -34,7 +34,7 @@ describe('Should handle superposition options correctly', () => {
     });
     it('Should correct several options for consistency', () => {
         const tracks = resolveSuperposedTracks({
-            overlay: [{ x: { axis: 'top' } }, { x: { axis: 'bottom' } }],
+            _overlay: [{ x: { axis: 'top' } }, { x: { axis: 'bottom' } }],
             width: 100,
             height: 100
         });
@@ -46,7 +46,7 @@ describe('Should handle superposition options correctly', () => {
     it('Should delete title except the last one in overlaid tracks', () => {
         const tracks = resolveSuperposedTracks({
             title: 'title',
-            overlay: [{ x: { axis: 'top' } }, { x: { axis: 'bottom' } }],
+            _overlay: [{ x: { axis: 'top' } }, { x: { axis: 'bottom' } }],
             width: 100,
             height: 100
         });
@@ -62,22 +62,22 @@ describe('Spread Tracks By Data', () => {
         expect(spread).toHaveLength(1);
     });
     it('overlay: []', () => {
-        const spread = spreadTracksByData([{ overlay: [], width: 100, height: 100 }]);
+        const spread = spreadTracksByData([{ _overlay: [], width: 100, height: 100 }]);
         expect(spread).toHaveLength(1);
     });
     it('overlay: [{}]', () => {
-        const spread = spreadTracksByData([{ overlay: [{}], width: 100, height: 100 }]);
+        const spread = spreadTracksByData([{ _overlay: [{}], width: 100, height: 100 }]);
         expect(spread).toHaveLength(1);
     });
     it('overlay: [{ data }]', () => {
-        const base = { overlay: [{ data: { type: 'csv', url: '' } }] } as OverlaidTrack;
+        const base = { _overlay: [{ data: { type: 'csv', url: '' } }] } as OverlaidTrack;
         const spread = spreadTracksByData([base]);
         expect(spread).toHaveLength(1);
         expect(spread[0]).toEqual(base); // The length is zero, so no point to spread
     });
     it('overlay: [{}, { data }]', () => {
         const spread = spreadTracksByData([
-            { overlay: [{}, { data: { type: 'csv', url: '' } }], width: 100, height: 100 }
+            { _overlay: [{}, { data: { type: 'csv', url: '' } }], width: 100, height: 100 }
         ]);
         expect(spread).toHaveLength(1); // There is only one unique data/dataTransform specification, so should not spread.
         expect('data' in spread[0]).toBe(true); // Since there is not data spec in the parent, it should be borrowed from a child.
@@ -85,7 +85,7 @@ describe('Spread Tracks By Data', () => {
     it('overlay: [{}, { data }, { data }]', () => {
         const spread = spreadTracksByData([
             {
-                overlay: [
+                _overlay: [
                     {},
                     { data: { type: 'csv', url: '' } },
                     { data: { type: 'vector', url: '', column: 'c', value: 'p' } }
@@ -102,7 +102,7 @@ describe('Spread Tracks By Data', () => {
     it('overlay: [{ data1 }, { data2 }]', () => {
         const spread = spreadTracksByData([
             {
-                overlay: [
+                _overlay: [
                     { data: { type: 'csv', url: '' } },
                     { data: { type: 'vector', url: '', column: 'c', value: 'p' } }
                 ],
@@ -119,7 +119,7 @@ describe('Spread Tracks By Data', () => {
     it('Axis Position of overlay: [{ data1 }, { data2 }]', () => {
         const spread = spreadTracksByData([
             {
-                overlay: [
+                _overlay: [
                     { data: { type: 'csv', url: '' }, y: { field: 'y', type: 'quantitative' } },
                     {
                         data: { type: 'vector', url: '', column: 'c', value: 'p' },
@@ -144,7 +144,7 @@ describe('Spread Tracks By Data', () => {
         const spread = spreadTracksByData([
             {
                 title: 'title',
-                overlay: [{ data: { type: 'vector', url: '', column: 'c', value: 'p' } }],
+                _overlay: [{ data: { type: 'vector', url: '', column: 'c', value: 'p' } }],
                 width: 100,
                 height: 100
             }
@@ -156,7 +156,7 @@ describe('Spread Tracks By Data', () => {
         const spread = spreadTracksByData([
             {
                 title: 'title',
-                overlay: [
+                _overlay: [
                     { data: { type: 'vector', url: '', column: 'c', value: 'p' } },
                     { data: { type: 'vector', url: '', column: 'c', value: 'p' } }
                 ],
@@ -172,7 +172,7 @@ describe('Spread Tracks By Data', () => {
         const spread = spreadTracksByData([
             {
                 title: 'title',
-                overlay: [
+                _overlay: [
                     { data: { type: 'csv', url: '' } },
                     { data: { type: 'vector', url: '', column: 'c', value: 'p' } }
                 ],

--- a/src/gosling-schema/gosling.schema.guards.test.ts
+++ b/src/gosling-schema/gosling.schema.guards.test.ts
@@ -11,7 +11,7 @@ describe('Type Guard', () => {
                     chromosomeField: 'Chr.',
                     genomicFields: ['ISCN_start', 'ISCN_stop', 'Basepair_start', 'Basepair_stop']
                 },
-                overlay: [
+                _overlay: [
                     {
                         mark: 'rect',
                         dataTransform: [{ type: 'filter', field: 'Stain', oneOf: ['acen-1', 'acen-2'], not: true }],

--- a/src/gosling-schema/gosling.schema.guards.ts
+++ b/src/gosling-schema/gosling.schema.guards.ts
@@ -129,11 +129,11 @@ export function IsTrackStyle(track: Style | undefined): track is Style {
 }
 
 export function IsSingleTrack(track: Track): track is SingleTrack {
-    return !('overlay' in track);
+    return !('_overlay' in track);
 }
 
 export function IsOverlaidTrack(track: Partial<Track>): track is OverlaidTrack {
-    return 'overlay' in track;
+    return '_overlay' in track;
 }
 
 export function IsTemplateTrack(track: Partial<Track>): track is TemplateTrack {
@@ -298,7 +298,7 @@ export function IsXAxis(_: Track) {
         return true;
     } else if (IsOverlaidTrack(_)) {
         let isFound = false;
-        _.overlay.forEach(t => {
+        _._overlay.forEach(t => {
             if (isFound) return;
 
             if (IsChannelDeep(t.x) && t.x.axis && t.x.axis !== 'none') {
@@ -315,7 +315,7 @@ export function IsYAxis(_: Track) {
         return true;
     } else if (IsOverlaidTrack(_)) {
         let isFound = false;
-        _.overlay.forEach(t => {
+        _._overlay.forEach(t => {
             if (isFound) return;
 
             if (IsChannelDeep(t.y) && t.y.axis && t.y.axis !== 'none') {

--- a/src/gosling-schema/gosling.schema.json
+++ b/src/gosling-schema/gosling.schema.json
@@ -4033,113 +4033,7 @@
           "description": "internal",
           "type": "boolean"
         },
-        "_renderingId": {
-          "description": "internal",
-          "type": "string"
-        },
-        "assembly": {
-          "$ref": "#/definitions/Assembly",
-          "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
-        },
-        "baselineY": {
-          "type": "number"
-        },
-        "centerRadius": {
-          "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
-          "type": "number"
-        },
-        "color": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Color"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "data": {
-          "$ref": "#/definitions/DataDeep"
-        },
-        "dataTransform": {
-          "items": {
-            "$ref": "#/definitions/DataTransform"
-          },
-          "type": "array"
-        },
-        "displacement": {
-          "$ref": "#/definitions/Displacement"
-        },
-        "endAngle": {
-          "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
-          "type": "number"
-        },
-        "experimental": {
-          "additionalProperties": false,
-          "properties": {
-            "mouseEvents": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "$ref": "#/definitions/MouseEventsDeep"
-                }
-              ]
-            },
-            "performanceMode": {
-              "default": false,
-              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
-              "type": "boolean"
-            }
-          },
-          "type": "object"
-        },
-        "flipY": {
-          "type": "boolean"
-        },
-        "height": {
-          "description": "Specify the track height in pixels.",
-          "type": "number"
-        },
-        "id": {
-          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
-          "type": "string"
-        },
-        "innerRadius": {
-          "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
-          "type": "number"
-        },
-        "layout": {
-          "$ref": "#/definitions/Layout",
-          "description": "Specify the layout type of all tracks."
-        },
-        "linkingId": {
-          "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
-          "type": "string"
-        },
-        "mark": {
-          "$ref": "#/definitions/Mark"
-        },
-        "opacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Opacity"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "orientation": {
-          "$ref": "#/definitions/Orientation",
-          "description": "Specify the orientation."
-        },
-        "outerRadius": {
-          "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
-          "type": "number"
-        },
-        "overlay": {
+        "_overlay": {
           "items": {
             "additionalProperties": false,
             "properties": {
@@ -4472,6 +4366,112 @@
           },
           "type": "array"
         },
+        "_renderingId": {
+          "description": "internal",
+          "type": "string"
+        },
+        "assembly": {
+          "$ref": "#/definitions/Assembly",
+          "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+        },
+        "baselineY": {
+          "type": "number"
+        },
+        "centerRadius": {
+          "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+          "type": "number"
+        },
+        "color": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Color"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "data": {
+          "$ref": "#/definitions/DataDeep"
+        },
+        "dataTransform": {
+          "items": {
+            "$ref": "#/definitions/DataTransform"
+          },
+          "type": "array"
+        },
+        "displacement": {
+          "$ref": "#/definitions/Displacement"
+        },
+        "endAngle": {
+          "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+          "type": "number"
+        },
+        "experimental": {
+          "additionalProperties": false,
+          "properties": {
+            "mouseEvents": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "flipY": {
+          "type": "boolean"
+        },
+        "height": {
+          "description": "Specify the track height in pixels.",
+          "type": "number"
+        },
+        "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
+          "type": "string"
+        },
+        "innerRadius": {
+          "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
+          "type": "number"
+        },
+        "layout": {
+          "$ref": "#/definitions/Layout",
+          "description": "Specify the layout type of all tracks."
+        },
+        "linkingId": {
+          "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+          "type": "string"
+        },
+        "mark": {
+          "$ref": "#/definitions/Mark"
+        },
+        "opacity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Opacity"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "orientation": {
+          "$ref": "#/definitions/Orientation",
+          "description": "Specify the orientation."
+        },
+        "outerRadius": {
+          "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
+          "type": "number"
+        },
         "overlayOnPreviousTrack": {
           "type": "boolean"
         },
@@ -4700,7 +4700,7 @@
         }
       },
       "required": [
-        "overlay"
+        "_overlay"
       ],
       "type": "object"
     },
@@ -5081,139 +5081,7 @@
           "description": "internal",
           "type": "boolean"
         },
-        "_renderingId": {
-          "description": "internal",
-          "type": "string"
-        },
-        "assembly": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Assembly",
-              "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
-            },
-            {
-              "const": "unknown",
-              "description": "No assemblies can be associated with a dummy track",
-              "type": "string"
-            }
-          ],
-          "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
-        },
-        "baselineY": {
-          "type": "number"
-        },
-        "centerRadius": {
-          "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
-          "type": "number"
-        },
-        "color": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Color"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "data": {
-          "$ref": "#/definitions/DataDeep"
-        },
-        "dataTransform": {
-          "items": {
-            "$ref": "#/definitions/DataTransform"
-          },
-          "type": "array"
-        },
-        "displacement": {
-          "$ref": "#/definitions/Displacement"
-        },
-        "encoding": {
-          "additionalProperties": {
-            "$ref": "#/definitions/Channel"
-          },
-          "type": "object"
-        },
-        "endAngle": {
-          "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
-          "type": "number"
-        },
-        "experimental": {
-          "additionalProperties": false,
-          "properties": {
-            "mouseEvents": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "$ref": "#/definitions/MouseEventsDeep"
-                }
-              ]
-            },
-            "performanceMode": {
-              "default": false,
-              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
-              "type": "boolean"
-            }
-          },
-          "type": "object"
-        },
-        "flipY": {
-          "type": "boolean"
-        },
-        "height": {
-          "description": "Specify the track height in pixels.",
-          "type": "number"
-        },
-        "id": {
-          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
-          "type": "string"
-        },
-        "innerRadius": {
-          "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
-          "type": "number"
-        },
-        "layout": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Layout",
-              "description": "Specify the layout type of all tracks."
-            },
-            {
-              "const": "linear",
-              "description": "Only linear layout are supported at this time",
-              "type": "string"
-            }
-          ],
-          "description": "Specify the layout type of all tracks."
-        },
-        "linkingId": {
-          "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
-          "type": "string"
-        },
-        "mark": {
-          "$ref": "#/definitions/Mark"
-        },
-        "opacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Opacity"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "orientation": {
-          "$ref": "#/definitions/Orientation",
-          "description": "Specify the orientation."
-        },
-        "outerRadius": {
-          "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
-          "type": "number"
-        },
-        "overlay": {
+        "_overlay": {
           "items": {
             "additionalProperties": false,
             "properties": {
@@ -5545,6 +5413,138 @@
             "type": "object"
           },
           "type": "array"
+        },
+        "_renderingId": {
+          "description": "internal",
+          "type": "string"
+        },
+        "assembly": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Assembly",
+              "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+            },
+            {
+              "const": "unknown",
+              "description": "No assemblies can be associated with a dummy track",
+              "type": "string"
+            }
+          ],
+          "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+        },
+        "baselineY": {
+          "type": "number"
+        },
+        "centerRadius": {
+          "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+          "type": "number"
+        },
+        "color": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Color"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "data": {
+          "$ref": "#/definitions/DataDeep"
+        },
+        "dataTransform": {
+          "items": {
+            "$ref": "#/definitions/DataTransform"
+          },
+          "type": "array"
+        },
+        "displacement": {
+          "$ref": "#/definitions/Displacement"
+        },
+        "encoding": {
+          "additionalProperties": {
+            "$ref": "#/definitions/Channel"
+          },
+          "type": "object"
+        },
+        "endAngle": {
+          "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+          "type": "number"
+        },
+        "experimental": {
+          "additionalProperties": false,
+          "properties": {
+            "mouseEvents": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "flipY": {
+          "type": "boolean"
+        },
+        "height": {
+          "description": "Specify the track height in pixels.",
+          "type": "number"
+        },
+        "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
+          "type": "string"
+        },
+        "innerRadius": {
+          "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
+          "type": "number"
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Layout",
+              "description": "Specify the layout type of all tracks."
+            },
+            {
+              "const": "linear",
+              "description": "Only linear layout are supported at this time",
+              "type": "string"
+            }
+          ],
+          "description": "Specify the layout type of all tracks."
+        },
+        "linkingId": {
+          "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+          "type": "string"
+        },
+        "mark": {
+          "$ref": "#/definitions/Mark"
+        },
+        "opacity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Opacity"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "orientation": {
+          "$ref": "#/definitions/Orientation",
+          "description": "Specify the orientation."
+        },
+        "outerRadius": {
+          "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
+          "type": "number"
         },
         "overlayOnPreviousTrack": {
           "type": "boolean"

--- a/src/gosling-schema/gosling.schema.ts
+++ b/src/gosling-schema/gosling.schema.ts
@@ -492,7 +492,7 @@ export type DisplacementType = 'pile' | 'spread';
  */
 export type OverlaidTrack = Partial<SingleTrack> & {
     // This is a property internally used when compiling
-    overlay: Partial<Omit<SingleTrack, 'height' | 'width' | 'layout' | 'title' | 'subtitle'>>[];
+    _overlay: Partial<Omit<SingleTrack, 'height' | 'width' | 'layout' | 'title' | 'subtitle'>>[];
 };
 
 /**

--- a/src/tracks/gosling-track/gosling-track.ts
+++ b/src/tracks/gosling-track/gosling-track.ts
@@ -188,8 +188,8 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             this.#assembly = this.options.spec.assembly;
 
             // Add unique IDs to each of the overlaid tracks that will be rendered independently.
-            if ('overlay' in this.options.spec) {
-                this.options.spec.overlay = (this.options.spec as OverlaidTrack).overlay.map(o => {
+            if ('_overlay' in this.options.spec) {
+                this.options.spec._overlay = (this.options.spec as OverlaidTrack)._overlay.map(o => {
                     return { ...o, _renderingId: uuid.v1() };
                 });
             } else {


### PR DESCRIPTION
I noticed that the `overlay` property of `Overlaid` is only meant to be used internally but didn't have an underscore prefix. 

## Change List
 - Turn all references of `overlay` to `_overlay` 

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
