### PR TITLE
feat: support tracks- and views-related APIs

### DIFF
--- a/demo/gosling-component.tsx
+++ b/demo/gosling-component.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, type RefObject, useImperativeHandle } from 'react';
 import { PixiManager } from '@pixi-manager';
-import { compile, type CompileResult, type UrlToFetchOptions } from '../src/compiler/compile';
+import { compile, type UrlToFetchOptions } from '../src/compiler/compile';
 import { getTheme } from '../src/core/utils/theme';
 import { createTrackDefs } from './track-def/main';
 import { renderTrackDefs } from './renderer/main';
@@ -18,10 +18,11 @@ interface GoslingComponentProps {
     theme?: Theme;
     urlToFetchOptions?: UrlToFetchOptions;
     ref?: RefObject<GoslingRef>;
+    visualized?: () => void;
 }
 
 export function GoslingComponent(props: GoslingComponentProps) {
-    const { spec, urlToFetchOptions, theme = 'light', ref } = props;
+    const { spec, urlToFetchOptions, theme = 'light', ref, visualized = () => {} } = props;
 
     const [compiledResults, setCompiledResults] = useState<ReturnType<typeof compile>>();
 
@@ -29,6 +30,10 @@ export function GoslingComponent(props: GoslingComponentProps) {
         return {
             api: createApiV2(compiledResults)
         };
+    }, [compiledResults]);
+
+    useEffect(() => {
+        visualized();
     }, [compiledResults]);
 
     // Pixi manager should persist between render calls. Otherwise performance degrades greatly.
