### PR TITLE
feat(core): Create `gosling.js/utils` entrypoint for exporting utility funcs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
         ".": {
             "types": "./dist/src/index.d.ts",
             "import": "./dist/gosling.js"
+        },
+        "./utils": {
+            "types": "./dist/src/exported-utils.d.ts",
+            "import": "./dist/utils.js"
         }
     },
     "scripts": {

--- a/src/exported-utils.ts
+++ b/src/exported-utils.ts
@@ -1,0 +1,8 @@
+export {
+    getRelativeGenomicPosition,
+    computeChromSizes,
+    getChromInterval,
+    getChromTotalSize,
+    parseGenomicPosition
+} from './core/utils/assembly';
+export { sanitizeChrName } from './data-fetchers/utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,21 +13,3 @@ export { validateGoslingSpec } from '@gosling-lang/gosling-schema';
 export { GoslingComponent } from './core/gosling-component';
 export type { GoslingRef } from './core/gosling-component';
 export { embed } from './core/gosling-embed';
-
-import {
-    getRelativeGenomicPosition,
-    computeChromSizes,
-    getChromInterval,
-    getChromTotalSize,
-    parseGenomicPosition
-} from './core/utils/assembly';
-import { sanitizeChrName } from './data-fetchers/utils';
-const utils = {
-    getRelativeGenomicPosition,
-    computeChromSizes,
-    getChromInterval,
-    getChromTotalSize,
-    parseGenomicPosition,
-    sanitizeChrName
-};
-export { utils };

--- a/vite.config.js
+++ b/vite.config.js
@@ -90,9 +90,11 @@ const esm = defineConfig({
         target: 'es2018',
         sourcemap: true,
         lib: {
-            entry: path.resolve(__dirname, 'src/index.ts'),
+            entry: {
+                gosling: path.resolve(__dirname, 'src/index.ts'),
+                utils: path.resolve(__dirname, 'src/exported-utils.ts'),
+            },
             formats: ['es'],
-            fileName: 'gosling'
         },
         rollupOptions: { external }
     },


### PR DESCRIPTION
Allows import of some whitelisted functions via separate entrypoint (much simpler than #1000):

```javascript
import { getRelativeGenomicPosition } from 'gosling.js/utils';
```

...at the cost of some build complexity. If you look at the output, you'll see that `dist/utils.ts` contains imports for `d3-array` and `generic-filehandle` even though the exported functions don't use these imports at all.

```javascript
import { c, b, d, a, p, s } from "./exported-utils-068d7b17.js";
import "d3-array";
import "generic-filehandle";
export {
  c as computeChromSizes,
  b as getChromInterval,
  d as getChromTotalSize,
  a as getRelativeGenomicPosition,
  p as parseGenomicPosition,
  s as sanitizeChrName
};
//# sourceMappingURL=exported-utils.js.map
```

This is because those dependencies do not have `sideEffect: false` in the package.json, which means Vite doesn't know if importing the modules have global side effects. Should be fine in this context, but just so folks know what's going on.