### PR TITLE
fix: parsed genomic coordinates shouldn't be NaN even if assembly is not specified

### DIFF
--- a/editor/example/json-spec/spatial-layout.ts
+++ b/editor/example/json-spec/spatial-layout.ts
@@ -17,9 +17,11 @@ export const EX_SPEC_SPATIAL_MINIMAL: GoslingSpec = {
             },
             tracks: [
                 {
+                    color: { field: 'coord', type: 'quantitative' },
                     data: {
                         type: 'csv',
-                        url: 'https://gist.githubusercontent.com/sehilyi/29d1cfed56da3ed37370f31a508c8024/raw/9ab733bff25c4c539d86451dfb9d03d4e241d1ad/yeast_model.values.csv'
+                        url: 'https://gist.githubusercontent.com/sehilyi/29d1cfed56da3ed37370f31a508c8024/raw/9ab733bff25c4c539d86451dfb9d03d4e241d1ad/yeast_model.values.csv',
+                        genomicFields: ['position']
                     },
                     width: 500,
                     height: 500

--- a/src/compiler/_normalize-3d-spec.ts
+++ b/src/compiler/_normalize-3d-spec.ts
@@ -18,13 +18,23 @@ export function _fixTrackToWalkaround(t: Track) {
             chr,
             coord
         };
-        const dataTransform: JoinTransform = {
+        const dataTransform: Omit<JoinTransform, 'to'> = {
             type: 'join',
-            from: { url, chromosomeField: chr, genomicField: coord },
-            to: { startField: 'start', endField: 'end' }
+            from: { url, chromosomeField: chr, genomicField: coord }
         };
+        // TODO: need to support other data types as well
+        let to: JoinTransform['to'];
+        if (t.data?.type === 'bigwig') {
+            to = { startField: 'start', endField: 'end' };
+        } else if (t.data?.type === 'csv') {
+            // TODO: Not the reliable way to select two data fields corresponding to start and end positions
+            const startField = t.data.genomicFields?.[0] ?? 'unknown';
+            const endField = t.data.genomicFields?.[1] ?? undefined;
+            to = { startField, endField };
+        }
+
         // @ts-expect-error
-        t.dataTransform = [dataTransform];
+        t.dataTransform = [{ ...dataTransform, to }];
         t.layout = 'spatial';
     } else if (typeof layout == 'object') {
         t.layout = layout.type;

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -114,7 +114,6 @@ export async function joinData(
     };
     const fromData = await fetchDataIfNeeded(from.url);
 
-    console.error(fromData);
     // a very naive approach to join two files
     const joinned: Datum[] = fromData.map(f => {
         // TODO: to be most accurate, need to find all data records matching and aggregate data
@@ -125,7 +124,6 @@ export async function joinData(
         }) ?? { value: 0 };
         return { ...found, ...f };
     });
-    console.error(joinned);
     return joinned;
 }
 

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -98,7 +98,6 @@ export async function joinData(
     assembly: Assembly = 'hg19'
 ): Promise<Datum[]> {
     const { from, to } = transform;
-
     const fetchDataIfNeeded = async (url: string) => {
         if (FETCH_CACHE[url]) return FETCH_CACHE[url];
         const response = await fetch(url);
@@ -108,14 +107,14 @@ export async function joinData(
         for (const d of data) {
             const chrName = d[from.chromosomeField];
             const chromPosition = d[from.genomicField];
-            d[from.genomicField] = chromSizes.interval[chrName]?.[0] + +chromPosition;
+            d[from.genomicField] = (chromSizes.interval[chrName]?.[0] ?? 0) + +chromPosition;
         }
-        console.warn(chromSizes);
         FETCH_CACHE[url] = data;
         return data;
     };
     const fromData = await fetchDataIfNeeded(from.url);
 
+    console.error(fromData);
     // a very naive approach to join two files
     const joinned: Datum[] = fromData.map(f => {
         // TODO: to be most accurate, need to find all data records matching and aggregate data
@@ -126,6 +125,7 @@ export async function joinData(
         }) ?? { value: 0 };
         return { ...found, ...f };
     });
+    console.error(joinned);
     return joinned;
 }
 

--- a/src/core/utils/data-transform.ts
+++ b/src/core/utils/data-transform.ts
@@ -113,16 +113,19 @@ export async function joinData(
         return data;
     };
     const fromData = await fetchDataIfNeeded(from.url);
-
     // a very naive approach to join two files
     const joinned: Datum[] = fromData.map(f => {
         // TODO: to be most accurate, need to find all data records matching and aggregate data
         const found = toData.find(t => {
-            const start = +t[to.startField] <= +f[from.genomicField];
-            const end = to.endField ? +t[to.endField] >= +f[from.genomicField] : true;
-            return start && end;
+            if (to.endField) {
+                const start = +t[to.startField] <= +f[from.genomicField];
+                const end = +t[to.endField] >= +f[from.genomicField];
+                return start && end;
+            } else {
+                return +t[to.startField] == +f[from.genomicField];
+            }
         }) ?? { value: 0 };
-        return { ...found, ...f };
+        return { ...f, ...found };
     });
     return joinned;
 }


### PR DESCRIPTION
With this patch, the join transform should work with CSV files.

## Screenshots
![Screenshot 2025-04-03 at 5 22 27 PM](https://github.com/user-attachments/assets/fda1405e-6912-491e-9a92-49a7eb0e1fc0)

![Screenshot 2025-04-03 at 5 22 35 PM](https://github.com/user-attachments/assets/8b84ed40-e1b2-40d2-98ec-f4e874e3bbce)
