### PR TITLE
ci: update the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,17 +21,3 @@ jobs:
       - run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-            fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 20
-      - run: npx changelogithub
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,12 +138,14 @@ If there is an example you would like to add to the editor example library, plea
 
 ## Bumping Gosling.js
 
-GitHub Action handles bumping the version of Gosling.js. The pattern looks like the following:
+To increase the version of Gosling.js:
 
 ```
 pnpm version patch # or minor or major
-git push origin main --tags
+git push origin main
 ```
+
+And then create a [release](https://github.com/gosling-lang/gosling.js/releases) through the GitHub UI using the version name as the tag (e.g., `v1.0.3`). This will trigger the GitHub workflow to publish a package.
 
 # Internal Explanations  
 ## How does a Gosling spec get turned into a HiGlass spec?


### PR DESCRIPTION
## Change

This PR slightly changes the release workflow, which now follows Gos and HiGlass. Previously, release notes were automatically generated by GitHub based on commit messages. However, such notes are not very helpful in understanding all the changes made. With changes in the PR, we will write a release note ourselves (based on the draft automatically generated by GitHub), and after creating a release note, GitHub Actions will handle the publishing of the gosling.js library.

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
