### PR TITLE
fix(track): Allows for tracks in stacked circular tracks to receive click events

### DIFF
--- a/src/tracks/gosling-track/gosling-track.ts
+++ b/src/tracks/gosling-track/gosling-track.ts
@@ -482,6 +482,35 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             });
         }
 
+        /**
+         * This is how the mask gets drawn. Overrides method in PixiTrack. 
+         * Compared to the method in PixiTrack, this method draws a circular mask when the layout is circular.
+         * @param position
+         * @param dimensions
+         */
+        override setMask(position: [number, number], dimensions: [number, number]) {
+            this.pMask.clear();
+            this.pMask.beginFill();
+
+            if (this.options.spec.layout === 'circular') {
+                /**
+                 * If the layout is circular, we want the mask to be circular as well.
+                 * Circular layout have multiple tracks on top of each other so if the mask is not circular, click
+                 * events will be triggered only on the top track.
+                 */
+                const [x, y] = this.position;
+                const [width, height] = this.dimensions;
+                const cx = x + width / 2.0;
+                const cy = y + height / 2.0;
+                const outerRadius = this.options.spec.outerRadius!;
+                this.pMask.drawCircle(cx, cy, outerRadius);
+            } else {
+                // Normal rectangular mask. This is what is done in PixiTrack
+                this.pMask.drawRect(position[0], position[1], dimensions[0], dimensions[1]);
+            }
+            this.pMask.endFill();
+        }
+
         /* *
          *
          *  Tile and data processing methods

--- a/src/tracks/gosling-track/gosling-track.ts
+++ b/src/tracks/gosling-track/gosling-track.ts
@@ -483,7 +483,7 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
         }
 
         /**
-         * This is how the mask gets drawn. Overrides method in PixiTrack. 
+         * This is how the mask gets drawn. Overrides method in PixiTrack.
          * Compared to the method in PixiTrack, this method draws a circular mask when the layout is circular.
          * @param position
          * @param dimensions


### PR DESCRIPTION
Fix #992 
Toward #

## Change List
 - Allows for tracks in stacked circular tracks to receive click events by making circular masks for tracks with circular layouts 

**Demo** 

https://github.com/gosling-lang/gosling.js/assets/14843470/06e7ded8-de69-4d43-bf1b-e0265f6129b3




## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
