### PR TITLE
ci: Just install gos in GitHub Action

### DIFF
--- a/.github/workflows/update-gos.yml
+++ b/.github/workflows/update-gos.yml
@@ -42,8 +42,7 @@ jobs:
         with:
           python-version: "3.x"
       - run: |
-          python -m pip install --upgrade hatch
-          hatch shell
+          python -m pip install .
           python tools/generate_schema_wrapper.py ${{ steps.tag.outputs.tag_name }}
 
       - name: Create Pull Request


### PR DESCRIPTION
pip install for the Gos release was hanging and installed a bunch of unnecessary deps. This cleans that up.