@@ -41,7 +46,7 @@ export function GoslingComponent(props: GoslingComponentProps) {
         if (!pixiManager) {
             const canvasWidth = 1000,
                 canvasHeight = 1000; // These initial sizes don't matter because the size will be updated
-            const pixiManager = new PixiManager(canvasWidth, canvasHeight, plotElement, () => { });
+            const pixiManager = new PixiManager(canvasWidth, canvasHeight, plotElement, () => {});
             const compileResult = renderGosling(spec, plotElement, pixiManager, theme, urlToFetchOptions);
             setCompiledResults(compileResult);
             setPixiManager(pixiManager);
@@ -113,7 +118,7 @@ function renderGosling(
 /** Debounces the resize observer */
 function debounce(f: (arg0: unknown) => unknown, delay: number) {
     let timer = 0;
-    return function(...args: [arg0: unknown]) {
+    return function (...args: [arg0: unknown]) {
         clearTimeout(timer);
         // @ts-expect-error
         timer = setTimeout(() => f.apply(this, args), delay);

--- a/demo/gosling-component.tsx
+++ b/demo/gosling-component.tsx
@@ -89,6 +89,7 @@ function renderGosling(
                 pixiManager.clearAll();
                 const rescaledTracks = rescaleTrackInfos(
                     trackInfos,
+                    // XXX: this needs to be exposed as GoslingComponent's parameter
                     containerWidth - 100, // minus 100 to account for the padding
                     containerHeight - 100,
                     isResponsiveWidth,

--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -14,7 +14,7 @@ import 'allotment/dist/style.css';
 import { debounce, isEqual } from 'lodash-es';
 import stripJsonComments from 'strip-json-comments';
 import JSONCrush from 'jsoncrush';
-import type { Datum } from '@gosling-lang/gosling-schema';
+import type { Datum, VisUnitApiData } from '@gosling-lang/gosling-schema';
 import { Themes } from '@gosling-lang/gosling-theme';
 
 import { ICONS, type ICON_INFO } from './icon';
@@ -251,6 +251,9 @@ function Editor(props: RouteComponentProps) {
     const [description, setDescription] = useState<string | null>();
     const [showViews, setShowViews] = useState(false);
     const [expertMode, setExpertMode] = useState(false);
+
+    // Gosling Tracks and views that are obtained through Gosling API
+    const [tracksAndViews, setTracksAndViews] = useState<VisUnitApiData[]>();
 
     // This parameter only matter when a markdown description was loaded from a gist but the user wants to hide it
     const [hideDescription, setHideDescription] = useState<boolean>(IS_SMALL_SCREEN || false);
@@ -594,10 +597,10 @@ function Editor(props: RouteComponentProps) {
             typeof goslingSpec?.responsiveSize === 'undefined'
                 ? false
                 : typeof goslingSpec?.responsiveSize === 'boolean'
-                    ? goslingSpec?.responsiveSize === true
-                    : typeof goslingSpec?.responsiveSize === 'object'
-                        ? goslingSpec?.responsiveSize.width === true || goslingSpec?.responsiveSize.height === true
-                        : false;
+                  ? goslingSpec?.responsiveSize === true
+                  : typeof goslingSpec?.responsiveSize === 'object'
+                    ? goslingSpec?.responsiveSize.width === true || goslingSpec?.responsiveSize.height === true
+                    : false;
         if (newIsResponsive !== isResponsive && newIsResponsive) {
             setScreenSize(undefined); // reset the screen
             setVisibleScreenSize(undefined);
@@ -703,7 +706,6 @@ function Editor(props: RouteComponentProps) {
 
     // Layers to be shown on top of the Gosling visualization to show the hiererchy of Gosling views and tracks
     const VisHierarchy = useMemo(() => {
-        const tracksAndViews = gosRef.current?.api.getTracksAndViews();
         console.warn('tracks', tracksAndViews);
         const maxHeight = Math.max(...(tracksAndViews?.map(d => d.shape.height) ?? []));
         return (
@@ -738,32 +740,32 @@ function Editor(props: RouteComponentProps) {
                     })}
             </div>
         );
-    }, [demo]);
+    }, [tracksAndViews]);
 
     // console.log('editor.render()');
     return (
         <>
             <div
                 className={`demo-navbar ${theme === 'dark' ? 'dark' : ''}`}
-            // To test APIs, uncomment the following code.
-            // onClick={() => {
-            //     if (!gosRef.current) return;
-            // // ! Be aware that the first view is for the title/subtitle track. So navigation API does not work.
-            // const id = gosRef.current.api.getViewIds()?.[1]; //'view-1';
-            // if(id) {
-            //     gosRef.current.api.zoomToExtent(id);
-            // }
-            //
-            // // Static visualization rendered in canvas
-            // const { canvas } = gosRef.current.api.getCanvas({
-            //     resolution: 1,
-            //     transparentBackground: true,
-            // });
-            // const testDiv = document.getElementById('preview-container');
-            // if(canvas && testDiv) {
-            //     testDiv.appendChild(canvas);
-            // }
-            // }}
+                // To test APIs, uncomment the following code.
+                // onClick={() => {
+                //     if (!gosRef.current) return;
+                // // ! Be aware that the first view is for the title/subtitle track. So navigation API does not work.
+                // const id = gosRef.current.api.getViewIds()?.[1]; //'view-1';
+                // if(id) {
+                //     gosRef.current.api.zoomToExtent(id);
+                // }
+                //
+                // // Static visualization rendered in canvas
+                // const { canvas } = gosRef.current.api.getCanvas({
+                //     resolution: 1,
+                //     transparentBackground: true,
+                // });
+                // const testDiv = document.getElementById('preview-container');
+                // if(canvas && testDiv) {
+                //     testDiv.appendChild(canvas);
+                // }
+                // }}
             >
                 <button
                     style={{ cursor: 'pointer', lineHeight: '40px' }}
@@ -1197,7 +1199,16 @@ function Editor(props: RouteComponentProps) {
                                             background: isResponsive ? 'white' : 'none'
                                         }}
                                     >
-                                        <GoslingComponent ref={gosRef} spec={goslingSpec} theme={'light'} />
+                                        <GoslingComponent
+                                            ref={gosRef}
+                                            spec={goslingSpec}
+                                            theme={'light'}
+                                            visualized={() => {
+                                                console.warn('just visualized');
+                                                const tracksAndViews = gosRef.current?.api.getTracksAndViews();
+                                                setTracksAndViews(tracksAndViews);
+                                            }}
+                                        />
                                         {showViews && !isResponsive ? VisHierarchy : null}
                                     </div>
                                     {/* {expertMode && false ? (
@@ -1251,8 +1262,8 @@ function Editor(props: RouteComponentProps) {
                                             {'REFRESH DATA'}
                                         </button>
                                         {previewData.current.length > selectedPreviewData &&
-                                            previewData.current[selectedPreviewData] &&
-                                            previewData.current[selectedPreviewData].data.length > 0 ? (
+                                        previewData.current[selectedPreviewData] &&
+                                        previewData.current[selectedPreviewData].data.length > 0 ? (
                                             <>
                                                 <div className="editor-data-preview-tab">
                                                     {previewData.current.map((d: PreviewData, i: number) => (
@@ -1313,8 +1324,9 @@ function Editor(props: RouteComponentProps) {
                 </Allotment>
                 {/* Description Panel */}
                 <div
-                    className={`description ${hideDescription ? '' : 'description-shadow '}${isDescResizing ? '' : 'description-transition'
-                        } ${theme === 'dark' ? 'dark' : ''}`}
+                    className={`description ${hideDescription ? '' : 'description-shadow '}${
+                        isDescResizing ? '' : 'description-transition'
+                    } ${theme === 'dark' ? 'dark' : ''}`}
                     style={{ width: !description || hideDescription ? 0 : descPanelWidth }}
                 >
                     <div

--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -703,9 +703,8 @@ function Editor(props: RouteComponentProps) {
 
     // Layers to be shown on top of the Gosling visualization to show the hiererchy of Gosling views and tracks
     const VisHierarchy = useMemo(() => {
-        return <></>;
-
         const tracksAndViews = gosRef.current?.api.getTracksAndViews();
+        console.warn('tracks', tracksAndViews);
         const maxHeight = Math.max(...(tracksAndViews?.map(d => d.shape.height) ?? []));
         return (
             <div style={{ position: 'absolute', top: '60px', left: '60px', height: maxHeight, pointerEvents: 'none' }}>

--- a/editor/Editor.tsx
+++ b/editor/Editor.tsx
@@ -706,10 +706,12 @@ function Editor(props: RouteComponentProps) {
 
     // Layers to be shown on top of the Gosling visualization to show the hiererchy of Gosling views and tracks
     const VisHierarchy = useMemo(() => {
-        console.warn('tracks', tracksAndViews);
         const maxHeight = Math.max(...(tracksAndViews?.map(d => d.shape.height) ?? []));
+        const padding = '50px'; // Padding GoslingComponent
         return (
-            <div style={{ position: 'absolute', top: '60px', left: '60px', height: maxHeight, pointerEvents: 'none' }}>
+            <div
+                style={{ position: 'absolute', top: padding, left: padding, height: maxHeight, pointerEvents: 'none' }}
+            >
                 {tracksAndViews
                     ?.sort(a => (a.type === 'track' ? 1 : -1))
                     ?.map(d => {
@@ -1192,6 +1194,7 @@ function Editor(props: RouteComponentProps) {
                                     <div
                                         style={{
                                             width: isResponsive && screenSize?.width ? screenSize.width : '100%',
+                                            position: 'relative',
                                             height:
                                                 isResponsive && screenSize?.height
                                                     ? screenSize.height
@@ -1204,7 +1207,6 @@ function Editor(props: RouteComponentProps) {
                                             spec={goslingSpec}
                                             theme={'light'}
                                             visualized={() => {
-                                                console.warn('just visualized');
                                                 const tracksAndViews = gosRef.current?.api.getTracksAndViews();
                                                 setTracksAndViews(tracksAndViews);
                                             }}

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -56,7 +56,14 @@ export function createApiV2(
     compileResult?: ReturnType<typeof compile>
 ): Pick<
     GoslingApi,
-    'getTracksAndViews' | 'getTracks' | 'getTrackIds' | 'getTrack' | 'getViews' | 'getView' | 'subscribe' | 'unsubscribe'
+    | 'getTracksAndViews'
+    | 'getTracks'
+    | 'getTrackIds'
+    | 'getTrack'
+    | 'getViews'
+    | 'getView'
+    | 'subscribe'
+    | 'unsubscribe'
 > {
     const tracksAndViews = compileResult?.tracksAndViews ?? [];
     const getTracksAndViews = () => {
@@ -94,8 +101,7 @@ export function createApiV2(
         getTracks,
         getTrack,
         getView,
-        getViews,
-
+        getViews
     };
 }
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -4,6 +4,7 @@ import { subscribe, unsubscribe } from './pubsub';
 import { computeChromSizes, GenomicPositionHelper } from '../core/utils/assembly';
 import type { CompleteThemeDeep } from '../core/utils/theme';
 import type { IdTable } from './track-and-view-ids';
+import type { compile } from 'src/compiler/compile';
 
 // TODO: Complete the API
 export type HiGlassApi = {
@@ -50,11 +51,51 @@ export interface GoslingApi {
     };
 }
 
-// TODO: After fully implementing this, remove `Partial` from the return type
-export function createApiV2(): Pick<GoslingApi, 'subscribe' | 'unsubscribe'> & Partial<GoslingApi> {
+// TODO: After fully implementing this, remove `Pick` from the return type
+export function createApiV2(
+    compileResult?: ReturnType<typeof compile>
+): Pick<
+    GoslingApi,
+    'getTracksAndViews' | 'getTracks' | 'getTrackIds' | 'getTrack' | 'getViews' | 'getView' | 'subscribe' | 'unsubscribe'
+> {
+    const tracksAndViews = compileResult?.tracksAndViews ?? [];
+    const getTracksAndViews = () => {
+        return [...tracksAndViews];
+    };
+    const getTracks = () => {
+        return [...getTracksAndViews().filter(d => d.type === 'track')] as TrackApiData[];
+    };
+    const getTrackIds = () => {
+        return getTracks().map(d => d.id);
+    };
+    const getTrack = (trackId: string) => {
+        const trackInfoFound = getTracks().find(d => d.id === trackId);
+        if (!trackInfoFound) {
+            console.warn(`[getTrack()] Unable to find a track using the ID (${trackId})`);
+        }
+        return trackInfoFound;
+    };
+    const getViews = () => {
+        return [...getTracksAndViews().filter(d => d.type === 'view')] as ViewApiData[];
+    };
+    const getView = (viewId: string) => {
+        const view = getViews().find(d => d.id === viewId);
+        if (!view) {
+            console.warn(`Unable to find a view with the ID of ${viewId}`);
+        }
+        return view;
+    };
+
     return {
         subscribe,
-        unsubscribe
+        unsubscribe,
+        getTrackIds,
+        getTracksAndViews,
+        getTracks,
+        getTrack,
+        getView,
+        getViews,
+
     };
 }
 


### PR DESCRIPTION
Toward #1161 

- ~Something to still fix: The track/view objects stored in the `ref` is not up-to-date~