### PR TITLE
fix: add valid esm.sh path for higlass-text module

### DIFF
--- a/editor/html-template.ts
+++ b/editor/html-template.ts
@@ -19,7 +19,8 @@ export const getHtmlTemplate = (
           "react-dom": "https://esm.sh/react-dom@${reactVersion}",
           "pixi": "https://esm.sh/pixi.js@${pixiVersion}",
           "higlass": "https://esm.sh/higlass@${higlassVersion}?external=react,react-dom,pixi",
-          "gosling.js": "https://esm.sh/gosling.js@${goslingVersion}?external=react,react-dom,pixi,higlass"
+          "higlass-text": "https://esm.sh/higlass-text/es/index.js",
+          "gosling.js": "https://esm.sh/gosling.js@${goslingVersion}?external=react,react-dom,pixi,higlass,higlass-text"
         }
       }
     </script>


### PR DESCRIPTION
Temporary fix for the HTML files produced by HTML export in Gosling editor not working due to an esm.sh URL that no longer finds the correct (ESM) module. Probably would be better to fix on higlass-text level, but in the meantime, this PR at least makes it so that the produced HTML files continue working.

Some more context: https://github.com/gosling-lang/gosling.js/issues/1103#issuecomment-2643447163

Fix #1103
Toward #

## Change List
 -

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
