### PR TITLE
fix(editor): deprecated versions of github workflows

### DIFF
--- a/.github/workflows/deploy-editor.yml
+++ b/.github/workflows/deploy-editor.yml
@@ -32,7 +32,7 @@ jobs:
                   echo "gosling.js.org" >> build/CNAME
               env:
                   NODE_OPTIONS: '--max_old_space_size=8192'
-            - uses: actions/upload-pages-artifact@v2
+            - uses: actions/upload-pages-artifact@v3
               with:
                   path: build
 
@@ -45,4 +45,4 @@ jobs:
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v2
+              uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fix #
Toward #

## Change List
 - The GitHub action won't deploy the editor unless we upgrade versions

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
