### PR TITLE
perf(track): reduce webgl memory usage

### DIFF
--- a/src/tracks/gosling-track/gosling-track.ts
+++ b/src/tracks/gosling-track/gosling-track.ts
@@ -1,4 +1,4 @@
-import type * as PIXI from 'pixi.js';
+import * as PIXI from 'pixi.js';
 import { isEqual, sampleSize, uniqBy } from 'lodash-es';
 import type { ScaleLinear } from 'd3-scale';
 import type {
@@ -399,7 +399,8 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             this.pBackground.clear();
             this.pBackground.removeChildren();
             this.pBorder.clear();
-            this.pBorder.removeChildren();
+            const children = this.pBorder.removeChildren();
+            children.forEach(c => c.destroy());
             this.displayedLegends = [];
 
             // Because a single tile contains one track or multiple tracks overlaid, we draw marks and embellishments

--- a/src/tracks/gosling-track/gosling-track.ts
+++ b/src/tracks/gosling-track/gosling-track.ts
@@ -1,4 +1,4 @@
-import * as PIXI from 'pixi.js';
+import type * as PIXI from 'pixi.js';
 import { isEqual, sampleSize, uniqBy } from 'lodash-es';
 import type { ScaleLinear } from 'd3-scale';
 import type {


### PR DESCRIPTION
Fix #
Toward #

Interacting with a visualization causes webgl memory to skyrocket. I use `about:memory` in Firefox to check memory usage. 
<img width="435" alt="image" src="https://github.com/gosling-lang/gosling.js/assets/14843470/7a85100c-577d-45d2-8146-6abef79b03f8">
This was because `Graphics` objects were not being destroyed between draw calls, causing an accumulation of Graphics objects. With this fix, webgl textures memory only gets up to 10-15 MB. 


## Change List
 - Destroy the Graphics objects in `pBorder` before redrawing

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
