### PR TITLE
feat(core): remove tooltip information about the number of additional elements

### DIFF
--- a/src/tracks/gosling-track/gosling-track.ts
+++ b/src/tracks/gosling-track/gosling-track.ts
@@ -1197,7 +1197,8 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
             this.pMouseHover.clear();
         }
         /**
-         * From all tiles and overlaid tracks, collect element(s) that are withing a mouse position.
+         * From all tiles and overlaid tracks, collect element(s) that are within a mouse position.
+         * In the array, the first element is the element that is directly within the mouse position.
          */
         #getElementsWithinMouse(mouseX: number, mouseY: number) {
             const models = this.visibleAndFetchedGoslingModels();
@@ -1460,12 +1461,6 @@ const factory: PluginTrackFactory<Tile, GoslingTrackOptions> = (HGC, context, op
                         .join('');
 
                     content = `<table style='text-align: left; margin-top: 12px'>${content}</table>`;
-                    if (capturedElements.length > 1) {
-                        content +=
-                            `<div style='padding: 4px 8px; margin-top: 4px; text-align: center; color: grey'>` +
-                            `${capturedElements.length - 1} Additional Selections...` +
-                            '</div>';
-                    }
                     return `<div>${content}</div>`;
                 }
             }


### PR DESCRIPTION
Fix #
Toward #

## Change List
- Remove information about "x Additional Selections" on a tooltip. This was considered rather confusing to people (e.g., feedback of Chromoscope).

### Before
<img src="https://github.com/gosling-lang/gosling.js/assets/9922882/8523e91b-5a38-478f-aae4-75b144133c21" width="300px"/>

### After
<img src="https://github.com/gosling-lang/gosling.js/assets/9922882/266b13ec-658d-4586-a16f-c9b2d7867489" width="300px"/>

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
