### PR TITLE
feat: add a separate entry just for compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "./utils": {
       "types": "./dist/src/exported-utils.d.ts",
       "import": "./dist/utils.js"
+    },
+    "./compiler": {
+      "types": "./dist/src/exported-compiler.d.ts",
+      "import": "./dist/compiler.js"
     }
   },
   "scripts": {

--- a/src/exported-compiler.ts
+++ b/src/exported-compiler.ts
@@ -1,0 +1,1 @@
+export { compile as _compile } from './compiler/compile';

--- a/vite.config.js
+++ b/vite.config.js
@@ -94,6 +94,7 @@ const esm = defineConfig({
             entry: {
                 gosling: path.resolve(__dirname, 'src/index.ts'),
                 utils: path.resolve(__dirname, 'src/exported-utils.ts'),
+                compiler: path.resolve(__dirname, 'src/exported-compiler.ts')
             },
             formats: ['es'],
         },


### PR DESCRIPTION
Expose the compiler function as a separate entry. Users can import this by

```ts
import { _compiler } from 'gosling.js/compiler';
```