### PR TITLE
ci(core): Prefer uv for Python bootstrapping in Gos workflow

### DIFF
--- a/.github/workflows/update-gos.yml
+++ b/.github/workflows/update-gos.yml
@@ -8,9 +8,14 @@ on:
   release:
     types: [published]
 
+
+env:
+  # Deno not necessary for running auto-gen scripts
+  SKIP_DENO_BUILD: "1"
+
 jobs:
 
-  sync:
+  Sync:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1

--- a/.github/workflows/update-gos.yml
+++ b/.github/workflows/update-gos.yml
@@ -26,12 +26,8 @@ jobs:
         with:
           app-id: ${{ vars.GOSLING_BOT_APP_ID }}
           private-key: ${{ secrets.GOSLING_BOT_APP_KEY }}
-
-      - name: Check token scopes
-        run: |
-          curl -s -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
-               -H "Accept: application/vnd.github+json" \
-               https://api.github.com/rate_limit
+          owner: gosling-lang
+          repositories: gos
 
       - name: Checkout gosling-lang/gos (with submodules)
         uses: actions/checkout@v4

--- a/.github/workflows/update-gos.yml
+++ b/.github/workflows/update-gos.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+  pull-requests: write
 
 env:
   # Deno not necessary for running auto-gen scripts
@@ -23,6 +26,12 @@ jobs:
         with:
           app-id: ${{ vars.GOSLING_BOT_APP_ID }}
           private-key: ${{ secrets.GOSLING_BOT_APP_KEY }}
+
+      - name: Check token scopes
+        run: |
+          curl -s -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+               -H "Accept: application/vnd.github+json" \
+               https://api.github.com/rate_limit
 
       - name: Checkout gosling-lang/gos (with submodules)
         uses: actions/checkout@v4

--- a/.github/workflows/update-gos.yml
+++ b/.github/workflows/update-gos.yml
@@ -33,12 +33,11 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
+      - uses: astral-sh/setup-uv@v5
+
       - run: |
-          python -m pip install .
-          python tools/generate_schema_wrapper.py ${{ steps.tag.outputs.tag_name }}
+          uv run tools/generate_schema_wrapper.py ${{ steps.tag.outputs.tag_name }}
+          uv run tools/generate_api_docs.py
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/update-gos.yml
+++ b/.github/workflows/update-gos.yml
@@ -13,11 +13,16 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GOSLING_BOT_APP_ID }}
+          private-key: ${{ secrets.GOSLING_BOT_APP_KEY }}
 
       - name: Checkout gosling-lang/gos (with submodules)
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: gosling-lang/gos
           submodules: true
 
@@ -42,7 +47,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "Bump Gosling.js to `${{ steps.tag.outputs.tag_name }}`"
           title: "Bump Gosling.js to `${{ steps.tag.outputs.tag_name }}`"
           body: "Automated PR. Update binding for Gosling.js `${{ steps.tag.outputs.tag_name }}`."

--- a/.github/workflows/update-gos.yml
+++ b/.github/workflows/update-gos.yml
@@ -50,7 +50,7 @@ jobs:
           uv run tools/generate_api_docs.py
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "Bump Gosling.js to `${{ steps.tag.outputs.tag_name }}`"


### PR DESCRIPTION
I think the personal access token (`secrets.PAT`) still needs refreshing for this to workflow to work again. But not the workflow mimics the instructions in the Gos README.

To be clear, this GitHub action isn't necessary. Manual syncing works just fine, it's just it can be easy to forget when to sync and action was an attempt to try to make that easy.

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
