### PR TITLE
refactor(core): make header mark use underscore 

### DIFF
--- a/src/compiler/bounding-box.ts
+++ b/src/compiler/bounding-box.ts
@@ -385,7 +385,7 @@ export function getNumOfYAxes(tracks: Track[]): number {
 const getTextTrack = (size: Size, title?: string, subtitle?: string) => {
     return JSON.parse(
         JSON.stringify({
-            mark: 'header',
+            mark: '_header',
             width: size.width,
             height: size.height,
             title,

--- a/src/compiler/gosling-to-higlass.ts
+++ b/src/compiler/gosling-to-higlass.ts
@@ -282,7 +282,7 @@ export function goslingToHiGlass(
         });
 
         hgModel.validateSpec(true);
-    } else if (firstResolvedSpec.mark === 'header') {
+    } else if (firstResolvedSpec.mark === '_header') {
         // `text` tracks are used to show title and subtitle of the views
         hgModel.addDefaultView(`${trackId}-title`).setLayout(layout);
         if (typeof firstResolvedSpec.title === 'string') {

--- a/src/gosling-schema/gosling.schema.json
+++ b/src/gosling-schema/gosling.schema.json
@@ -3758,7 +3758,7 @@
         "triangleRight",
         "triangleBottom",
         "brush",
-        "header"
+        "_header"
       ],
       "type": "string"
     },

--- a/src/gosling-schema/gosling.schema.ts
+++ b/src/gosling-schema/gosling.schema.ts
@@ -274,7 +274,7 @@ export type Mark =
     | 'brush'
     // TODO: perhaps need to make this invisible to users
     // being used to show title/subtitle internally
-    | 'header';
+    | '_header';
 
 /* ----------------------------- API & MOUSE EVENTS ----------------------------- */
 interface CommonEventData {

--- a/src/gosling-schema/gosling.schema.ts
+++ b/src/gosling-schema/gosling.schema.ts
@@ -272,8 +272,7 @@ export type Mark =
     | 'triangleRight'
     | 'triangleBottom'
     | 'brush'
-    // TODO: perhaps need to make this invisible to users
-    // being used to show title/subtitle internally
+    // The _header mark is used internally for text tracks
     | '_header';
 
 /* ----------------------------- API & MOUSE EVENTS ----------------------------- */

--- a/src/gosling-schema/template.schema.json
+++ b/src/gosling-schema/template.schema.json
@@ -924,7 +924,7 @@
         "triangleRight",
         "triangleBottom",
         "brush",
-        "header"
+        "_header"
       ],
       "type": "string"
     },


### PR DESCRIPTION
Fix #1066
Toward #

## Change List
 - Change `"header"` mark name to `"_header"` to clarify that it is only used internally. 

## Checklist
 - [x] Ensure the PR works with all demos on the online editor
 - [x] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
