### PR TITLE
ci(core): Add GH Action for experimental editor deploy

### DIFF
--- a/.github/workflows/deploy-editor-experimental.yml
+++ b/.github/workflows/deploy-editor-experimental.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches: [spatial]
+# These permissions are needed to interact with GitHub's OIDC Token endpoint.
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   Deploy:
@@ -20,11 +24,13 @@ jobs:
       - run: pnpm build-editor
 
       - name: Setup AWS CLI
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: us-east-1
-
-      - name: Sync build to S3 bucket
-          run: aws s3 sync build s3://my-bucket-name --delete
+      - name: Copy files to the s3 website content bucket
+        run:
+          aws s3 sync build s3://spatial.gosling-lang.org
+      - name: Invalidate CloudFront cache
+        run:
+          aws cloudfront create-invalidation --distribution-id ${{secrets.CF_DISTRIBUTION_ID}} --paths "/*"

--- a/.github/workflows/deploy-editor-experimental.yml
+++ b/.github/workflows/deploy-editor-experimental.yml
@@ -1,0 +1,30 @@
+name: Deploy Editor (experimental)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [spatial]
+
+jobs:
+  Deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: spatial
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: true
+
+      - run: pnpm build-editor
+
+      - name: Setup AWS CLI
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Sync build to S3 bucket
+          run: aws s3 sync build s3://my-bucket-name --delete


### PR DESCRIPTION
I actually think we should merge this into `main`, as it's just a GitHub action to configure that we want changes from `spatial` to run.

Still needs configuration of:

- [x] AWS credentials
- [x] bucket to deploy to

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
