### PR TITLE
feat(core): export several util functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
         ".": {
             "types": "./dist/src/index.d.ts",
             "import": "./dist/gosling.js"
+        },
+        "./utils": {
+            "types": "./dist/src/exported-utils.d.ts",
+            "import": "./dist/utils.js"
         }
     },
     "scripts": {

--- a/src/exported-utils.ts
+++ b/src/exported-utils.ts
@@ -1,0 +1,8 @@
+export {
+    getRelativeGenomicPosition,
+    computeChromSizes,
+    getChromInterval,
+    getChromTotalSize,
+    parseGenomicPosition
+} from './core/utils/assembly';
+export { sanitizeChrName } from './data-fetchers/utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,21 @@ export { validateGoslingSpec } from '@gosling-lang/gosling-schema';
 export { GoslingComponent } from './core/gosling-component';
 export type { GoslingRef } from './core/gosling-component';
 export { embed } from './core/gosling-embed';
+
+import { 
+    getRelativeGenomicPosition,
+    computeChromSizes,
+    getChromInterval,
+    getChromTotalSize,
+    parseGenomicPosition,
+} from './core/utils/assembly';
+import { sanitizeChrName } from './data-fetchers/utils';
+const utils = {
+    getRelativeGenomicPosition,
+    computeChromSizes,
+    getChromInterval,
+    getChromTotalSize,
+    parseGenomicPosition,
+    sanitizeChrName
+};
+export { utils };

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,21 +13,3 @@ export { validateGoslingSpec } from '@gosling-lang/gosling-schema';
 export { GoslingComponent } from './core/gosling-component';
 export type { GoslingRef } from './core/gosling-component';
 export { embed } from './core/gosling-embed';
-
-import {
-    getRelativeGenomicPosition,
-    computeChromSizes,
-    getChromInterval,
-    getChromTotalSize,
-    parseGenomicPosition
-} from './core/utils/assembly';
-import { sanitizeChrName } from './data-fetchers/utils';
-const utils = {
-    getRelativeGenomicPosition,
-    computeChromSizes,
-    getChromInterval,
-    getChromTotalSize,
-    parseGenomicPosition,
-    sanitizeChrName
-};
-export { utils };

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,12 @@ export { GoslingComponent } from './core/gosling-component';
 export type { GoslingRef } from './core/gosling-component';
 export { embed } from './core/gosling-embed';
 
-import { 
+import {
     getRelativeGenomicPosition,
     computeChromSizes,
     getChromInterval,
     getChromTotalSize,
-    parseGenomicPosition,
+    parseGenomicPosition
 } from './core/utils/assembly';
 import { sanitizeChrName } from './data-fetchers/utils';
 const utils = {

--- a/vite.config.js
+++ b/vite.config.js
@@ -90,9 +90,11 @@ const esm = defineConfig({
         target: 'es2018',
         sourcemap: true,
         lib: {
-            entry: path.resolve(__dirname, 'src/index.ts'),
+            entry: {
+                gosling: path.resolve(__dirname, 'src/index.ts'),
+                utils: path.resolve(__dirname, 'src/exported-utils.ts'),
+            },
             formats: ['es'],
-            fileName: 'gosling'
         },
         rollupOptions: { external }
     },


### PR DESCRIPTION
Fix #983

## Change List
 - Added several util functions for calculating chromosome positions. This is the first time exposing util functions, and the user API could be changed after discussing with the team.


> ~~import { utils } from 'gosling.js';~~
> ~~console.log(utils);~~
> ~~// print~~
> ~~{~~
>    ~~getRelativeGenomicPosition,~~
>    ~~computeChromSizes,~~
>    ~~getChromInterval,~~
>    ~~getChromTotalSize,~~
>    ~~parseGenomicPosition,~~
>    ~~sanitizeChrName~~
>~~}~~

```ts
import { getRelativeGenomicPosition } from 'gosling.js/utils';
```

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
