### PR TITLE
fix(core): rename from .es.js to .js

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
         "url": "https://github.com/gosling-lang/gosling.js"
     },
     "homepage": "https://gosling-lang.github.io/gosling.js/",
-    "main": "dist/gosling.es.js",
-    "module": "dist/gosling.es.js",
+    "main": "dist/gosling.js",
+    "module": "dist/gosling.js",
     "types": "dist/src/index.d.ts",
     "files": [
         "dist"
@@ -18,7 +18,7 @@
     "exports": {
         ".": {
             "types": "./dist/src/index.d.ts",
-            "import": "./dist/gosling.es.js"
+            "import": "./dist/gosling.js"
         }
     },
     "scripts": {


### PR DESCRIPTION
I upgraded vite and didn't realize that it also changes the extensions of the dist files. Just updated to reflect this. 

## Change List
 - renames exports in package.json 

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
