### PR TITLE
fix(core): remove `"template"` key from template track after processing

### DIFF
--- a/src/core/utils/template.ts
+++ b/src/core/utils/template.ts
@@ -303,6 +303,10 @@ export function replaceTrackTemplates(spec: GoslingSpec, templates: TemplateTrac
         if ('encoding' in viewBase) {
             delete viewBase.encoding;
         }
+        // Remove a template property since it is not a template anymore
+        if('template' in viewBase) {
+            delete viewBase.template;
+        }
         const convertedView: OverlaidTracks = {
             ...viewBase,
             alignment: 'overlay',


### PR DESCRIPTION
Fix #
Toward #

This is a PR into [etowahadams/datatrack](https://github.com/gosling-lang/gosling.js/pull/1074).

## Change List
 - remove `"template"` key from template track after processing
   - This PR was necessary since a non-template track (i.e., a track converted from a template track) is incorrectly considered as a template track in Gosling.
     - Gosling considers a track `TemplateTrack` if there is a "template" key ([code](https://github.com/gosling-lang/gosling.js/blob/1aa335b2ee481c77e24bd1b09a5692e2f8bce8dc/src/gosling-schema/gosling.schema.guards.ts#L140)).
   - This addressed broken demo examples with template tracks in https://github.com/gosling-lang/gosling.js/pull/1074

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
