### PR TITLE
feat: Create separate entrypoint for gosling.js/utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,15 +19,20 @@
         ".": {
             "types": "./dist/src/index.d.ts",
             "import": "./dist/gosling.js"
+        },
+        "./utils": {
+            "types": "./dist/src/exported-utils.d.ts",
+            "import": "./dist/exported-utils.js"
         }
     },
     "scripts": {
         "start": "vite --mode editor",
         "start-embed": "vite",
         "build": "run-s build-clear build-types build-lib",
-        "build-lib": "vite build --mode lib",
+        "build-lib": "vite build --mode lib && npm run build-utils",
         "build-types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build-editor": "node --max_old_space_size=8192 ./node_modules/vite/bin/vite.js build",
+        "build-utils": "esbuild --bundle --format=esm --outfile=dist/exported-utils.js ./src/exported-utils.ts",
         "build-clear": "rm -rf ./dist",
         "preview": "vite preview",
         "check": "tsc --noEmit",

--- a/src/core/utils/assembly.ts
+++ b/src/core/utils/assembly.ts
@@ -1,151 +1,16 @@
-import type { Assembly, ChromSizes, GenomicPosition } from '@gosling-lang/gosling-schema';
-import {
-    CHROM_SIZE_HG16,
-    CHROM_SIZE_HG17,
-    CHROM_SIZE_HG18,
-    CHROM_SIZE_HG19,
-    CHROM_SIZE_HG38,
-    CHROM_SIZE_MM10,
-    CHROM_SIZE_MM9
-} from './chrom-size';
+import type { Assembly } from '@gosling-lang/gosling-schema';
 
-export interface ChromSize {
-    size: { [chr: string]: number };
-    interval: { [chr: string]: [number, number] };
-    total: number;
-    path: string;
-}
+// re-export public assembly-specific utilities
+export type { ChromSize } from './exported-utils';
+export {
+    getRelativeGenomicPosition,
+    computeChromSizes,
+    getChromInterval,
+    getChromTotalSize,
+    parseGenomicPosition
+} from './exported-utils';
 
-/**
- * Get relative chromosome position (e.g., `100` => `{ chromosome: 'chr1', position: 100 }`)
- * @param absPos number which is the absolute chromosome position
- * @param assembly the assembly used to calculate which chromosome position
- * @param returnWithinAssembly If true, then if the absolute position is before the first chromosome, it returns the
- * first position of the first chromosome. If the absolute position is after the last chromosome, it returns the last
- * position of the last chromosome
- * @returns the genomic position of the absPos
- */
-export function getRelativeGenomicPosition(
-    absPos: number,
-    assembly?: Assembly,
-    returnWithinAssembly = false
-): GenomicPosition {
-    const chrSizes = Object.entries(computeChromSizes(assembly).interval);
-    const minPosChr = { chromosome: 'unknown', position: Infinity } as GenomicPosition;
-    const maxPosChr = { chromosome: 'unknown', position: 0 } as GenomicPosition;
-    for (const chrSize of chrSizes) {
-        const [chromosome, absInterval] = chrSize;
-        const [start, end] = absInterval;
-        // absPos was found within this chromosome
-        if (start <= absPos && absPos < end) {
-            return { chromosome, position: absPos - start } as GenomicPosition;
-        }
-        // Update the min and max chromosomes found
-        if (start < minPosChr.position) {
-            minPosChr.chromosome = chromosome;
-            minPosChr.position = start;
-        }
-        if (end > maxPosChr.position) {
-            maxPosChr.chromosome = chromosome;
-            maxPosChr.position = end;
-        }
-    }
-    if (returnWithinAssembly) {
-        // Return either the min or max chromosome position
-        if (absPos < minPosChr.position) {
-            return minPosChr;
-        } else {
-            return maxPosChr;
-        }
-    } else {
-        return { chromosome: 'unknown', position: absPos };
-    }
-}
-
-/**
- * Generate a URL for custom chrom sizes
- * @param chromSizes A custom assembly that specifies chromosomes and their sizes
- */
-function createChromSizesUrl(chromSizes: ChromSizes): string {
-    const text = chromSizes.map(d => d.join('\t')).join('\n');
-    const tsv = new Blob([text], { type: 'text/tsv' });
-    return URL.createObjectURL(tsv);
-}
-
-/**
- * Get chromosome sizes.
- * @param assembly (default: 'hg38')
- */
-export function computeChromSizes(assembly?: Assembly): ChromSize {
-    if (assembly && typeof assembly === 'string' && assembly in CRHOM_SIZES) {
-        return CRHOM_SIZES[assembly];
-    } else if (Array.isArray(assembly) && assembly.length !== 0) {
-        // custom assembly
-        const size = Object.fromEntries(assembly);
-        return {
-            size,
-            interval: getChromInterval(size),
-            total: getChromTotalSize(size),
-            path: createChromSizesUrl(assembly)
-        };
-    } else {
-        // We do not have that assembly prepared, so return a default one.
-        return CRHOM_SIZES.hg38;
-    }
-}
-
-const basePath = (assembly: string) => `https://s3.amazonaws.com/gosling-lang.org/data/${assembly}.chrom.sizes`;
-const CRHOM_SIZES: { [assembly: string]: ChromSize } = Object.freeze({
-    hg38: {
-        size: CHROM_SIZE_HG38,
-        interval: getChromInterval(CHROM_SIZE_HG38),
-        total: getChromTotalSize(CHROM_SIZE_HG38),
-        path: basePath('hg38')
-    },
-    hg19: {
-        size: CHROM_SIZE_HG19,
-        interval: getChromInterval(CHROM_SIZE_HG19),
-        total: getChromTotalSize(CHROM_SIZE_HG19),
-        path: basePath('hg19')
-    },
-    hg18: {
-        size: CHROM_SIZE_HG18,
-        interval: getChromInterval(CHROM_SIZE_HG18),
-        total: getChromTotalSize(CHROM_SIZE_HG18),
-        path: basePath('hg18')
-    },
-    hg17: {
-        size: CHROM_SIZE_HG17,
-        interval: getChromInterval(CHROM_SIZE_HG17),
-        total: getChromTotalSize(CHROM_SIZE_HG17),
-        path: basePath('hg17')
-    },
-    hg16: {
-        size: CHROM_SIZE_HG16,
-        interval: getChromInterval(CHROM_SIZE_HG16),
-        total: getChromTotalSize(CHROM_SIZE_HG16),
-        path: basePath('hg16')
-    },
-    mm10: {
-        size: CHROM_SIZE_MM10,
-        interval: getChromInterval(CHROM_SIZE_MM10),
-        total: getChromTotalSize(CHROM_SIZE_MM10),
-        path: basePath('mm10')
-    },
-    mm9: {
-        size: CHROM_SIZE_MM9,
-        interval: getChromInterval(CHROM_SIZE_MM9),
-        total: getChromTotalSize(CHROM_SIZE_MM9),
-        path: basePath('mm9')
-    },
-    // `unknown` assembly contains only one chromosome with max length
-    unknown: {
-        size: { chr: Number.MAX_VALUE },
-        interval: { chr: [0, Number.MAX_VALUE] },
-        total: Number.MAX_VALUE,
-        path: basePath('hg38') // just to ensure this does not make crash
-    }
-});
+import { parseGenomicPosition, computeChromSizes } from './exported-utils';
 
 /**
  * Some presets of auto-complete IDs (`autocompleteId`) to search for genes using the HiGlass server.
@@ -162,39 +27,6 @@ export function getAutoCompleteId(assembly?: Assembly) {
         default:
             return 'P0PLbQMwTYGy-5uPIQid7A';
     }
-}
-
-/**
- * Calculate cumulative interval of each chromosome.
- */
-export function getChromInterval(chromSize: { [k: string]: number }) {
-    const interval: { [k: string]: [number, number] } = {};
-
-    Object.keys(chromSize).reduce((sum, k) => {
-        interval[k] = [sum, sum + chromSize[k]];
-        return sum + chromSize[k];
-    }, 0);
-
-    return interval;
-}
-
-/**
- * Calculate total size of entire chromosomes.
- */
-export function getChromTotalSize(chromSize: { [k: string]: number }) {
-    return Object.values(chromSize).reduce((sum, current) => sum + current, 0);
-}
-
-export function parseGenomicPosition(position: string): { chromosome: string; start?: number; end?: number } {
-    const [chromosome, intervalString] = position.split(':');
-    if (intervalString) {
-        const [start, end] = intervalString.split('-').map(s => +s.replace(/,/g, ''));
-        // only return if both are valid
-        if (!Number.isNaN(start) && !Number.isNaN(end)) {
-            return { chromosome, start, end };
-        }
-    }
-    return { chromosome };
 }
 
 /**

--- a/src/core/utils/exported-utils.ts
+++ b/src/core/utils/exported-utils.ts
@@ -1,0 +1,182 @@
+import type { Assembly, ChromSizes, GenomicPosition } from '@gosling-lang/gosling-schema';
+
+import {
+    CHROM_SIZE_HG16,
+    CHROM_SIZE_HG17,
+    CHROM_SIZE_HG18,
+    CHROM_SIZE_HG19,
+    CHROM_SIZE_HG38,
+    CHROM_SIZE_MM10,
+    CHROM_SIZE_MM9
+} from './chrom-size';
+
+export interface ChromSize {
+    size: { [chr: string]: number };
+    interval: { [chr: string]: [number, number] };
+    total: number;
+    path: string;
+}
+
+/**
+ * Get relative chromosome position (e.g., `100` => `{ chromosome: 'chr1', position: 100 }`)
+ * @param absPos number which is the absolute chromosome position
+ * @param assembly the assembly used to calculate which chromosome position
+ * @param returnWithinAssembly If true, then if the absolute position is before the first chromosome, it returns the
+ * first position of the first chromosome. If the absolute position is after the last chromosome, it returns the last
+ * position of the last chromosome
+ * @returns the genomic position of the absPos
+ */
+export function getRelativeGenomicPosition(
+    absPos: number,
+    assembly?: Assembly,
+    returnWithinAssembly = false
+): GenomicPosition {
+    const chrSizes = Object.entries(computeChromSizes(assembly).interval);
+    const minPosChr = { chromosome: 'unknown', position: Infinity } as GenomicPosition;
+    const maxPosChr = { chromosome: 'unknown', position: 0 } as GenomicPosition;
+    for (const chrSize of chrSizes) {
+        const [chromosome, absInterval] = chrSize;
+        const [start, end] = absInterval;
+        // absPos was found within this chromosome
+        if (start <= absPos && absPos < end) {
+            return { chromosome, position: absPos - start } as GenomicPosition;
+        }
+        // Update the min and max chromosomes found
+        if (start < minPosChr.position) {
+            minPosChr.chromosome = chromosome;
+            minPosChr.position = start;
+        }
+        if (end > maxPosChr.position) {
+            maxPosChr.chromosome = chromosome;
+            maxPosChr.position = end;
+        }
+    }
+    if (returnWithinAssembly) {
+        // Return either the min or max chromosome position
+        if (absPos < minPosChr.position) {
+            return minPosChr;
+        } else {
+            return maxPosChr;
+        }
+    } else {
+        return { chromosome: 'unknown', position: absPos };
+    }
+}
+
+/**
+ * Generate a URL for custom chrom sizes
+ * @param chromSizes A custom assembly that specifies chromosomes and their sizes
+ */
+function createChromSizesUrl(chromSizes: ChromSizes): string {
+    const text = chromSizes.map(d => d.join('\t')).join('\n');
+    const tsv = new Blob([text], { type: 'text/tsv' });
+    return URL.createObjectURL(tsv);
+}
+
+/**
+ * Get chromosome sizes.
+ * @param assembly (default: 'hg38')
+ */
+export function computeChromSizes(assembly?: Assembly): ChromSize {
+    if (assembly && typeof assembly === 'string' && assembly in CRHOM_SIZES) {
+        return CRHOM_SIZES[assembly];
+    } else if (Array.isArray(assembly) && assembly.length !== 0) {
+        // custom assembly
+        const size = Object.fromEntries(assembly);
+        return {
+            size,
+            interval: getChromInterval(size),
+            total: getChromTotalSize(size),
+            path: createChromSizesUrl(assembly)
+        };
+    } else {
+        // We do not have that assembly prepared, so return a default one.
+        return CRHOM_SIZES.hg38;
+    }
+}
+
+const basePath = (assembly: string) => `https://s3.amazonaws.com/gosling-lang.org/data/${assembly}.chrom.sizes`;
+const CRHOM_SIZES: { [assembly: string]: ChromSize } = Object.freeze({
+    hg38: {
+        size: CHROM_SIZE_HG38,
+        interval: getChromInterval(CHROM_SIZE_HG38),
+        total: getChromTotalSize(CHROM_SIZE_HG38),
+        path: basePath('hg38')
+    },
+    hg19: {
+        size: CHROM_SIZE_HG19,
+        interval: getChromInterval(CHROM_SIZE_HG19),
+        total: getChromTotalSize(CHROM_SIZE_HG19),
+        path: basePath('hg19')
+    },
+    hg18: {
+        size: CHROM_SIZE_HG18,
+        interval: getChromInterval(CHROM_SIZE_HG18),
+        total: getChromTotalSize(CHROM_SIZE_HG18),
+        path: basePath('hg18')
+    },
+    hg17: {
+        size: CHROM_SIZE_HG17,
+        interval: getChromInterval(CHROM_SIZE_HG17),
+        total: getChromTotalSize(CHROM_SIZE_HG17),
+        path: basePath('hg17')
+    },
+    hg16: {
+        size: CHROM_SIZE_HG16,
+        interval: getChromInterval(CHROM_SIZE_HG16),
+        total: getChromTotalSize(CHROM_SIZE_HG16),
+        path: basePath('hg16')
+    },
+    mm10: {
+        size: CHROM_SIZE_MM10,
+        interval: getChromInterval(CHROM_SIZE_MM10),
+        total: getChromTotalSize(CHROM_SIZE_MM10),
+        path: basePath('mm10')
+    },
+    mm9: {
+        size: CHROM_SIZE_MM9,
+        interval: getChromInterval(CHROM_SIZE_MM9),
+        total: getChromTotalSize(CHROM_SIZE_MM9),
+        path: basePath('mm9')
+    },
+    // `unknown` assembly contains only one chromosome with max length
+    unknown: {
+        size: { chr: Number.MAX_VALUE },
+        interval: { chr: [0, Number.MAX_VALUE] },
+        total: Number.MAX_VALUE,
+        path: basePath('hg38') // just to ensure this does not make crash
+    }
+});
+
+/**
+ * Calculate cumulative interval of each chromosome.
+ */
+export function getChromInterval(chromSize: { [k: string]: number }) {
+    const interval: { [k: string]: [number, number] } = {};
+
+    Object.keys(chromSize).reduce((sum, k) => {
+        interval[k] = [sum, sum + chromSize[k]];
+        return sum + chromSize[k];
+    }, 0);
+
+    return interval;
+}
+
+/**
+ * Calculate total size of entire chromosomes.
+ */
+export function getChromTotalSize(chromSize: { [k: string]: number }) {
+    return Object.values(chromSize).reduce((sum, current) => sum + current, 0);
+}
+
+export function parseGenomicPosition(position: string): { chromosome: string; start?: number; end?: number } {
+    const [chromosome, intervalString] = position.split(':');
+    if (intervalString) {
+        const [start, end] = intervalString.split('-').map(s => +s.replace(/,/g, ''));
+        // only return if both are valid
+        if (!Number.isNaN(start) && !Number.isNaN(end)) {
+            return { chromosome, start, end };
+        }
+    }
+    return { chromosome };
+}

--- a/src/data-fetchers/exported-utils.ts
+++ b/src/data-fetchers/exported-utils.ts
@@ -1,0 +1,25 @@
+import type { Assembly } from '@gosling-lang/gosling-schema';
+
+/**
+ * Get a chromosome name for the consistentcy, e.g., `1` --> `chr1`.
+ * @param chrName A chromosome name to be sanitized
+ * @param assembly A genome assembly of the data
+ * @param chromosomePrefix A prefix string that can be replaced to 'chr'
+ * @returns
+ */
+export function sanitizeChrName(chrName: string, assembly: Assembly, chromosomePrefix?: string) {
+    if (Array.isArray(assembly)) {
+        // this is a custom assembly, so use this as is
+        return chrName;
+    }
+
+    // For assemblies in Gosling, we use the `chr` prefix consistently
+    if (chromosomePrefix) {
+        // `hs1` --> `chr1`
+        chrName = chrName.replace(chromosomePrefix, 'chr');
+    } else if (!chrName.includes('chr')) {
+        // `1` --> `chr1`
+        chrName = `chr${chrName}`;
+    }
+    return chrName;
+}

--- a/src/data-fetchers/utils.ts
+++ b/src/data-fetchers/utils.ts
@@ -4,6 +4,8 @@ import { RemoteFile as _RemoteFile } from 'generic-filehandle';
 import type * as HiGlass from '@higlass/types';
 import type { Assembly, ChromSizes, Datum } from '@gosling-lang/gosling-schema';
 
+export { sanitizeChrName } from './exported-utils';
+
 export type CommonDataConfig = {
     assembly: Assembly;
     x?: string;
@@ -86,30 +88,6 @@ const absToChr = (absPosition: number, chromInfo: HiGlass.ChromInfo) => {
 
     return [chromInfo.cumPositions[insertPoint].chr, chrPosition, offset, insertPoint] as const;
 };
-
-/**
- * Get a chromosome name for the consistentcy, e.g., `1` --> `chr1`.
- * @param chrName A chromosome name to be sanitized
- * @param assembly A genome assembly of the data
- * @param chromosomePrefix A prefix string that can be replaced to 'chr'
- * @returns
- */
-export function sanitizeChrName(chrName: string, assembly: Assembly, chromosomePrefix?: string) {
-    if (Array.isArray(assembly)) {
-        // this is a custom assembly, so use this as is
-        return chrName;
-    }
-
-    // For assemblies in Gosling, we use the `chr` prefix consistently
-    if (chromosomePrefix) {
-        // `hs1` --> `chr1`
-        chrName = chrName.replace(chromosomePrefix, 'chr');
-    } else if (!chrName.includes('chr')) {
-        // `1` --> `chr1`
-        chrName = `chr${chrName}`;
-    }
-    return chrName;
-}
 
 export type ExtendedChromInfo = HiGlass.ChromInfo & {
     absToChr(absPos: number): ReturnType<typeof absToChr> | null;

--- a/src/exported-utils.ts
+++ b/src/exported-utils.ts
@@ -1,0 +1,2 @@
+export * from './data-fetchers/exported-utils';
+export * from './core/utils/exported-utils';


### PR DESCRIPTION
Allows import of some whitelisted functions via separate entrypoint:

```javascript
import { getRelativeGenomicPosition } from 'gosling.js/utils';
```

...at the cost of some build complexity.

#997 is much more simple because it doesn't require changing our build. This configures esbuild to bundle `src/exported-utils.ts` into a single file which is imported under `gosling.js/utils`. I needed to make extra `exported-utils` files because esbuild was including some dependencies not used by these functions in the final build. .