### PR TITLE
feat(core): remove specProcessed event

### DIFF
--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -8,7 +8,6 @@ import type { UrlToFetchOptions } from 'src/core/gosling-component';
 import { renderHiGlass as createHiGlassModels } from './create-higlass-models';
 import { manageResponsiveSpecs } from './responsive';
 import type { IdTable } from '../api/track-and-view-ids';
-import { publish } from '../api/pubsub';
 
 /** The callback function called everytime after the spec has been compiled */
 export type CompileCallback = (
@@ -69,13 +68,6 @@ export function compile(
         traverseToFixSpecDownstream(specCopy);
         trackInfos = getRelativeTrackInfo(specCopy, theme).trackInfos;
     }
-
-    // publish the fixed spec
-    // used for alt-gosling
-    publish('specProcessed', {
-        id: specCopy.id,
-        spec: specCopy
-    });
 
     // Make HiGlass models for individual tracks
     createHiGlassModels(specCopy, trackInfos, callback, theme, urlToFetchOptions);

--- a/src/gosling-schema/gosling.schema.ts
+++ b/src/gosling-schema/gosling.schema.ts
@@ -284,13 +284,6 @@ interface CommonEventData {
     data: Datum[];
 }
 
-interface SpecEventData {
-    /** Source visualization ID, i.e., `track.id` */
-    id: string;
-    /** Gosling spec */
-    spec: GoslingSpec;
-}
-
 export interface GenomicPosition {
     chromosome: string;
     position: number;

--- a/src/gosling-schema/gosling.schema.ts
+++ b/src/gosling-schema/gosling.schema.ts
@@ -379,7 +379,6 @@ export type _EventMap = {
     click: PointMouseEventData;
     rangeSelect: RangeMouseEventData;
     rawData: CommonEventData;
-    specProcessed: SpecEventData;
     trackMouseOver: TrackApiData;
     trackClick: TrackApiData; // TODO (Jul-25-2022): with https://github.com/higlass/higlass/pull/1098, we can support circular layouts
     onNewTrack: OnNewTrackEventData;


### PR DESCRIPTION
Fix #1067
Toward #

## Change List
 - Remove `specProcessed` event. 

This event is not being used by altgosling as far as I can tell. Instead this data is received through the compile callback. 

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
