### PR TITLE
refactor(core): change _processedSpec to experimental_processedSpec

### DIFF
--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -26,7 +26,7 @@ export interface UrlToFetchOptions {
 type CompiledCallbackFn = (
     goslingSpec: gosling.GoslingSpec,
     higlassSpec: gosling.HiGlassSpec,
-    _additionalData: { _processedSpec: gosling.GoslingSpec }
+    experimental: { experimental_processedSpec: gosling.GoslingSpec }
 ) => void;
 
 export interface GoslingCompProps {
@@ -122,7 +122,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
                         }
 
                         // If a callback function is provided, return compiled information.
-                        props.compiled?.(spec, newHiGlassSpec, { _processedSpec: newGoslingSpec });
+                        props.compiled?.(spec, newHiGlassSpec, { experimental_processedSpec: newGoslingSpec });
 
                         // Change the size of wrapper `<div/>` elements
                         setSize(newSize);

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -26,6 +26,7 @@ export interface UrlToFetchOptions {
 type CompiledCallbackFn = (
     goslingSpec: gosling.GoslingSpec,
     higlassSpec: gosling.HiGlassSpec,
+    /** @deprecated This is an experimental object that is not intended for production usage. */
     experimental: { _processedSpec: gosling.GoslingSpec }
 ) => void;
 
@@ -122,7 +123,7 @@ export const GoslingComponent = forwardRef<GoslingRef, GoslingCompProps>((props,
                         }
 
                         // If a callback function is provided, return compiled information.
-                        props.compiled?.(spec, newHiGlassSpec, { experimental_processedSpec: newGoslingSpec });
+                        props.compiled?.(spec, newHiGlassSpec, { _processedSpec: newGoslingSpec });
 
                         // Change the size of wrapper `<div/>` elements
                         setSize(newSize);

--- a/src/core/gosling-component.tsx
+++ b/src/core/gosling-component.tsx
@@ -26,7 +26,7 @@ export interface UrlToFetchOptions {
 type CompiledCallbackFn = (
     goslingSpec: gosling.GoslingSpec,
     higlassSpec: gosling.HiGlassSpec,
-    experimental: { experimental_processedSpec: gosling.GoslingSpec }
+    experimental: { _processedSpec: gosling.GoslingSpec }
 ) => void;
 
 export interface GoslingCompProps {


### PR DESCRIPTION
Fix #1068
Toward #

## Change List
 - Change `_processedSpec` in compile callback function to `experimental_processedSpec`

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
