### PR TITLE
feat: support `resized` callback; enable getting information of resized tracks and views

### DIFF
--- a/demo/gosling-component.tsx
+++ b/demo/gosling-component.tsx
@@ -110,12 +110,11 @@ export function renderGosling(
     // 3. If the spec is responsive, we need to add a resize observer to the container
     const { isResponsiveWidth, isResponsiveHeight } = checkResponsiveSpec(processedSpec);
     if (isResponsiveWidth || isResponsiveHeight) {
-        console.error('here');
         const resizeObserver = new ResizeObserver(
             debounce(entries => {
                 // @ts-expect-error
                 const { width: containerWidth, height: containerHeight } = entries[0].contentRect;
-                console.warn('Resizing to', containerWidth, containerHeight);
+                // console.warn('Resizing to', containerWidth, containerHeight);
                 // Remove all of the previously drawn overlay divs and tracks
                 pixiManager.clearAll();
                 const rescaledTracks = rescaleTrackInfos(
@@ -137,6 +136,7 @@ export function renderGosling(
                 // Resize the canvas to make sure it fits the tracks
                 const { width, height } = calculateWidthHeight(rescaledTracks);
                 pixiManager.resize(width, height);
+                // Call an API function
                 resized?.();
             }, 300)
         );

--- a/demo/gosling-component.tsx
+++ b/demo/gosling-component.tsx
@@ -138,7 +138,7 @@ export function renderGosling(
                 // Resize the canvas to make sure it fits the tracks
                 const { width, height } = calculateWidthHeight(rescaledTracks);
                 pixiManager.resize(width, height);
-                // Call an API function
+                // Notify that the visualization has been resized
                 resized?.();
             }, 300)
         );

--- a/demo/gosling-component.tsx
+++ b/demo/gosling-component.tsx
@@ -22,7 +22,9 @@ interface GoslingComponentProps {
     theme?: Theme;
     urlToFetchOptions?: UrlToFetchOptions;
     ref?: RefObject<GoslingRef>;
+    /** A callback function to notify that visualization has been rendered for the first time */
     visualized?: () => void;
+    /** A callback function to notify that visualization has been resized. Only called when responsive design is used. */
     resized?: () => void;
 }
 

--- a/editor/example/spec/visual-encoding.ts
+++ b/editor/example/spec/visual-encoding.ts
@@ -231,6 +231,7 @@ const spec: GoslingSpec = {
     layout: 'linear',
     arrangement: 'vertical',
     centerRadius: 0.8,
+    responsiveSize: { width: true },
     xDomain: { chromosome: 'chr1', interval: [1, 3000500] },
     views: [heatmapView, barView, stackView, lineView, pointView, pointView2, areaView2, barView2, bandView]
 };

--- a/editor/example/spec/visual-encoding.ts
+++ b/editor/example/spec/visual-encoding.ts
@@ -231,7 +231,6 @@ const spec: GoslingSpec = {
     layout: 'linear',
     arrangement: 'vertical',
     centerRadius: 0.8,
-    responsiveSize: { width: true },
     xDomain: { chromosome: 'chr1', interval: [1, 3000500] },
     views: [heatmapView, barView, stackView, lineView, pointView, pointView2, areaView2, barView2, bandView]
 };

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -104,9 +104,9 @@ export function createApiV2(
         return createEmptyApi();
     }
 
-    const { tracksAndViews, theme, pixiManager, plots } = compileResult;
+    const { theme, pixiManager, plots } = compileResult;
     const getTracksAndViews = () => {
-        return [...tracksAndViews];
+        return [...compileResult.tracksAndViews];
     };
     const getTracks = () => {
         return [...getTracksAndViews().filter(d => d.type === 'track')] as TrackApiData[];


### PR DESCRIPTION
Fix #
Toward #

## Change List
 - Support `resized` callback.
```ts
<Gosling ... resized={() => console.log('Gosling is resized!')}/>
```
 - Enable getting information of resized tracks and views, i.e., when they update, `gosRef.current.api.getTracksAndViews()` gives the updated information.

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
