### PR TITLE
feat(core): Make reactive default in component 

### DIFF
--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -1220,7 +1220,6 @@ function Editor(props: RouteComponentProps) {
                                             border={'none'}
                                             id={'goslig-component-root'}
                                             className={'goslig-component'}
-                                            experimental={{ reactive: true }}
                                             compiled={(_, h) => {
                                                 setHg(h);
                                             }}

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -40,9 +40,7 @@ export interface GoslingCompProps {
     theme?: Theme;
     templates?: TemplateTrackDef[];
     urlToFetchOptions?: UrlToFetchOptions;
-    experimental?: {
-        reactive?: boolean;
-    };
+    reactive?: boolean;
 }
 
 export type GoslingRef = {
@@ -51,6 +49,7 @@ export type GoslingRef = {
 };
 
 export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props, ref) => {
+    const { reactive = true } = props;
     const [viewConfig, setViewConfig] = useState<gosling.HiGlassSpec>();
     // Keeping track of whether the initial render has occured is important so the API works pr
     const [isInitialRender, setIsInitialRender] = useState(true);
@@ -129,7 +128,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
 
                         // Update the compiled view config
                         const isMountedOnce = typeof viewConfig !== 'undefined';
-                        if (props.experimental?.reactive && isMountedOnce) {
+                        if (reactive && isMountedOnce) {
                             // Use API to update visualization.
                             setTimeout(() => {
                                 preverseZoomStatus(


### PR DESCRIPTION
Fix  #1064
Toward #

## Change List
- Moves `reactive` out of the experimental properties 
 - Makes `reactive=true` the default option in GoslingComponent

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
