### PR TITLE
feat(api): use gosling server instead of HiGlass server for gene search

### DIFF
--- a/editor/example/json-spec/index.ts
+++ b/editor/example/json-spec/index.ts
@@ -24,7 +24,7 @@ import { EX_SPEC_CYTOBANDS } from './ideograms';
 import { EX_SPEC_PILEUP } from './pileup';
 import { EX_SPEC_TEMPLATE } from './track-template';
 import { EX_SPEC_MOUSE_EVENT } from './mouse-event';
-import { EX_SPEC_PERF_ALIGNMENT } from './perf-alignment'
+import { EX_SPEC_PERF_ALIGNMENT } from './perf-alignment';
 import { EX_SPEC_DEBUG } from './debug';
 
 export const JsonExampleSpecs = {

--- a/src/compiler/higlass-model.ts
+++ b/src/compiler/higlass-model.ts
@@ -4,7 +4,7 @@ import type { Assembly, AxisPosition, Domain, DummyTrack, Orientation, ZoomLimit
 import { getNumericDomain } from '../core/utils/scales';
 import type { RelativePosition } from './bounding-box';
 import { validateSpec } from '@gosling-lang/gosling-schema';
-import { getAutoCompleteId, computeChromSizes } from '../core/utils/assembly';
+import { getAutoCompleteObject, computeChromSizes } from '../core/utils/assembly';
 import type { CompleteThemeDeep } from '../core/utils/theme';
 import exampleHg from '../core/example/hg-view-config-1';
 import { insertItemToArray } from '../core/utils/array';
@@ -15,12 +15,7 @@ export const HIGLASS_AXIS_SIZE = 30;
 const getViewTemplate = (assembly?: Assembly) => {
     return {
         genomePositionSearchBoxVisible: false,
-        genomePositionSearchBox: {
-            autocompleteServer: 'https://higlass.io/api/v1',
-            autocompleteId: getAutoCompleteId(assembly),
-            chromInfoServer: 'https://higlass.io/api/v1',
-            chromInfoId: assembly ?? 'hg38'
-        },
+        genomePositionSearchBox: getAutoCompleteObject(assembly),
         layout: { w: 12, h: 12, x: 0, y: 0 },
         tracks: {
             top: [],

--- a/src/core/utils/assembly.ts
+++ b/src/core/utils/assembly.ts
@@ -150,17 +150,29 @@ const CRHOM_SIZES: { [assembly: string]: ChromSize } = Object.freeze({
 /**
  * Some presets of auto-complete IDs (`autocompleteId`) to search for genes using the HiGlass server.
  */
-export function getAutoCompleteId(assembly?: Assembly) {
+export function getAutoCompleteObject(assembly: Assembly = 'hg38') {
+    const base = {
+        autocompleteServer: 'https://server.gosling-lang.org/api/v1',
+        chromInfoServer: 'https://server.gosling-lang.org/api/v1',
+        chromInfoId: assembly
+    };
     switch (assembly) {
         case 'hg19':
-            return 'OHJakQICQD6gTD7skx4EWA';
+            return { ...base, autocompleteId: 'gene-annotation-hg19' };
         case 'mm10':
-            return 'QDutvmyiSrec5nX4pA5WGQ';
+            return { ...base, autocompleteId: 'gene-annotation-mm10' };
         case 'mm9':
-            return 'GUm5aBiLRCyz2PsBea7Yzg';
+            // mm9 is not supported by the Gosling server, so we use HiGlass server.
+            // To support, we need to add mm9 gene annotation to the Gosling server.
+            return {
+                ...base,
+                autocompleteServer: 'https://higlass.io/api/v1',
+                chromInfoServer: 'https://higlass.io/api/v1',
+                autocompleteId: 'GUm5aBiLRCyz2PsBea7Yzg'
+            };
         case 'hg38':
         default:
-            return 'P0PLbQMwTYGy-5uPIQid7A';
+            return { ...base, autocompleteId: 'gene-annotation' };
     }
 }
 


### PR DESCRIPTION
Fix #
Toward #

## Change List
 - Replace the HiGlass server with the Gosling server for supporting gene search APIs
   - The Gosling server has three assemblies supported, so I replaced the HiGlass server for three assemblies: https://server.gosling-lang.org/api/v1/tilesets/?limit=99999&dt=gene-annotation

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
