### PR TITLE
chore(core): use latest codecov in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
                   NODE_OPTIONS: '--max_old_space_size=4096'
             - uses: codecov/codecov-action@v3
               with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
                   fail_ci_if_error: true
 
     Lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
                 yarn coverage
               env:
                   NODE_OPTIONS: '--max_old_space_size=4096'
-            - uses: codecov/codecov-action@v1
+            - uses: codecov/codecov-action@v3
               with:
                   fail_ci_if_error: true
 


### PR DESCRIPTION
Fix #
Toward #

## Change List
 - Ues v3 codecov-actions

This might address the issue with occasional Codecov error with [unfound token issues](https://github.com/codecov/codecov-action/issues/557)

```
{'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
404
==> Uploading to Codecov
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 10 47.2M  100   171   10 5151k    478  14.0M  0:00:03 --:--:--  0:00:03 14.1M
    {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
Error: Codecov failed with the following error: The process '/usr/bin/bash' failed with exit code 1
```

cc @thomcsmits 

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
