### PR TITLE
feat: draw track outline for withinLink

### DIFF
--- a/src/core/mark/outline-circular.ts
+++ b/src/core/mark/outline-circular.ts
@@ -8,6 +8,8 @@ export function drawCircularOutlines(trackInfo: any, tm: GoslingTrackModel, them
     /* track spec */
     const spec = tm.spec();
 
+    if (spec.layout !== 'circular') return;
+
     /* track size */
     const [l, t] = trackInfo.position;
     const [trackWidth, trackHeight] = trackInfo.dimensions;
@@ -27,24 +29,21 @@ export function drawCircularOutlines(trackInfo: any, tm: GoslingTrackModel, them
     /* render */
     const g = trackInfo.pBackground;
 
-    if (!(spec.layout === 'circular' && spec.mark === 'withinLink')) {
-        // circular link marks usually use entire inner space
-        g.lineStyle(
-            spec.style?.outlineWidth ? spec.style?.outlineWidth / 2.5 : 0,
-            colorToHex(spec.style?.outline ?? '#DBDBDB'),
-            1, // 0.4, // alpha
-            1 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
-        );
-        g.beginFill(
-            colorToHex(tm.spec().style?.background ?? theme.track.background),
-            tm.spec().style?.backgroundOpacity ??
-                (!theme.track.background || theme.track.background === 'transparent' ? 0 : 1)
-        );
-        g.moveTo(posStartInner.x, posStartInner.y);
-        g.arc(cx, cy, trackInnerRadius, startRad, endRad, true);
-        g.arc(cx, cy, trackOuterRadius, endRad, startRad, false);
-        g.closePath();
-    }
+    g.lineStyle(
+        spec.style?.outlineWidth ? spec.style?.outlineWidth / 2.5 : 0,
+        colorToHex(spec.style?.outline ?? '#DBDBDB'),
+        1, // 0.4, // alpha
+        1 // alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+    );
+    g.beginFill(
+        colorToHex(tm.spec().style?.background ?? theme.track.background),
+        tm.spec().style?.backgroundOpacity ??
+            (!theme.track.background || theme.track.background === 'transparent' ? 0 : 1)
+    );
+    g.moveTo(posStartInner.x, posStartInner.y);
+    g.arc(cx, cy, trackInnerRadius, startRad, endRad, true);
+    g.arc(cx, cy, trackOuterRadius, endRad, startRad, false);
+    g.closePath();
 
     if (IsChannelDeep(spec.x) && spec.x.axis === 'top') {
         // outer line


### PR DESCRIPTION
Fix #1070
Toward #

## Change List
 - It was intended that the outline is not drawn for the withinLink mark, since `withinLink` uses the entire space of the track. But, I think it makes more sense to draw outline if users specify that (i.e., `outline: true`).

![Screenshot 2025-03-07 at 10 04 23 AM](https://github.com/user-attachments/assets/121b14e1-7d0f-42a0-8fb5-3fd8e9f92549)


## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
