### PR TITLE
feat: expose the compiler function

### DIFF
--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -8,6 +8,7 @@ import type { UrlToFetchOptions } from 'src/core/gosling-component';
 import { renderHiGlass as createHiGlassModels } from './create-higlass-models';
 import { manageResponsiveSpecs } from './responsive';
 import type { IdTable } from '../api/track-and-view-ids';
+import { getTheme } from '@gosling-lang/gosling-theme';
 
 /** The callback function called everytime after the spec has been compiled */
 export type CompileCallback = (
@@ -18,15 +19,18 @@ export type CompileCallback = (
     idTable: IdTable
 ) => void;
 
+/**
+ * Process the Gosling specification, including normalization and filling in defaults.
+ */
 export function compile(
     spec: GoslingSpec,
     callback: CompileCallback,
-    templates: TemplateTrackDef[],
-    theme: Required<CompleteThemeDeep>,
+    templates: TemplateTrackDef[] = [],
+    theme: Required<CompleteThemeDeep> = getTheme('light'),
     containerStatus: {
         containerSize?: { width: number; height: number };
         containerParentSize?: { width: number; height: number };
-    },
+    } = {},
     urlToFetchOptions?: UrlToFetchOptions
 ) {
     // Make sure to keep the original spec as-is

--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -1,7 +1,7 @@
 import type { GoslingSpec, TemplateTrackDef, VisUnitApiData } from '@gosling-lang/gosling-schema';
 import type { HiGlassSpec } from '@gosling-lang/higlass-schema';
 import { traverseToFixSpecDownstream } from './spec-preprocess';
-import { replaceTrackTemplates } from '../core/utils/template';
+import { GoslingTemplates, replaceTrackTemplates } from '../core/utils/template';
 import { getRelativeTrackInfo, type Size } from './bounding-box';
 import type { CompleteThemeDeep } from '../core/utils/theme';
 import type { UrlToFetchOptions } from 'src/core/gosling-component';
@@ -25,7 +25,7 @@ export type CompileCallback = (
 export function compile(
     spec: GoslingSpec,
     callback: CompileCallback,
-    templates: TemplateTrackDef[] = [],
+    templates: TemplateTrackDef[] = GoslingTemplates,
     theme: Required<CompleteThemeDeep> = getTheme('light'),
     containerStatus: {
         containerSize?: { width: number; height: number };

--- a/src/exported-utils.ts
+++ b/src/exported-utils.ts
@@ -10,3 +10,4 @@ export { sanitizeChrName } from './data-fetchers/utils';
 // These are experimental and may be removed in the future
 export { convertToFlatTracks as _convertToFlatTracks } from './compiler/spec-preprocess';
 export { spreadTracksByData as _spreadTracksByData } from './core/utils/overlay';
+export { compile as _compile } from './compiler/compile';


### PR DESCRIPTION
Fix #
Toward #

## Change List
 - It will be beneficial to expose the `compile` function as part of `gosling.js/utils` since it enables calling the function in nodejs. This will be helpful when compiling a large number of specs to get the corresponding processed specs (which is the case for AltGosling). Users can use this by:

```ts
import { _compile } from 'gosling.js/utils';

_compile(spec, (hgSpec, trackSizes, processedSpec) => {
  console.log(hgSpec); // higlass spec
  console.log(trackSizes);
  console.log(processedSpec);
});
```
Since this is an experimental user API, the name starts with an underscore.

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
