### PR TITLE
feat(core): return a processed spec when a new spec is compiled

### DIFF
--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -23,9 +23,15 @@ const DELAY_FOR_CONTAINER_RESIZE_BEFORE_RERENDER = 300;
 export interface UrlToFetchOptions {
     [url: string]: RequestInit;
 }
+type CompiledCallbackFn = (
+    goslingSpec: gosling.GoslingSpec,
+    higlassSpec: gosling.HiGlassSpec,
+    _additionalData: { _processedSpec: gosling.GoslingSpec }
+) => void
+
 interface GoslingCompProps {
     spec?: gosling.GoslingSpec;
-    compiled?: (goslingSpec: gosling.GoslingSpec, higlassSpec: gosling.HiGlassSpec) => void;
+    compiled?: CompiledCallbackFn;
     padding?: number;
     margin?: number;
     border?: string;
@@ -112,7 +118,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
                     }
 
                     // If a callback function is provided, return compiled information.
-                    props.compiled?.(props.spec!, newHiGlassSpec);
+                    props.compiled?.(props.spec!, newHiGlassSpec, { _processedSpec: newGoslingSpec });
 
                     // Change the size of wrapper `<div/>` elements
                     setSize(newSize);


### PR DESCRIPTION
Fix #
Toward #

## Change List
 - This PR adds an **internal** object as the third parameter of compile callback function:

```ts
<GoslingComponent spec={spec} compiled={(newSpec, newHg, _internalData) => {
   const { _processedSpec } =  _internalData;
}/> 
```

https://github.com/gosling-lang/gosling.js/blob/346a2f6652f51d69198f480ee27f0754a6b11027/src/compiler/compile.ts#L75-L81

The `_processedSpec` is the same as the `specCopy ` object above, which is the processed spec.

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
