### PR TITLE
chore(core): upgrade higlass

### DIFF
--- a/editor/html-template.ts
+++ b/editor/html-template.ts
@@ -1,17 +1,17 @@
 import { version as _goslingVersion } from '../package.json';
+import { dependencies as _goslingDependencies } from '../package.json';
 
 export const getHtmlTemplate = (
     spec: string,
     reactVersion = 18,
     pixiVersion = 6,
-    higlassVersion = 1.13,
+    higlassVersion = _goslingDependencies['higlass'],
     goslingVersion = _goslingVersion
 ) => `
 <!DOCTYPE html>
 <html>
 <head>
     <title>Gosling Visualization</title>
-    <link rel="stylesheet" href="https://esm.sh/higlass@${higlassVersion}/dist/hglib.css">
     <script type="importmap">
       {
         "imports": {

--- a/editor/index.tsx
+++ b/editor/index.tsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Route } from 'react-router-dom';
 import Editor from './Editor';
 import './index.css';
-import 'higlass/dist/hglib.css';
 
 const root = createRoot(document.getElementById('root') as HTMLElement);
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "fflate": "^0.7.1",
         "generic-filehandle": "^3.0.1",
         "gosling-theme": "^0.0.10",
-        "higlass": "^1.13.2",
+        "higlass": "^1.13.3",
         "higlass-register": "^0.3.0",
         "higlass-text": "^0.1.1",
         "json-stringify-pretty-compact": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2778,11 +2778,6 @@ email-addresses@^3.0.1:
   resolved "https://registry.yarnpkg.com/email-addresses/-/email-addresses-3.1.0.tgz#cabf7e085cbdb63008a70319a74e6136188812fb"
   integrity sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==
 
-emitter-component@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/emitter-component/-/emitter-component-1.1.1.tgz#065e2dbed6959bf470679edabeaf7981d1003ab6"
-  integrity sha512-G+mpdiAySMuB7kesVRLuyvYRqDmshB7ReKEVuyBPkzQlmiDiLrt7hHHIy4Aff552bgknVN7B2/d3lzhGO5dvpQ==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -3670,10 +3665,10 @@ higlass-text@^0.1.1:
     higlass-register "^0.3.0"
     slugid "^2.0.0"
 
-higlass@^1.13.2:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/higlass/-/higlass-1.13.2.tgz#54d3832a6c3c583b7418c0a386a4716f5cf3389e"
-  integrity sha512-B+56rUulGpkI8ep3Dt9QIowKg/Zo9eLBkNHSM/ethuSB5HngC3fVOWu7Ienr0ZAz3/eqmhbSFTh/D1IQqFI5ug==
+higlass@^1.13.3:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/higlass/-/higlass-1.13.3.tgz#8bf01bce70f64fa333cb589433c2bca808542334"
+  integrity sha512-aZ+Q+ClF1TTeV81ChuGSd5CHiVJf8+1c6w6/sXGAOonkGVQ54yuZpSYafMatKAjytM6/fwSaHs3uQT2xUEE2MA==
   dependencies:
     ajv "^6.10.0"
     box-intersect "^1.0.1"
@@ -3703,15 +3698,12 @@ higlass@^1.13.2:
     pub-sub-es "^2.0.1"
     react-checkbox-tree "^1.7.3"
     react-color "^2.13.8"
-    react-contextmenu "^2.9.2"
     react-grid-layout "^0.16.6"
-    react-resizable "^1.8.0"
     react-simple-code-editor "^0.9.10"
     react-sortable-hoc "^1.10.1"
     reactcss "^1.2.3"
     robust-point-in-polygon "^1.0.3"
     slugid "^3.2.0"
-    stream "0.0.2"
     url-parse "^1.4.3"
     vkbeautify "^0.99.3"
 
@@ -4983,7 +4975,7 @@ nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.4.tgz#fd59d5e904e8e1f03c25a7d5a15cfa16c714a1e5"
   integrity sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g==
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -5570,14 +5562,6 @@ react-color@^2.13.8:
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
 
-react-contextmenu@^2.9.2:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/react-contextmenu/-/react-contextmenu-2.14.0.tgz#d8966f30614b9b780b928be4c8d92bd740d55cdd"
-  integrity sha512-ktqMOuad6sCFNJs/ltEwppN8F0YeXmqoZfwycgtZR/MxOXMYx1xgYC44SzWH259HdGyshk1/7sXGuIRwj9hzbw==
-  dependencies:
-    classnames "^2.2.5"
-    object-assign "^4.1.0"
-
 react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -5652,7 +5636,7 @@ react-refresh@^0.14.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
-react-resizable@1.x, react-resizable@^1.8.0:
+react-resizable@1.x:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-1.11.1.tgz#02ca6850afa7a22c1b3e623e64aef71ee252af69"
   integrity sha512-S70gbLaAYqjuAd49utRHibtHLrHXInh7GuOR+6OO6RO6uleQfuBnWmZjRABfqNEx3C3Z6VPLg0/0uOYFrkfu9Q==
@@ -6187,13 +6171,6 @@ stream-browserify@^3.0.0:
   dependencies:
     inherits "~2.0.4"
     readable-stream "^3.5.0"
-
-stream@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/stream/-/stream-0.0.2.tgz#7f5363f057f6592c5595f00bc80a27f5cec1f0ef"
-  integrity sha512-gCq3NDI2P35B2n6t76YJuOp7d6cN/C7Rt0577l91wllh0sY9ZBuw9KaSGqH/b0hzn3CWWJbpbW0W0WvQ1H/Q7g==
-  dependencies:
-    emitter-component "^1.1.1"
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"


### PR DESCRIPTION
Fix #999 
Toward #

## Change List
 - Upgrade minimum HiGlass to [1.13.3](https://github.com/higlass/higlass/releases/tag/v1.13.3), which injects CSS via JS in final HiGlass build.
 - Remove HiGlass CSS import
 - Update HTML template 

https://github.com/gosling-lang/gosling-website/pull/90


## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [x] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
