### PR TITLE
fix: correct brushing when xOffset is used in circular tracks

### DIFF
--- a/src/tracks/gosling-brush/brush-track.ts
+++ b/src/tracks/gosling-brush/brush-track.ts
@@ -170,11 +170,16 @@ function BrushTrack(HGC: any, ...args: any[]): any {
                 const [w, h] = this.dimensions;
                 const endEvent = event.sourceEvent;
 
-                // adjust the position
-                const startX = this.startEvent.layerX - x;
-                const startY = this.startEvent.layerY - y;
-                const endX = endEvent.layerX - x;
-                const endY = endEvent.layerY - y;
+                // Use clientX/clientY instead of layerX/layerY to avoid coordinate system issues
+                // when the mouse moves over different SVG elements during drag
+                // Get the bounding rect from the parent SVG, which should be stable
+                const svg = this.gMain.node().ownerSVGElement || this.gMain.node().closest('svg');
+                const svgRect = svg.getBoundingClientRect();
+
+                const startX = this.startEvent.clientX - svgRect.left - x;
+                const startY = this.startEvent.clientY - svgRect.top - y;
+                const endX = endEvent.clientX - svgRect.left - x;
+                const endY = endEvent.clientY - svgRect.top - y;
 
                 // calculate the radian difference from the drag event
                 // rotate the origin +90 degree so that it is positioned on the 12 O'clock


### PR DESCRIPTION
Fix #
Toward #

## Change List
 -

## Checklist
 - [ ] Ensure the PR works with all demos on the online editor
 - [ ] Unit tests added or updated
 - [ ] Examples added or updated
 - [ ] [Documentation](https://github.com/gosling-lang/gosling-website) updated (e.g., added API functions)
 - [ ] Screenshots for visual changes (e.g., new encoding support or UI change on Editor)
