### PR TITLE
fix(track): prevent circular layout legend from being obscured

### DIFF
--- a/src/tracks/gosling-track/gosling-track.ts
+++ b/src/tracks/gosling-track/gosling-track.ts
@@ -522,11 +522,10 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             this.pMask.clear();
             this.pMask.beginFill();
 
-            if (this.options.spec.layout === 'circular') {
+            if (this.options.spec.layout === 'circular' && this.options.spec.overlayOnPreviousTrack) {
                 /**
-                 * If the layout is circular, we want the mask to be circular as well.
-                 * Circular layout have multiple tracks on top of each other so if the mask is not circular, click
-                 * events will be triggered only on the top track.
+                 * If the layout is circular and is overlaid on another track, the mask should be circular
+                 * so outer tracks can still receive click events.
                  */
                 const [x, y] = this.position;
                 const [width, height] = this.dimensions;


### PR DESCRIPTION
Fix #1027
Toward #

## Change List
 - Makes circular layout legend fully visible. Before the circular layout mask would prevent the legend from being shown. 


Before:
<img width="200" alt="image" src="https://github.com/gosling-lang/gosling.js/assets/14843470/182c59a7-efc0-4bf6-a3fe-57bc1f337a14">

After:
<img width="200" alt="image" src="https://github.com/gosling-lang/gosling.js/assets/14843470/16f2331d-f649-4a1a-85c8-9dbcb4654cc7">


## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [x] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
