### PR TITLE
fix: fix error when importing `higlass-text`

### DIFF
--- a/editor/html-template.ts
+++ b/editor/html-template.ts
@@ -19,7 +19,7 @@ export const getHtmlTemplate = (
           "react-dom": "https://esm.sh/react-dom@${reactVersion}",
           "pixi": "https://esm.sh/pixi.js@${pixiVersion}",
           "higlass": "https://esm.sh/higlass@${higlassVersion}?external=react,react-dom,pixi",
-          "gosling.js": "https://esm.sh/gosling.js@${goslingVersion}?external=react,react-dom,pixi,higlass,higlass-text"
+          "gosling.js": "https://esm.sh/gosling.js@${goslingVersion}?external=react,react-dom,pixi,higlass"
         }
       }
     </script>

--- a/editor/html-template.ts
+++ b/editor/html-template.ts
@@ -19,7 +19,6 @@ export const getHtmlTemplate = (
           "react-dom": "https://esm.sh/react-dom@${reactVersion}",
           "pixi": "https://esm.sh/pixi.js@${pixiVersion}",
           "higlass": "https://esm.sh/higlass@${higlassVersion}?external=react,react-dom,pixi",
-          "higlass-text": "https://esm.sh/higlass-text/es/index.js",
           "gosling.js": "https://esm.sh/gosling.js@${goslingVersion}?external=react,react-dom,pixi,higlass,higlass-text"
         }
       }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "generic-filehandle": "^3.0.1",
     "higlass": "^1.13.4",
     "higlass-register": "^0.3.0",
-    "higlass-text": "^0.1.1",
+    "higlass-text": "^0.1.7",
     "json-stringify-pretty-compact": "^2.0.0",
     "jspdf": "^2.3.1",
     "lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ dependencies:
     specifier: ^0.3.0
     version: 0.3.0
   higlass-text:
-    specifier: ^0.1.1
-    version: 0.1.6
+    specifier: ^0.1.7
+    version: 0.1.7
   json-stringify-pretty-compact:
     specifier: ^2.0.0
     version: 2.0.0
@@ -4133,8 +4133,8 @@ packages:
     resolution: {integrity: sha512-D4I+ATxFuTn+Q6p8Y9rUa+X3b3cqMqhu9Tya6uHtvgV5cs39Mk7i6Z+7PMA8YuwQd5gLMSxCm2lCyWmxRVBQsQ==}
     dev: false
 
-  /higlass-text@0.1.6:
-    resolution: {integrity: sha512-sjAROJfE38bSP72XncPTBV4AeYRs50N85OqRXooEwXF5zKVssBv1EKrvls0ralnSQ1aZX74cB/hTskbI91iRng==}
+  /higlass-text@0.1.7:
+    resolution: {integrity: sha512-TpmbvklUWBEApL1QDyu29+kI/Wo1rxG8QdDPM+uAuSKVRArSDa1FbO22SoTAxRmY/ynGLZXcK9Uidreeb0YUwg==}
     dependencies:
       d3-color: 3.1.0
       d3-scale: 4.0.2


### PR DESCRIPTION
Fix #1115 
Fix #1003

## Change List
 - Use the latest patch of `higlass-text` (0.1.7) to fix an error (https://github.com/higlass/higlass-text/pull/3).
 - Removed the separate import of `higlass-text` from the HTML template, which is not necessary anymore

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
