### PR TITLE
perf(track): Persist GoslingTrackModels

### DIFF
--- a/src/tracks/gosling-track/gosling-track-model.ts
+++ b/src/tracks/gosling-track/gosling-track-model.ts
@@ -79,7 +79,7 @@ export class GoslingTrackModel {
         this.dataAggregated = data; // this will be updated after validity of the spec is checked
 
         this.specOriginal = spec;
-        this.specComplete = structuredClone(spec);
+        this.specComplete = JSON.parse(JSON.stringify(spec));
 
         this.channelScales = {};
 

--- a/src/tracks/gosling-track/gosling-track.ts
+++ b/src/tracks/gosling-track/gosling-track.ts
@@ -174,6 +174,8 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
         #loadingText = new HGC.libraries.PIXI.Text('', loadingTextStyle);
         prevVisibleAndFetchedTiles?: Tile[];
         resolvedTracks: SingleTrack[] | undefined;
+        // This is used to persist processed tile data across draw() calls.
+        #processedTileMap: WeakMap<Tile, boolean> = new WeakMap();
 
         /* *
          *
@@ -416,6 +418,8 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             this.getResolvedTracks(true); // force update
             this.clearMouseEventData();
             this.textsBeingUsed = 0;
+            // Without this, tracks with the same ID between specs will not be redrawn
+            this.#processedTileMap = new WeakMap();
 
             this.processAllTiles(true);
             this.draw();
@@ -555,6 +559,11 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             this.tileSize = this.tilesetInfo?.tile_size ?? 1024;
 
             const tiles = this.visibleAndFetchedTiles();
+            // If we have already processed all tiles, we don't need to do anything
+            // this.#processedTileMap contains all of data needed to draw
+            if (tiles.every(tile => this.#processedTileMap.get(tile) !== undefined)) {
+                return;
+            }
 
             // generated tabular data
             tiles.forEach(tile => this.#generateTabularData(tile, force));
@@ -571,6 +580,11 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             if (flatTileData.length !== 0) {
                 this.options.siblingIds.forEach(id => publish('rawData', { id, data: flatTileData }));
             }
+
+            // Record processed tiles so that we don't process them again
+            tiles.forEach(tile => {
+                this.#processedTileMap.set(tile, true);
+            });
         }
 
         /**


### PR DESCRIPTION
Fix #1043
Toward #

## Change List
 - Persist GoslingTrackModels between draw calls 
 - Switch from `structuredClone()` to `JSON.parse(JSON.stringify())`


https://github.com/gosling-lang/gosling.js/assets/14843470/7fd82e40-3fac-4814-9228-52c722011bb3



## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
