### PR TITLE
fix(core): publish events on first render

### DIFF
--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -100,7 +100,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
     // TODO: add a `force` parameter since changing `linkingId` might not update vis
     const compile = useCallback(
         (altSpec?: gosling.GoslingSpec) => {
-                const spec = altSpec ?? props.spec;
+            const spec = altSpec ?? props.spec;
             if (spec) {
                 const valid = gosling.validateGoslingSpec(spec);
 

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -174,7 +174,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
                 wrapperSize.current.width !== newSize.width
             ) {
                 wrapperSize.current = newSize;
-                compile(props.spec);
+                compile();
             }
         });
 
@@ -188,7 +188,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
                 wrapperParentSize.current.width !== newSize.width
             ) {
                 wrapperParentSize.current = newSize;
-                compile(props.spec);
+                compile();
             }
         });
 
@@ -208,7 +208,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
             });
             setIsInitialRender(false);
         } else {
-            compile(props.spec);
+            compile();
         }
     }, [props.spec, theme, isInitialRender]);
 

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -99,7 +99,8 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
 
     // TODO: add a `force` parameter since changing `linkingId` might not update vis
     const compile = useCallback(
-        (spec: gosling.GoslingSpec | undefined) => {
+        (altSpec?: gosling.GoslingSpec) => {
+                const spec = altSpec ?? props.spec;
             if (spec) {
                 const valid = gosling.validateGoslingSpec(spec);
 


### PR DESCRIPTION
Fix #1020
Toward #

## Change List
 - Compile a blank spec in the initial render so that the Gosling ref can get associated with the DOM. 

This enables subscription events to work properly. 

https://github.com/gosling-lang/gosling.js/assets/14843470/3d57b4ff-1919-426f-bdbf-83dcc06ae1ad



## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
