### PR TITLE
feat: re-implement `(un)subscribe` APIs

### DIFF
--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -311,11 +311,12 @@ function Editor(props: RouteComponentProps) {
     // publish event listeners to Gosling.js
     useEffect(() => {
         if (gosRef.current) {
+            // gosRef.current.api.zoomTo('bam-1', `chr${data.data.chr1}:${data.data.start1}-${data.data.end1}`, 2000);
+            // gosRef.current.api.zoomTo('bam-2', `chr${data.data.chr2}:${data.data.start2}-${data.data.end2}`, 2000);
+            /*
             gosRef.current.api.subscribe('rawData', (type, data) => {
                 console.warn('rawData', type, data);
             });
-            // gosRef.current.api.zoomTo('bam-1', `chr${data.data.chr1}:${data.data.start1}-${data.data.end1}`, 2000);
-            // gosRef.current.api.zoomTo('bam-2', `chr${data.data.chr2}:${data.data.start2}-${data.data.end2}`, 2000);
             // TODO: show messages on the right-bottom of the editor
             gosRef.current.api.subscribe('mouseOver', (type, eventData) => {
                 console.warn(type, eventData.id, eventData.genomicPosition, eventData.data);
@@ -345,14 +346,17 @@ function Editor(props: RouteComponentProps) {
             gosRef.current.api.subscribe('onNewView', (type, eventData) => {
                 console.warn(type, eventData);
             });
+            */
         }
         return () => {
+            /*
             gosRef.current?.api.unsubscribe('rawData');
             gosRef.current?.api.unsubscribe('mouseOver');
             gosRef.current?.api.unsubscribe('click');
             gosRef.current?.api.unsubscribe('rangeSelect');
             gosRef.current?.api.unsubscribe('trackClick');
             gosRef.current?.api.unsubscribe('location');
+            */
         };
     }, [gosRef.current]);
 
@@ -699,6 +703,8 @@ function Editor(props: RouteComponentProps) {
 
     // Layers to be shown on top of the Gosling visualization to show the hiererchy of Gosling views and tracks
     const VisHierarchy = useMemo(() => {
+        return <></>;
+
         const tracksAndViews = gosRef.current?.api.getTracksAndViews();
         const maxHeight = Math.max(...(tracksAndViews?.map(d => d.shape.height) ?? []));
         return (

--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -24,7 +24,7 @@ import { traverseTracksAndViews } from '../src/compiler/spec-preprocess';
 import { examples, type Example } from './example';
 import EditorPanel, { type EditorLangauge } from './EditorPanel';
 import EditorExamples from './EditorExamples';
-import { GoslingComponent } from '../demo/GoslingComponent';
+import { GoslingComponent, type GoslingRef } from '../demo/gosling-component';
 
 import './Editor.css';
 import { uuid } from '../src/core/utils/uuid';
@@ -296,7 +296,7 @@ function Editor(props: RouteComponentProps) {
 
     // for using HiGlass JS API
     // const hgRef = useRef<any>();
-    const gosRef = useRef<gosling.GoslingRef>(null);
+    const gosRef = useRef<GoslingRef>(null);
 
     const debounceCodeEdit = useRef(
         debounce((code: string, language: EditorLangauge) => {
@@ -311,46 +311,48 @@ function Editor(props: RouteComponentProps) {
     // publish event listeners to Gosling.js
     useEffect(() => {
         if (gosRef.current) {
-            // gosRef.current.api.subscribe('rawdata', (type, data) => {
-            // console.log('rawdata', data);
+            gosRef.current.api.subscribe('rawData', (type, data) => {
+                console.warn('rawData', type, data);
+            });
             // gosRef.current.api.zoomTo('bam-1', `chr${data.data.chr1}:${data.data.start1}-${data.data.end1}`, 2000);
             // gosRef.current.api.zoomTo('bam-2', `chr${data.data.chr2}:${data.data.start2}-${data.data.end2}`, 2000);
-            // console.log('click', data.data);
             // TODO: show messages on the right-bottom of the editor
-            // gosRef.current.api.subscribe('mouseOver', (type, eventData) => {
-            //     console.warn(type, eventData.id, eventData.genomicPosition, eventData.data);
-            //     // setMouseEventInfo({ type: 'mouseOver', data: eventData.data, position: eventData.genomicPosition });
-            // });
-            // gosRef.current.api.subscribe('click', (type, eventData) => {
-            //     console.warn(type, eventData.id, eventData.genomicPosition, eventData.data);
-            //     // setMouseEventInfo({ type: 'click', data: eventData.data, position: eventData.genomicPosition });
-            // });
+            gosRef.current.api.subscribe('mouseOver', (type, eventData) => {
+                console.warn(type, eventData.id, eventData.genomicPosition, eventData.data);
+                //     // setMouseEventInfo({ type: 'mouseOver', data: eventData.data, position: eventData.genomicPosition });
+            });
+            gosRef.current.api.subscribe('click', (type, eventData) => {
+                console.warn(type, eventData.id, eventData.genomicPosition, eventData.data);
+                // setMouseEventInfo({ type: 'click', data: eventData.data, position: eventData.genomicPosition });
+            });
             // Range Select API
-            // gosRef.current.api.subscribe('rangeSelect', (type, eventData) => {
-            //     console.warn(type, eventData.id, eventData.genomicRange, eventData.data);
-            // });
+            gosRef.current.api.subscribe('rangeSelect', (type, eventData) => {
+                console.warn(type, eventData.id, eventData.genomicRange, eventData.data);
+            });
             // Mouse click on a track
-            // gosRef.current.api.subscribe('trackClick', (type, eventData) => {
-            //     console.warn(type, eventData.id, eventData.spec, eventData.shape);
-            // });
+            gosRef.current.api.subscribe('trackClick', (type, eventData) => {
+                console.warn(type, eventData.id, eventData.spec, eventData.shape);
+            });
             // Location API
-            // gosRef.current.api.subscribe('location', (type, eventData) => {
-            //     console.warn(type, eventData.id, eventData.genomicRange);
+            gosRef.current.api.subscribe('location', (type, eventData) => {
+                console.warn(type, eventData.id, eventData.genomicRange);
+            });
             // New Track
-            // gosRef.current.api.subscribe('onNewTrack', (type, eventData) => {
-            //     console.warn(type, eventData);
-            // });
+            gosRef.current.api.subscribe('onNewTrack', (type, eventData) => {
+                console.warn(type, eventData);
+            });
             // New View
-            // gosRef.current.api.subscribe('onNewView', (type, eventData) => {
-            //     console.warn(type, eventData);
-            // });
+            gosRef.current.api.subscribe('onNewView', (type, eventData) => {
+                console.warn(type, eventData);
+            });
         }
         return () => {
-            // gosRef.current?.api.unsubscribe('mouseOver');
-            // gosRef.current?.api.unsubscribe('click');
-            // gosRef.current?.api.unsubscribe('rangeSelect');
-            // gosRef.current?.api.unsubscribe('trackClick');
-            // gosRef.current?.api.unsubscribe('location');
+            gosRef.current?.api.unsubscribe('rawData');
+            gosRef.current?.api.unsubscribe('mouseOver');
+            gosRef.current?.api.unsubscribe('click');
+            gosRef.current?.api.unsubscribe('rangeSelect');
+            gosRef.current?.api.unsubscribe('trackClick');
+            gosRef.current?.api.unsubscribe('location');
         };
     }, [gosRef.current]);
 
@@ -588,10 +590,10 @@ function Editor(props: RouteComponentProps) {
             typeof goslingSpec?.responsiveSize === 'undefined'
                 ? false
                 : typeof goslingSpec?.responsiveSize === 'boolean'
-                  ? goslingSpec?.responsiveSize === true
-                  : typeof goslingSpec?.responsiveSize === 'object'
-                    ? goslingSpec?.responsiveSize.width === true || goslingSpec?.responsiveSize.height === true
-                    : false;
+                    ? goslingSpec?.responsiveSize === true
+                    : typeof goslingSpec?.responsiveSize === 'object'
+                        ? goslingSpec?.responsiveSize.width === true || goslingSpec?.responsiveSize.height === true
+                        : false;
         if (newIsResponsive !== isResponsive && newIsResponsive) {
             setScreenSize(undefined); // reset the screen
             setVisibleScreenSize(undefined);
@@ -738,25 +740,25 @@ function Editor(props: RouteComponentProps) {
         <>
             <div
                 className={`demo-navbar ${theme === 'dark' ? 'dark' : ''}`}
-                // To test APIs, uncomment the following code.
-                // onClick={() => {
-                //     if (!gosRef.current) return;
-                // // ! Be aware that the first view is for the title/subtitle track. So navigation API does not work.
-                // const id = gosRef.current.api.getViewIds()?.[1]; //'view-1';
-                // if(id) {
-                //     gosRef.current.api.zoomToExtent(id);
-                // }
-                //
-                // // Static visualization rendered in canvas
-                // const { canvas } = gosRef.current.api.getCanvas({
-                //     resolution: 1,
-                //     transparentBackground: true,
-                // });
-                // const testDiv = document.getElementById('preview-container');
-                // if(canvas && testDiv) {
-                //     testDiv.appendChild(canvas);
-                // }
-                // }}
+            // To test APIs, uncomment the following code.
+            // onClick={() => {
+            //     if (!gosRef.current) return;
+            // // ! Be aware that the first view is for the title/subtitle track. So navigation API does not work.
+            // const id = gosRef.current.api.getViewIds()?.[1]; //'view-1';
+            // if(id) {
+            //     gosRef.current.api.zoomToExtent(id);
+            // }
+            //
+            // // Static visualization rendered in canvas
+            // const { canvas } = gosRef.current.api.getCanvas({
+            //     resolution: 1,
+            //     transparentBackground: true,
+            // });
+            // const testDiv = document.getElementById('preview-container');
+            // if(canvas && testDiv) {
+            //     testDiv.appendChild(canvas);
+            // }
+            // }}
             >
                 <button
                     style={{ cursor: 'pointer', lineHeight: '40px' }}
@@ -1244,8 +1246,8 @@ function Editor(props: RouteComponentProps) {
                                             {'REFRESH DATA'}
                                         </button>
                                         {previewData.current.length > selectedPreviewData &&
-                                        previewData.current[selectedPreviewData] &&
-                                        previewData.current[selectedPreviewData].data.length > 0 ? (
+                                            previewData.current[selectedPreviewData] &&
+                                            previewData.current[selectedPreviewData].data.length > 0 ? (
                                             <>
                                                 <div className="editor-data-preview-tab">
                                                     {previewData.current.map((d: PreviewData, i: number) => (
@@ -1306,9 +1308,8 @@ function Editor(props: RouteComponentProps) {
                 </Allotment>
                 {/* Description Panel */}
                 <div
-                    className={`description ${hideDescription ? '' : 'description-shadow '}${
-                        isDescResizing ? '' : 'description-transition'
-                    } ${theme === 'dark' ? 'dark' : ''}`}
+                    className={`description ${hideDescription ? '' : 'description-shadow '}${isDescResizing ? '' : 'description-transition'
+                        } ${theme === 'dark' ? 'dark' : ''}`}
                     style={{ width: !description || hideDescription ? 0 : descPanelWidth }}
                 >
                     <div

--- a/editor/example/json-spec/mouse-event.ts
+++ b/editor/example/json-spec/mouse-event.ts
@@ -121,7 +121,8 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                 }
             ]
         },
-        {
+        /*
+             {
             xDomain: { chromosome: 'chr3', interval: [52168000, 52890000] },
             tracks: [
                 {
@@ -182,7 +183,7 @@ export const EX_SPEC_MOUSE_EVENT: GoslingSpec = {
                     }
                 }
             ]
-        },
+        },*/
         {
             xDomain: { interval: [1, 1000000000] },
             tracks: [

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -50,6 +50,14 @@ export interface GoslingApi {
     };
 }
 
+// TODO: After fully implementing this, remove `Partial` from the return type
+export function createApiV2(): Pick<GoslingApi, 'subscribe' | 'unsubscribe'> & Partial<GoslingApi> {
+    return {
+        subscribe,
+        unsubscribe
+    };
+}
+
 export function createApi(
     hg: Readonly<HiGlassApi>,
     tracksAndViews: readonly VisUnitApiData[],

--- a/src/tracks/gosling-track/gosling-track-plot.ts
+++ b/src/tracks/gosling-track/gosling-track-plot.ts
@@ -51,10 +51,10 @@ export class GoslingTrack extends GoslingTrackClass implements Plot {
         // Setup the context object
         const context: GoslingTrackContext = {
             scene: pixiContainer,
-            id: 'test',
-            viewUid: 'test',
+            id: options.id,
+            viewUid: options.id, // V2: Is this used anywhere?
             // getLockGroupExtrema: () => null,
-            onMouseMoveZoom: () => {},
+            onMouseMoveZoom: () => { },
             // chromInfoPath: '',
             dataFetcher,
             //dataConfig: {
@@ -62,10 +62,10 @@ export class GoslingTrack extends GoslingTrackClass implements Plot {
             // tilesetUid: 'UvVPeLHuRDiYA3qwFlm7xQ'
             // coordSystem: "hg19",
             // },
-            animate: () => {},
-            onValueScaleChanged: () => {},
-            handleTilesetInfoReceived: () => {},
-            onTrackOptionsChanged: () => {},
+            animate: () => { },
+            onValueScaleChanged: () => { },
+            handleTilesetInfoReceived: () => { },
+            onTrackOptionsChanged: () => { },
             pubSub: fakePubSub,
             isValueScaleLocked: () => false,
             svgElement: svgElement,
@@ -137,10 +137,10 @@ export class GoslingTrack extends GoslingTrackClass implements Plot {
         // When the mouse moves over the overlay div, update the tooltip position
         this.domOverlay.addEventListener('mousemove', (e: MouseEvent) => {
             const { x, y } = getRelativePosition(this.domOverlay, e);
-            this.onMouseMove(x);
+            this.onMouseMove(x, y);
             // Update the tooltip position
-            tooltipDiv.style.left = `${x}px`;
-            tooltipDiv.style.top = `${y}px`;
+            tooltipDiv.style.left = `${x + 10}px`;
+            tooltipDiv.style.top = `${y + 10}px`;
             const tooltip = this.getMouseOverHtml(x, y);
             if (tooltip === '' || this.isRangeBrushActivated) {
                 tooltipDiv.innerHTML = '';

--- a/src/tracks/gosling-track/gosling-track.ts
+++ b/src/tracks/gosling-track/gosling-track.ts
@@ -301,8 +301,8 @@ export class GoslingTrackClass extends TiledPixiTrack<Tile, GoslingTrackOptions>
         this.drawTile(tile);
     }
 
-    override updateTile(/* tile: Tile */) {} // Never mind about this function for the simplicity.
-    renderTile(/* tile: Tile */) {} // Never mind about this function for the simplicity.
+    override updateTile(/* tile: Tile */) { } // Never mind about this function for the simplicity.
+    renderTile(/* tile: Tile */) { } // Never mind about this function for the simplicity.
 
     /**
      * Display a tile upon receiving a new one or when explicitly called by a developer, e.g., calling
@@ -483,9 +483,9 @@ export class GoslingTrackClass extends TiledPixiTrack<Tile, GoslingTrackOptions>
         const genomicRange = newXScale
             .domain()
             .map(absPos => getRelativeGenomicPosition(absPos, this.#assembly, true)) as [
-            GenomicPosition,
-            GenomicPosition
-        ];
+                GenomicPosition,
+                GenomicPosition
+            ];
         publish('location', {
             id: this.#viewUid,
             genomicRange: genomicRange


### PR DESCRIPTION
Toward #1161 

## Change List
 - Re-implement `(un)subscribe` APIs (The user API remains the same).

## Note
- Since we do not need to use HiGlass' view IDs, we related code can be largely removed and cleaned up, such as https://github.com/gosling-lang/gosling.js/blob/v2/src/api/track-and-view-ids.ts
- After implementing all APIs, it would be good to add tests so that all APIs work as expected.
