### PR TITLE
fix: fix type errors for new code under the `demo` folder

### DIFF
--- a/demo/linking/linkedEncoding.ts
+++ b/demo/linking/linkedEncoding.ts
@@ -5,13 +5,15 @@ import {
     type Assembly,
     type OverlaidTrack,
     type SingleTrack,
-    type SingleView
+    type SingleView,
+    type Track
 } from '@gosling-lang/gosling-schema';
 import { GenomicPositionHelper, computeChromSizes } from '../../src/core/utils/assembly';
 import { signal, type Signal } from '@preact/signals-core';
 import type { GoslingSpec } from 'gosling.js';
 import { TrackType } from '../track-def/main';
 import { isHeatmapTrack } from '../track-def/heatmap';
+import type { ProcessedTrack } from 'demo/track-def/types';
 
 /**
  * This is the information needed to link tracks together
@@ -204,6 +206,7 @@ function getSingleViewTrackLinks(gs: SingleView): TrackLink[] {
         } as TrackLink;
         // If the track has a domain, we create a signal and add it to the trackLink
         if ('y' in track && track.y && 'domain' in track.y && track.y.domain !== undefined) {
+            // @ts-expect-error - does this actually work?
             const domain = getDomain(track.y.domain, assembly);
             trackLink.signal = signal(domain);
         }
@@ -214,19 +217,25 @@ function getSingleViewTrackLinks(gs: SingleView): TrackLink[] {
     const viewXDomain = getDomain(xDomain, assembly);
     const trackLinks: TrackLink[] = [];
     tracks.forEach(track => {
-        const trackType = isHeatmapTrack(track) ? TrackType.Heatmap : TrackType.Gosling;
+        const processedTrack = track as ProcessedTrack;
+        const trackType = isHeatmapTrack(processedTrack) ? TrackType.Heatmap : TrackType.Gosling;
         // Handle the y domain
-        if (isGenomicEncoding(track, 'y') && hasDiffYDomainThanView(track)) {
-            const trackLink = createTrackLinkY(track.id, track, trackType, gs);
+        if (isGenomicEncoding(track as Track, 'y') && hasDiffYDomainThanView(track as Track)) {
+            const trackLink = createTrackLinkY(
+                processedTrack.id,
+                processedTrack as SingleTrack | OverlaidTrack,
+                trackType,
+                gs
+            );
             trackLinks.push(trackLink);
         }
         // Handle x domain
-        if (hasDiffXDomainThanView(gs, track, assembly, viewXDomain)) {
-            if (track.mark === 'brush') {
+        if (hasDiffXDomainThanView(gs, track as Track, assembly, viewXDomain)) {
+            if (processedTrack.mark === 'brush') {
                 console.warn('Track with brush mark should only be used as an overlay');
                 return;
             }
-            const trackLink = createTrackLinkX(track.id, track, trackType, gs);
+            const trackLink = createTrackLinkX(processedTrack.id, track as SingleTrack | OverlaidTrack, trackType, gs);
             trackLinks.push(trackLink);
         }
 
@@ -235,14 +244,18 @@ function getSingleViewTrackLinks(gs: SingleView): TrackLink[] {
         // Handle case where we have multiple overlay tracks (we only care about the brushes)
         track._overlay!.forEach(overlay => {
             if (overlay.mark === 'brush') {
+                const linkingId =
+                    'x' in overlay && overlay.x && 'linkingId' in overlay.x && overlay.x.linkingId
+                        ? overlay.x.linkingId
+                        : '';
                 const trackType = gs.layout === 'linear' ? TrackType.BrushLinear : TrackType.BrushCircular;
-                const trackLink = {
-                    trackId: overlay.id,
-                    linkingId: overlay.x.linkingId,
+                const trackLink: TrackLink = {
+                    trackId: overlay.id!,
+                    linkingId,
                     trackType,
                     encoding: 'brush'
                 };
-                if (overlay.x.domain !== undefined) {
+                if ('x' in overlay && overlay.x && 'domain' in overlay.x && overlay.x.domain !== undefined) {
                     const { assembly } = gs;
                     const domain = getDomain(overlay.x.domain, assembly);
                     trackLink.signal = signal(domain);
@@ -272,10 +285,13 @@ function getSingleViewLinks(gs: SingleView): ViewLink[] {
             const missingX = !('x' in track) || track.x === undefined;
             const missingY = !('y' in track) || track.y === undefined;
             const hasOverlay = '_overlay' in track && track._overlay.length == 1;
-            if (missingX && missingY && hasOverlay) track = { ...track, y: track._overlay[0].y };
+            if (missingX && missingY && hasOverlay) {
+                // @ts-expect-error - overlay exists
+                track = { ...track, y: track._overlay[0].y };
+            }
             // Continue as usual
             if (isGenomicEncoding(track, 'y') && !hasDiffYDomainThanView(track)) {
-                viewLinkY.trackIds.push(track.id);
+                viewLinkY.trackIds.push(track.id!);
             }
         });
         return viewLinkY;
@@ -297,11 +313,11 @@ function getSingleViewLinks(gs: SingleView): ViewLink[] {
             if (hasOverlaidTracks) {
                 track._overlay?.forEach(overlay => {
                     if (overlay.mark === 'brush') {
-                        viewLinkX.trackIds.push(overlay.id);
+                        viewLinkX.trackIds.push(overlay.id!);
                     }
                 });
             }
-            viewLinkX.trackIds.push(track.id);
+            viewLinkX.trackIds.push(track.id!);
         });
         return viewLinkX;
     }
@@ -309,8 +325,8 @@ function getSingleViewLinks(gs: SingleView): ViewLink[] {
     const viewXDomain = getDomain(xDomain, assembly);
     const viewYDomain = getDomain(yDomain ?? xDomain, assembly);
 
-    const xLink = addLinkX(tracks, assembly, viewXDomain);
-    const yLink = addLinkY(tracks, viewYDomain);
+    const xLink = addLinkX(tracks as Track[], assembly, viewXDomain);
+    const yLink = addLinkY(tracks as Track[], viewYDomain);
     return [xLink, yLink].filter(link => link.trackIds.length > 0);
 }
 
@@ -323,6 +339,7 @@ function hasDiffXDomainThanView(
     // If the track x has a linkingId which is different from the viewLinkingId, then it has a different domain
     const hasLinkingId = 'x' in track && track.x && 'linkingId' in track.x && track.x?.linkingId !== undefined;
     const viewLinkingId = view.linkingId;
+    // @ts-expect-error - linkingId can be undefined
     const trackLinkingId = track.x?.linkingId;
     if (hasLinkingId && viewLinkingId !== trackLinkingId) return true;
 
@@ -330,6 +347,7 @@ function hasDiffXDomainThanView(
     const hasXEncodingDomain = 'x' in track && track.x && 'domain' in track.x && track.x?.domain !== undefined;
 
     if (hasXEncodingDomain) {
+        // @ts-expect-error - x domain can be undefined
         const xEncodingDomain = getDomain(track.x?.domain, assembly);
         return !viewXDomain.every((val, index) => val === xEncodingDomain[index]);
     }
@@ -338,6 +356,7 @@ function hasDiffXDomainThanView(
 
 function isGenomicEncoding(track: Track, encoding: 'x' | 'y') {
     const isGenomic =
+        // @ts-expect-error - encoding can be undefined for dummy tracks
         encoding in track && track[encoding] && 'type' in track[encoding] && track[encoding].type === 'genomic';
     return isGenomic;
 }
@@ -375,9 +394,9 @@ function createDomainString(xDomain: GoslingSpec['xDomain']) {
         return xDomain;
     }
     let position = '';
-    const hasOnlyInterval = 'interval' in xDomain && !('chromosome' in xDomain);
-    const hasOnlyChromosome = 'chromosome' in xDomain && !('interval' in xDomain);
-    const hasBoth = 'chromosome' in xDomain && 'interval' in xDomain;
+    const hasOnlyInterval = xDomain && 'interval' in xDomain && !('chromosome' in xDomain);
+    const hasOnlyChromosome = xDomain && 'chromosome' in xDomain && !('interval' in xDomain);
+    const hasBoth = xDomain && 'chromosome' in xDomain && 'interval' in xDomain;
 
     if (typeof xDomain === 'string') {
         position = xDomain;

--- a/demo/linking/linkedEncoding.ts
+++ b/demo/linking/linkedEncoding.ts
@@ -3,6 +3,8 @@ import {
     IsMultipleViews,
     IsSingleView,
     type Assembly,
+    type OverlaidTrack,
+    type SingleTrack,
     type SingleView
 } from '@gosling-lang/gosling-schema';
 import { GenomicPositionHelper, computeChromSizes } from '../../src/core/utils/assembly';
@@ -165,31 +167,43 @@ function getLinkedFeaturesRecursive(gs: GoslingSpec): LinkInfo {
  */
 function getSingleViewTrackLinks(gs: SingleView): TrackLink[] {
     // Helper function to create a track link for the x encoding
-    function createTrackLinkX(trackId: string, track: Track, trackType: TrackType, gs: SingleView) {
+    function createTrackLinkX(
+        trackId: string,
+        track: SingleTrack | OverlaidTrack,
+        trackType: TrackType,
+        gs: SingleView
+    ) {
+        const linkingId = 'x' in track && track.x && 'linkingId' in track.x ? track.x.linkingId : undefined;
         const trackLink = {
             trackId: trackId,
-            linkingId: track.x.linkingId,
+            linkingId,
             trackType,
             encoding: 'x'
         } as TrackLink;
         // If the track has a domain, we create a signal and add it to the trackLink
-        if (track.x.domain !== undefined) {
+        if ('x' in track && track.x && 'domain' in track.x && track.x.domain !== undefined) {
             const { assembly } = gs;
             const domain = getDomain(track.x.domain, assembly);
             trackLink.signal = signal(domain);
         }
         return trackLink;
     }
-    function createTrackLinkY(trackId: string, track: Track, trackType: TrackType, gs: SingleView) {
+    function createTrackLinkY(
+        trackId: string,
+        track: SingleTrack | OverlaidTrack,
+        trackType: TrackType,
+        gs: SingleView
+    ) {
         const { assembly } = gs;
+        const linkingId = 'x' in track && track.x && 'linkingId' in track.x ? track.x.linkingId : undefined;
         const trackLink = {
             trackId: trackId,
-            linkingId: track.y.linkingId,
+            linkingId,
             trackType,
             encoding: 'y'
         } as TrackLink;
         // If the track has a domain, we create a signal and add it to the trackLink
-        if (track.y.domain !== undefined) {
+        if ('y' in track && track.y && 'domain' in track.y && track.y.domain !== undefined) {
             const domain = getDomain(track.y.domain, assembly);
             trackLink.signal = signal(domain);
         }

--- a/demo/track-def/axis.ts
+++ b/demo/track-def/axis.ts
@@ -1,5 +1,11 @@
 import { type AxisTrackOptions } from '@gosling-lang/genomic-axis';
-import { IsChannelDeep, IsDummyTrack, IsTemplateTrack, type AxisPosition } from '@gosling-lang/gosling-schema';
+import {
+    IsChannelDeep,
+    IsDummyTrack,
+    IsTemplateTrack,
+    type AxisPosition,
+    type Track
+} from '@gosling-lang/gosling-schema';
 import type { CompleteThemeDeep } from '../../src/core/utils/theme';
 import { resolveSuperposedTracks } from '../../src/core/utils/overlay';
 import { TrackType, type TrackDef } from './main';
@@ -27,7 +33,7 @@ export function getAxisTrackDef(
                 type: TrackType.Axis,
                 trackId: track.id,
                 boundingBox: boundingBox,
-                options: getAxisTrackCircularOptions(track, boundingBox, xAxisPosition, theme)
+                options: getAxisTrackCircularOptions(track as ProcessedCircularTrack, boundingBox, xAxisPosition, theme)
             });
         }
         if (track.layout === 'linear') {
@@ -95,7 +101,7 @@ function getAxisTrackLinearOptions(
     const narrowType = getAxisNarrowType(encoding, track.orientation, boundingBox.width, boundingBox.height);
     const options: AxisTrackOptions = {
         orientation: getAxisOrientation(encoding, track.orientation),
-        encoding: encoding,
+        encoding,
         static: track.static,
         innerRadius: 0,
         outerRadius: 0,
@@ -104,6 +110,7 @@ function getAxisTrackLinearOptions(
         startAngle: 0,
         endAngle: 0,
         layout: 'linear',
+        labelPosition: 'left',
         assembly: track.assembly ?? 'hg38',
         stroke: 'transparent', // text outline
         color: theme.axis.labelColor,
@@ -115,7 +122,14 @@ function getAxisTrackLinearOptions(
         tickColor: theme.axis.tickColor,
         tickFormat: narrowType === 'narrower' ? 'si' : 'plain',
         tickPositions: narrowType === 'regular' ? 'even' : 'ends',
-        reverseOrientation: position === 'bottom' || position === 'right' ? true : false
+        reverseOrientation: position === 'bottom' || position === 'right' ? true : false,
+        // TODO: Are these below really needed?
+        trackBorderWidth: 1,
+        labelColor: 'black',
+        labelTextOpacity: 1,
+        trackBorderColor: 'white',
+        backgroundColor: 'white',
+        showMousePosition: false // Making this `true` causes a crash
     };
     return options;
 }
@@ -156,6 +170,7 @@ function getAxisTrackCircularOptions(
     }
 
     const options: AxisTrackOptions = {
+        orientation: undefined,
         layout: 'circular',
         encoding: 'x',
         static: track.static,
@@ -176,7 +191,15 @@ function getAxisTrackCircularOptions(
         tickColor: theme.axis.tickColor,
         tickFormat: narrowType === 'narrower' ? 'si' : 'plain',
         tickPositions: narrowType === 'regular' ? 'even' : 'ends',
-        reverseOrientation: position === 'bottom' || position === 'right' ? true : false
+        reverseOrientation: position === 'bottom' || position === 'right' ? true : false,
+        // TODO: Are these below really needed?
+        trackBorderWidth: 1,
+        labelColor: 'black',
+        labelPosition: 'left',
+        labelTextOpacity: 1,
+        trackBorderColor: 'white',
+        backgroundColor: 'white',
+        showMousePosition: false // Making this `true` causes a crash
     };
     return options;
 }
@@ -194,7 +217,7 @@ function getAxisPositions(track: ProcessedTrack): {
         return { xAxisPosition: undefined, yAxisPosition: undefined };
     }
 
-    const resolvedSpecs = resolveSuperposedTracks(track);
+    const resolvedSpecs = resolveSuperposedTracks(track as Track);
     const firstResolvedSpec = resolvedSpecs[0];
 
     const hasXAxis =

--- a/demo/track-def/brush.ts
+++ b/demo/track-def/brush.ts
@@ -25,7 +25,7 @@ export function getBrushTrackDefs(
             });
         } else if (spec.layout === 'circular') {
             // If we have a circular layout, we use the BrushCircularTrack
-            const options = getBrushCircularOptions(spec, overlay);
+            const options = getBrushCircularOptions(spec as ProcessedCircularTrack, overlay);
             trackDefs.push({
                 type: TrackType.BrushCircular,
                 trackId: overlay.id,
@@ -42,6 +42,7 @@ export function getBrushTrackDefs(
  */
 function getBrushLinearOptions(spec: ProcessedTrack, overlay: OverlayTrack): BrushLinearTrackOptions {
     const options = {
+        static: spec.static ?? false,
         projectionFillColor: overlay.color?.value ?? 'gray',
         projectionStrokeColor: spec.stroke?.value ?? 'black',
         projectionFillOpacity: spec.opacity?.value ?? 0.3,
@@ -55,7 +56,8 @@ function getBrushLinearOptions(spec: ProcessedTrack, overlay: OverlayTrack): Bru
  * Get the options for a BrushCircularTrack
  */
 function getBrushCircularOptions(spec: ProcessedCircularTrack, overlay: OverlayTrack): BrushCircularTrackOptions {
-    const options = {
+    const options: BrushCircularTrackOptions = {
+        static: spec.static ?? false,
         projectionFillColor: overlay.color?.value ?? 'gray',
         projectionStrokeColor: overlay.stroke?.value ?? 'black',
         projectionFillOpacity: 0.3,

--- a/demo/track-def/gosling.ts
+++ b/demo/track-def/gosling.ts
@@ -53,6 +53,7 @@ export function processGoslingTrack(
 
 function getGoslingTrackOptions(spec: ProcessedTrack, theme: Required<CompleteThemeDeep>): GoslingTrackOptions {
     return {
+        // @ts-expect-error At this point, the spec is processed
         spec: spec,
         id: spec.id,
         siblingIds: [],

--- a/demo/track-def/heatmap.ts
+++ b/demo/track-def/heatmap.ts
@@ -22,7 +22,7 @@ export function processHeatmapTrack(
         boundingBox = newTrackBbox;
     }
 
-    const heatmapOptions = getHeatmapOptions(track, theme);
+    const heatmapOptions = getHeatmapOptions(track);
     trackDefs.push({
         type: TrackType.Heatmap,
         options: heatmapOptions,
@@ -44,7 +44,7 @@ function getHeatmapOptions(track: ProcessedTrack): HeatmapTrackOptions {
     const missingX = !('x' in track) || track.x === undefined;
     const missingY = !('y' in track) || track.y === undefined;
     const hasOverlay = '_overlay' in track && track._overlay && track._overlay.length == 1;
-    if (missingX && missingY && hasOverlay) track = { ...track, ...track._overlay[0] };
+    if (missingX && missingY && hasOverlay) track = { ...track, ...track._overlay?.[0] };
 
     // Get color range
     const colorStr =
@@ -73,8 +73,6 @@ function getHeatmapOptions(track: ProcessedTrack): HeatmapTrackOptions {
         colorbarPosition: 'hidden',
         labelShowAssembly: true,
         colorbarBackgroundColor: '#ffffff',
-        minWidth: 100,
-        minHeight: 100,
         heatmapValueScaling: 'log',
         showTooltip: false,
         zeroValueColor: undefined,

--- a/demo/track-def/text.ts
+++ b/demo/track-def/text.ts
@@ -54,7 +54,7 @@ function getTextTrackOptions(
             fontFamily: theme.root.titleFontFamily,
             offsetY: 0,
             align: theme.root.titleAlign,
-            text: spec.title
+            text: spec.title ?? ''
         };
     } else {
         return {
@@ -65,7 +65,7 @@ function getTextTrackOptions(
             fontFamily: theme.root.subtitleFontFamily,
             offsetY: 0,
             align: theme.root.subtitleAlign,
-            text: spec.subtitle
+            text: spec.subtitle ?? ''
         };
     }
 }

--- a/demo/track-def/types.ts
+++ b/demo/track-def/types.ts
@@ -14,8 +14,10 @@ import type { DataDeep, Assembly, DummyTrackStyle, Mark, X, Y } from '@gosling-l
 
 /** A Track after it has been compiled */
 export type ProcessedTrack = ProcessedLinearTrack | ProcessedCircularTrack | ProcessedDummyTrack;
+// TODO: This should be much better expanded to include all the properties that are actually present.
 /** All tracks potentially have these properties */
 export interface ProcessedTrackBase {
+    layout?: 'linear' | 'circular';
     id: string;
     height: number;
     width: number;

--- a/src/compiler/compile.test.ts
+++ b/src/compiler/compile.test.ts
@@ -28,7 +28,7 @@ describe('Compiler with UrlToFetchOptions', () => {
         expect(df).toMatchInlineSnapshot(`
           CsvDataFetcherClass {
             "dataConfig": {
-              "assembly": undefined,
+              "assembly": "hg38",
               "type": "csv",
               "url": "https://my-csv-url.com",
               "urlFetchOptions": {

--- a/src/data-fetchers/bigwig/bigwig-data-fetcher.ts
+++ b/src/data-fetchers/bigwig/bigwig-data-fetcher.ts
@@ -12,7 +12,7 @@ import type { ChromInfo, TilesetInfo } from '@higlass/types';
 import { DenseDataExtrema1D } from '@higlass/utils';
 import { chrToAbs } from '../utils';
 
-type BigWigDataConfig = BigWigData & CommonDataConfig;
+export type BigWigDataConfig = BigWigData & CommonDataConfig;
 
 type Tile = {
     tilePos: [number];

--- a/src/data-fetchers/csv/csv-data-fetcher.ts
+++ b/src/data-fetchers/csv/csv-data-fetcher.ts
@@ -5,7 +5,7 @@ import type { Assembly, CsvData, FilterTransform, Datum } from '@gosling-lang/go
 import { filterData } from '../../core/utils/data-transform';
 import { type CommonDataConfig, filterUsingGenoPos, sanitizeChrName, RemoteFile } from '../utils';
 
-type CsvDataConfig = CsvData & CommonDataConfig & { filter?: FilterTransform[] };
+export type CsvDataConfig = CsvData & CommonDataConfig & { filter?: FilterTransform[] };
 
 interface ChromSizes {
     chrToAbs: (chrom: string, chromPos: number) => number;

--- a/src/data-fetchers/vcf/vcf-data-fetcher.ts
+++ b/src/data-fetchers/vcf/vcf-data-fetcher.ts
@@ -41,6 +41,8 @@ export type VcfTile = Omit<VcfRecord, 'ALT' | 'INFO'> & {
     DISTPREVLOGE: number | null;
 } & { [infoKey: string]: any };
 
+export type VcfDataConfig = VcfData & { assembly: Assembly };
+
 class VcfDataFetcher implements TabularDataFetcher<VcfTile> {
     static config = { type: 'vcf' };
     dataConfig = {}; // required for higlass

--- a/src/interactors/pan-zoom.ts
+++ b/src/interactors/pan-zoom.ts
@@ -2,12 +2,16 @@ import { type Signal, batch } from '@preact/signals-core';
 import { scaleLinear } from 'd3-scale';
 import { ZoomTransform, type D3ZoomEvent, zoom } from 'd3-zoom';
 import { select } from 'd3-selection';
-import { zoomWheelBehavior, type Plot } from '../tracks/utils';
+import { zoomWheelBehavior, type HeatmapPlot, type Plot } from '../tracks/utils';
 
 /**
  * This interactor allows the user to pan and zoom the plot
  */
-export function panZoom(plot: Plot, xDomain: Signal<[number, number]>, yDomain?: Signal<[number, number]>) {
+export function panZoom(
+    plot: Plot | HeatmapPlot,
+    xDomain: Signal<[number, number]>,
+    yDomain?: Signal<[number, number]>
+) {
     plot.xDomain = xDomain; // Update the xDomain with the signal
     if ('yDomain' in plot && yDomain !== undefined) plot.yDomain = yDomain;
 

--- a/src/tracks/brush-circular/brush-circular-plot.ts
+++ b/src/tracks/brush-circular/brush-circular-plot.ts
@@ -5,15 +5,16 @@ import {
 } from './brush-circular';
 import { scaleLinear } from 'd3-scale';
 import { type Signal, effect, signal } from '@preact/signals-core';
+import type { Plot } from '../utils';
 
 /**
  * A wrapper around the BrushCircularTrackClass that allows for use with signals
  */
-export class BrushCircularTrack extends CircularBrushTrackClass {
+export class BrushCircularTrack extends CircularBrushTrackClass implements Plot {
     /** A signal containing the genomic x-domain [start, end] */
-    xDomain: Signal<number[]>;
+    xDomain: Signal<[number, number]>;
     /** A signal containing the brush x-domain [start, end] */
-    xBrushDomain: Signal<number[]>;
+    xBrushDomain: Signal<[number, number]>;
     /** The div element the zoom behavior will get attached to */
     domOverlay: HTMLElement;
     /** Width of the track */
@@ -42,8 +43,8 @@ export class BrushCircularTrack extends CircularBrushTrackClass {
         const context: BrushCircularTrackContext = {
             id: 'test',
             svgElement: svgElement,
-            registerViewportChanged: () => {},
-            removeViewportChanged: () => {},
+            registerViewportChanged: () => { },
+            removeViewportChanged: () => { },
             setDomainsCallback: (xDomain: [number, number]) => (xBrushDomain.value = xDomain),
             projectionXDomain: xBrushDomain.value
         };

--- a/src/tracks/brush-circular/brush-circular.ts
+++ b/src/tracks/brush-circular/brush-circular.ts
@@ -15,6 +15,7 @@ type CircularBrushData = {
 export type BrushCircularTrackContext = ViewportTrackerHorizontalContext;
 
 export interface BrushCircularTrackOptions {
+    static: boolean;
     innerRadius: number;
     outerRadius: number;
     startAngle: number;
@@ -27,6 +28,7 @@ export interface BrushCircularTrackOptions {
     strokeWidth: number;
 }
 const defaultOptions: BrushCircularTrackOptions = {
+    static: false,
     innerRadius: 100,
     outerRadius: 200,
     startAngle: 0,

--- a/src/tracks/brush-linear/brush-linear-track.ts
+++ b/src/tracks/brush-linear/brush-linear-track.ts
@@ -15,6 +15,7 @@ export interface BrushLinearTrackContext extends SVGTrackContext {
 }
 
 export interface BrushLinearTrackOptions {
+    static: boolean;
     projectionFillColor: string;
     projectionStrokeColor: string;
     projectionFillOpacity: number;

--- a/src/tracks/genomic-axis/axis-track-plot.ts
+++ b/src/tracks/genomic-axis/axis-track-plot.ts
@@ -36,11 +36,11 @@ export class AxisTrack extends AxisTrackClass {
         const context: AxisTrackContext = {
             chromInfoPath: 'https://s3.amazonaws.com/gosling-lang.org/data/hg38.chrom.sizes',
             scene: pixiContainer,
-            animate: () => {},
+            animate: () => { },
             dataConfig: {},
             id: 'test',
             viewUid: 'test',
-            pubSub: () => {},
+            pubSub: () => { },
             isShowGlobalMousePosition: () => false
             // id: 'test',
             // onValueScaleChanged: () => { },

--- a/src/tracks/genomic-axis/axis-track.ts
+++ b/src/tracks/genomic-axis/axis-track.ts
@@ -21,6 +21,9 @@ const TICK_TEXT_SEPARATION = 2;
 const TICK_COLOR = 0x777777;
 
 export type AxisTrackOptions = {
+    orientation?: 'horizontal' | 'vertical';
+    encoding: 'x' | 'y';
+    static: boolean;
     innerRadius: number;
     outerRadius: number;
     startAngle: number;

--- a/src/tracks/gosling-track/gosling-track.ts
+++ b/src/tracks/gosling-track/gosling-track.ts
@@ -299,8 +299,8 @@ export class GoslingTrackClass extends TiledPixiTrack<Tile, GoslingTrackOptions>
         this.drawTile(tile);
     }
 
-    override updateTile(/* tile: Tile */) {} // Never mind about this function for the simplicity.
-    renderTile(/* tile: Tile */) {} // Never mind about this function for the simplicity.
+    override updateTile(/* tile: Tile */) { } // Never mind about this function for the simplicity.
+    renderTile(/* tile: Tile */) { } // Never mind about this function for the simplicity.
 
     /**
      * Display a tile upon receiving a new one or when explicitly called by a developer, e.g., calling
@@ -480,9 +480,9 @@ export class GoslingTrackClass extends TiledPixiTrack<Tile, GoslingTrackOptions>
         const genomicRange = newXScale
             .domain()
             .map(absPos => getRelativeGenomicPosition(absPos, this.#assembly, true)) as [
-            GenomicPosition,
-            GenomicPosition
-        ];
+                GenomicPosition,
+                GenomicPosition
+            ];
         publish('location', {
             id: this.options.id,
             genomicRange: genomicRange

--- a/src/tracks/heatmap/heatmap-plot.ts
+++ b/src/tracks/heatmap/heatmap-plot.ts
@@ -11,6 +11,8 @@ import { scaleLinear } from 'd3-scale';
 import { DataFetcher } from '@higlass/datafetcher';
 import { signal, type Signal } from '@preact/signals-core';
 import type { Tile } from '@gosling-lang/gosling-track';
+import type { HeatmapPlot } from '../utils';
+import type { ProcessedTrack } from 'demo/track-def/types';
 
 export type HeatmapTrackContext = TiledPixiTrackContext & {
     svgElement: SVGElement;
@@ -21,6 +23,8 @@ export type HeatmapTrackContext = TiledPixiTrackContext & {
 };
 
 export type HeatmapTrackOptions = TiledPixiTrackOptions & {
+    spec: ProcessedTrack;
+    mousePositionColor?: string;
     maxDomain: number;
     dataTransform?: unknown;
     extent?: string;
@@ -41,7 +45,7 @@ export type HeatmapTrackOptions = TiledPixiTrackOptions & {
     selectRowsAggregationMethod?: unknown;
 };
 
-export class HeatmapTrack extends HeatmapTiledPixiTrack<HeatmapTrackOptions> {
+export class HeatmapTrack extends HeatmapTiledPixiTrack<HeatmapTrackOptions> implements HeatmapPlot {
     /** A signal containing the genomic x-domain [start, end] */
     xDomain: Signal<[number, number]>;
     /** A signal containing the genomic y-domain [start, end] */
@@ -50,6 +54,9 @@ export class HeatmapTrack extends HeatmapTiledPixiTrack<HeatmapTrackOptions> {
     maxDomain: number;
     /** The div element the zoom behavior will get attached to */
     domOverlay: HTMLElement;
+    width: number;
+    height: number;
+    orientation: undefined;
 
     constructor(
         options: HeatmapTrackOptions,
@@ -79,10 +86,10 @@ export class HeatmapTrack extends HeatmapTiledPixiTrack<HeatmapTrackOptions> {
             id: 'test',
             viewUid: 'test',
             dataFetcher,
-            animate: () => {},
-            onValueScaleChanged: () => {},
-            handleTilesetInfoReceived: () => {},
-            onTrackOptionsChanged: () => {},
+            animate: () => { },
+            onValueScaleChanged: () => { },
+            handleTilesetInfoReceived: () => { },
+            onTrackOptionsChanged: () => { },
             pubSub: fakePubSub,
             isValueScaleLocked: () => false,
             svgElement: svgElement
@@ -93,13 +100,15 @@ export class HeatmapTrack extends HeatmapTiledPixiTrack<HeatmapTrackOptions> {
         this.yDomain = yDomain;
         this.domOverlay = overlayDiv;
         this.maxDomain = options.maxDomain;
+        this.width = width;
+        this.height = height;
 
         // Now we need to initialize all of the properties that would normally be set by HiGlassComponent
-        this.setDimensions([width, height]);
+        this.setDimensions([this.width, this.height]);
         this.setPosition([0, 0]);
         // Create some scales which span the whole genome
-        const refXScale = scaleLinear().domain(xDomain.value).range([0, width]);
-        const refYScale = scaleLinear().domain(yDomain.value).range([0, height]);
+        const refXScale = scaleLinear().domain(xDomain.value).range([0, this.width]);
+        const refYScale = scaleLinear().domain(yDomain.value).range([0, this.height]);
         // Set the scales
         this.zoomed(refXScale, refYScale, 1, 0, 0);
         this.refScalesChanged(refXScale, refYScale);

--- a/src/tracks/utils.ts
+++ b/src/tracks/utils.ts
@@ -32,6 +32,9 @@ export interface Plot {
 export interface HeatmapPlot {
     addInteractor(interactor: (plot: Plot) => void): Plot;
     domOverlay: HTMLElement;
+    orientation: undefined;
+    width: number;
+    height: number;
     xDomain: Signal<[number, number]>;
     yDomain: Signal<[number, number]>;
     maxDomain: number;


### PR DESCRIPTION
Fix #1174 

## Change List
 - Fixes many type errors under the `demo` folder. This allows building types.
   - I used many `as` statements, which are not the most desirable and need to be revisited.