### PR TITLE
feat: show brushes even if they are not linked

### DIFF
--- a/demo/renderer/main.ts
+++ b/demo/renderer/main.ts
@@ -115,8 +115,7 @@ export function renderTrackDefs(
             const brushOptions = options as BrushLinearTrackOptions;
             const domain = getEncodingSignal(trackDef.trackId, 'x', linkedEncodings);
             const brushDomain = getEncodingSignal(trackDef.trackId, 'brush', linkedEncodings);
-            if (!domain || !brushDomain || !hasLinkedTracks(trackDef.trackId, linkedEncodings)) return;
-            // We only want to add the brush track if it is linked to another track
+            if (!domain || !brushDomain) return;
             const brush = new BrushLinearTrack(
                 brushOptions,
                 brushDomain,
@@ -130,8 +129,7 @@ export function renderTrackDefs(
             const brushOptions = options as BrushCircularTrackOptions;
             const domain = getEncodingSignal(trackDef.trackId, 'x', linkedEncodings);
             const brushDomain = getEncodingSignal(trackDef.trackId, 'brush', linkedEncodings);
-            if (!domain || !brushDomain || !hasLinkedTracks(trackDef.trackId, linkedEncodings)) return;
-            // We only want to add the brush track if it is linked to another track
+            if (!domain || !brushDomain) return;
             const brush = new BrushCircularTrack(
                 brushOptions,
                 brushDomain,

--- a/editor/example/json-spec/visual-linking.ts
+++ b/editor/example/json-spec/visual-linking.ts
@@ -21,7 +21,7 @@ export const EX_SPEC_LINKING: GoslingSpec = {
                         { mark: 'bar' },
                         {
                             mark: 'brush',
-                            x: { linkingId: 'detail' }
+                            x: { linkingId: 'detail-1', domain: { chromosome: 'chr1', interval: [0, 1000000] } }
                         }
                     ],
                     data: {
@@ -39,33 +39,6 @@ export const EX_SPEC_LINKING: GoslingSpec = {
                     color: { field: 'sample', type: 'nominal' },
                     width: 250,
                     height: 130
-                },
-                {
-                    layout: 'linear',
-                    xDomain: { chromosome: 'chr1' },
-                    alignment: 'overlay',
-                    tracks: [
-                        { mark: 'bar' },
-                        {
-                            mark: 'brush',
-                            x: { linkingId: 'detail' }
-                        }
-                    ],
-                    data: {
-                        url: GOSLING_PUBLIC_DATA.multivec,
-                        type: 'multivec',
-                        row: 'sample',
-                        column: 'position',
-                        value: 'peak',
-                        categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4']
-                    },
-                    x: { field: 'start', type: 'genomic' },
-                    xe: { field: 'end', type: 'genomic' },
-                    y: { field: 'peak', type: 'quantitative' },
-                    row: { field: 'sample', type: 'nominal' },
-                    color: { field: 'sample', type: 'nominal' },
-                    width: 400,
-                    height: 200
                 }
             ]
         },

--- a/editor/example/json-spec/visual-linking.ts
+++ b/editor/example/json-spec/visual-linking.ts
@@ -21,7 +21,7 @@ export const EX_SPEC_LINKING: GoslingSpec = {
                         { mark: 'bar' },
                         {
                             mark: 'brush',
-                            x: { linkingId: 'detail-1', domain: { chromosome: 'chr1', interval: [0, 1000000] } }
+                            x: { linkingId: 'detail' }
                         }
                     ],
                     data: {
@@ -39,6 +39,33 @@ export const EX_SPEC_LINKING: GoslingSpec = {
                     color: { field: 'sample', type: 'nominal' },
                     width: 250,
                     height: 130
+                },
+                {
+                    layout: 'linear',
+                    xDomain: { chromosome: 'chr1' },
+                    alignment: 'overlay',
+                    tracks: [
+                        { mark: 'bar' },
+                        {
+                            mark: 'brush',
+                            x: { linkingId: 'detail' }
+                        }
+                    ],
+                    data: {
+                        url: GOSLING_PUBLIC_DATA.multivec,
+                        type: 'multivec',
+                        row: 'sample',
+                        column: 'position',
+                        value: 'peak',
+                        categories: ['sample 1', 'sample 2', 'sample 3', 'sample 4']
+                    },
+                    x: { field: 'start', type: 'genomic' },
+                    xe: { field: 'end', type: 'genomic' },
+                    y: { field: 'peak', type: 'quantitative' },
+                    row: { field: 'sample', type: 'nominal' },
+                    color: { field: 'sample', type: 'nominal' },
+                    width: 400,
+                    height: 200
                 }
             ]
         },

--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -67,6 +67,5 @@ export function compile(
 
     // Make HiGlass models for individual tracks
     const compileResult = collectViewsAndTracks(specCopy, trackInfos, theme);
-    console.warn(compileResult);
     return compileResult;
 }


### PR DESCRIPTION
Fix #
Toward #

## Change List
 - Show `brush`es even if they are not linked to another. Gosling does not remove unlinked brushes when compiling.

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
